### PR TITLE
feat(communication): add Redis-powered service discovery, queue, circ…

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -8,7 +8,7 @@ actix-web = "4.4"
 axum = "0.7"
 tokio = { version = "1.0", features = ["full"] }
 sqlx = { version = "0.8.6", features = ["postgres", "runtime-tokio-rustls", "macros", "migrate", "uuid", "json", "chrono", "ipnetwork"] }
-redis = { version = "0.32.6", features = ["tokio-comp"] }
+redis = { version = "0.24", features = ["tokio-comp"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0"
@@ -27,3 +27,7 @@ actix-web-actors = "4.2"
 rust_decimal = { version = "1.32", features = ["serde"] }
 validator = { version = "0.16", features = ["derive"] }
 bcrypt = "0.14"
+tonic = "0.10"
+prost = "0.12"
+reqwest = { version = "0.11", features = ["json", "rustls-tls"] }
+rand = "0.8"

--- a/backend/src/service/communication/circuit_breaker.rs
+++ b/backend/src/service/communication/circuit_breaker.rs
@@ -1,0 +1,222 @@
+//! Circuit breaker implementation for fault tolerance
+//! Prevents cascading failures in microservices
+
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tokio::sync::RwLock;
+
+/// Circuit breaker states
+#[derive(Debug, Clone, PartialEq)]
+pub enum CircuitState {
+    Closed,   // Normal operation
+    Open,     // Failing fast
+    HalfOpen, // Testing if service recovered
+}
+
+/// Circuit breaker statistics
+#[derive(Debug, Clone)]
+pub struct CircuitStats {
+    pub total_requests: u32,
+    pub failed_requests: u32,
+    pub success_requests: u32,
+    pub last_failure_time: u64,
+    pub state: CircuitState,
+}
+
+/// Circuit breaker configuration
+#[derive(Debug, Clone)]
+pub struct CircuitConfig {
+    pub failure_threshold: u32,
+    pub recovery_timeout: Duration,
+    pub request_volume_threshold: u32,
+    pub success_threshold: u32,
+}
+
+impl Default for CircuitConfig {
+    fn default() -> Self {
+        Self {
+            failure_threshold: 5,
+            recovery_timeout: Duration::from_secs(60),
+            request_volume_threshold: 10,
+            success_threshold: 3,
+        }
+    }
+}
+
+/// Circuit breaker implementation
+pub struct CircuitBreaker {
+    config: CircuitConfig,
+    state: Arc<RwLock<CircuitState>>,
+    failure_count: AtomicU32,
+    success_count: AtomicU32,
+    total_requests: AtomicU32,
+    last_failure_time: AtomicU64,
+    last_success_time: AtomicU64,
+}
+
+impl CircuitBreaker {
+    pub fn new(config: CircuitConfig) -> Self {
+        Self {
+            config,
+            state: Arc::new(RwLock::new(CircuitState::Closed)),
+            failure_count: AtomicU32::new(0),
+            success_count: AtomicU32::new(0),
+            total_requests: AtomicU32::new(0),
+            last_failure_time: AtomicU64::new(0),
+            last_success_time: AtomicU64::new(0),
+        }
+    }
+
+    /// Execute a function with circuit breaker protection
+    pub async fn call<F, Fut, T, E>(&self, f: F) -> Result<T, CircuitBreakerError<E>>
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = Result<T, E>>,
+    {
+        // Check if circuit is open
+        if !self.can_execute().await {
+            return Err(CircuitBreakerError::CircuitOpen);
+        }
+
+        self.total_requests.fetch_add(1, Ordering::SeqCst);
+
+        match f().await {
+            Ok(result) => {
+                self.on_success().await;
+                Ok(result)
+            }
+            Err(e) => {
+                self.on_failure().await;
+                Err(CircuitBreakerError::CallFailed(e))
+            }
+        }
+    }
+
+    /// Check if the circuit breaker allows execution
+    async fn can_execute(&self) -> bool {
+        let state = self.state.read().await;
+        match *state {
+            CircuitState::Closed => true,
+            CircuitState::Open => {
+                let now = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs();
+                let last_failure = self.last_failure_time.load(Ordering::SeqCst);
+                
+                if now - last_failure >= self.config.recovery_timeout.as_secs() {
+                    drop(state);
+                    let mut state = self.state.write().await;
+                    *state = CircuitState::HalfOpen;
+                    true
+                } else {
+                    false
+                }
+            }
+            CircuitState::HalfOpen => true,
+        }
+    }
+
+    /// Handle successful execution
+    async fn on_success(&self) {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        
+        self.last_success_time.store(now, Ordering::SeqCst);
+        let success_count = self.success_count.fetch_add(1, Ordering::SeqCst) + 1;
+        
+        let state = self.state.read().await;
+        if *state == CircuitState::HalfOpen {
+            if success_count >= self.config.success_threshold {
+                drop(state);
+                let mut state = self.state.write().await;
+                *state = CircuitState::Closed;
+                self.reset_counts();
+            }
+        }
+    }
+
+    /// Handle failed execution
+    async fn on_failure(&self) {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        
+        self.last_failure_time.store(now, Ordering::SeqCst);
+        let failure_count = self.failure_count.fetch_add(1, Ordering::SeqCst) + 1;
+        let total_requests = self.total_requests.load(Ordering::SeqCst);
+        
+        let mut state = self.state.write().await;
+        match *state {
+            CircuitState::Closed => {
+                if total_requests >= self.config.request_volume_threshold
+                    && failure_count >= self.config.failure_threshold
+                {
+                    *state = CircuitState::Open;
+                    tracing::warn!("Circuit breaker opened due to {} failures", failure_count);
+                }
+            }
+            CircuitState::HalfOpen => {
+                *state = CircuitState::Open;
+                tracing::warn!("Circuit breaker reopened after failure in half-open state");
+            }
+            CircuitState::Open => {
+                // Already open, do nothing
+            }
+        }
+    }
+
+    /// Reset failure and success counts
+    fn reset_counts(&self) {
+        self.failure_count.store(0, Ordering::SeqCst);
+        self.success_count.store(0, Ordering::SeqCst);
+        self.total_requests.store(0, Ordering::SeqCst);
+    }
+
+    /// Get current circuit breaker statistics
+    pub async fn get_stats(&self) -> CircuitStats {
+        let state = self.state.read().await;
+        CircuitStats {
+            total_requests: self.total_requests.load(Ordering::SeqCst),
+            failed_requests: self.failure_count.load(Ordering::SeqCst),
+            success_requests: self.success_count.load(Ordering::SeqCst),
+            last_failure_time: self.last_failure_time.load(Ordering::SeqCst),
+            state: state.clone(),
+        }
+    }
+
+    /// Force circuit breaker to open state
+    pub async fn force_open(&self) {
+        let mut state = self.state.write().await;
+        *state = CircuitState::Open;
+    }
+
+    /// Force circuit breaker to closed state
+    pub async fn force_close(&self) {
+        let mut state = self.state.write().await;
+        *state = CircuitState::Closed;
+        self.reset_counts();
+    }
+}
+
+/// Circuit breaker error types
+#[derive(Debug)]
+pub enum CircuitBreakerError<E> {
+    CircuitOpen,
+    CallFailed(E),
+}
+
+impl<E: std::fmt::Display> std::fmt::Display for CircuitBreakerError<E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CircuitBreakerError::CircuitOpen => write!(f, "Circuit breaker is open"),
+            CircuitBreakerError::CallFailed(e) => write!(f, "Call failed: {}", e),
+        }
+    }
+}
+
+impl<E: std::error::Error> std::error::Error for CircuitBreakerError<E> {}

--- a/backend/src/service/communication/grpc_client.rs
+++ b/backend/src/service/communication/grpc_client.rs
@@ -1,0 +1,57 @@
+//! gRPC client builder with load balancing and circuit breaker integration
+
+use crate::service::communication::circuit_breaker::{CircuitBreaker, CircuitConfig};
+use crate::service::communication::load_balancer::LoadBalancer;
+use tonic::transport::{Channel, Endpoint};
+use std::time::Duration;
+
+pub struct GrpcClient {
+    load_balancer: LoadBalancer,
+    circuit_breaker: CircuitBreaker,
+    connect_timeout: Duration,
+}
+
+impl GrpcClient {
+    pub fn new(load_balancer: LoadBalancer, circuit_config: CircuitConfig, connect_timeout: Duration) -> Self {
+        Self {
+            load_balancer,
+            circuit_breaker: CircuitBreaker::new(circuit_config),
+            connect_timeout,
+        }
+    }
+
+    /// Get a gRPC channel to the next selected endpoint
+    pub async fn get_channel(&self) -> anyhow::Result<Channel> {
+        let endpoint_url = self
+            .load_balancer
+            .select_endpoint()
+            .await
+            .ok_or_else(|| anyhow::anyhow!("no available endpoints from load balancer"))?;
+
+        let endpoint = Endpoint::from_shared(endpoint_url)?
+            .connect_timeout(self.connect_timeout)
+            .tcp_nodelay(true);
+
+        let channel = endpoint.connect().await?;
+        Ok(channel)
+    }
+
+    /// Call a function using a channel protected by circuit breaker
+    pub async fn call_with<T, E, F, Fut>(&self, f: F) -> Result<T, crate::service::communication::circuit_breaker::CircuitBreakerError<E>>
+    where
+        F: FnOnce(Channel) -> Fut,
+        Fut: std::future::Future<Output = Result<T, E>>,
+        E: From<anyhow::Error>,
+    {
+        self.circuit_breaker
+            .call(|| async {
+                // Convert connection errors from anyhow::Error into user's error type E
+                let chan = match self.get_channel().await {
+                    Ok(c) => c,
+                    Err(e) => return Err(E::from(e)),
+                };
+                f(chan).await
+            })
+            .await
+    }
+}

--- a/backend/src/service/communication/health_checker.rs
+++ b/backend/src/service/communication/health_checker.rs
@@ -1,0 +1,85 @@
+//! Health checker for services using HTTP endpoints
+
+use crate::service::communication::service_discovery::{ServiceDiscovery, ServiceInfo};
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use std::time::Instant;
+use tokio::time::{self, Duration};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ServiceHealth {
+    pub service_id: String,
+    pub service_name: String,
+    pub healthy: bool,
+    pub latency_ms: u128,
+    pub status_code: Option<u16>,
+}
+
+pub struct HealthChecker {
+    client: Client,
+    discovery: ServiceDiscovery,
+}
+
+impl HealthChecker {
+    pub fn new(discovery: ServiceDiscovery) -> Self {
+        Self {
+            client: Client::new(),
+            discovery,
+        }
+    }
+
+    /// Check a single service health via HTTP GET to /health
+    pub async fn check_service(&self, info: &ServiceInfo) -> anyhow::Result<ServiceHealth> {
+        let url = format!("http://{}:{}{}", info.host, info.port, info.health_endpoint);
+        let start = Instant::now();
+        let resp = self.client.get(&url).send().await;
+        let latency = start.elapsed().as_millis();
+        match resp {
+            Ok(r) => Ok(ServiceHealth {
+                service_id: info.service_id.clone(),
+                service_name: info.service_name.clone(),
+                healthy: r.status().is_success(),
+                latency_ms: latency,
+                status_code: Some(r.status().as_u16()),
+            }),
+            Err(_e) => Ok(ServiceHealth {
+                service_id: info.service_id.clone(),
+                service_name: info.service_name.clone(),
+                healthy: false,
+                latency_ms: latency,
+                status_code: None,
+            }),
+        }
+    }
+
+    /// Periodically check health of all services with given name
+    pub async fn start_health_checks(&self, service_name: &str, interval: Duration) -> tokio::task::JoinHandle<()> {
+        let discovery = self.discovery.clone();
+        let client = self.client.clone();
+        let service_name = service_name.to_string();
+        
+        tokio::spawn(async move {
+            let checker = HealthChecker { client, discovery };
+            let mut ticker = time::interval(interval);
+            loop {
+                ticker.tick().await;
+                match checker.discovery.discover_services(&service_name).await {
+                    Ok(services) => {
+                        for s in services {
+                            if let Ok(health) = checker.check_service(&s).await {
+                                tracing::info!(
+                                    service = %health.service_name,
+                                    id = %health.service_id,
+                                    healthy = %health.healthy,
+                                    latency_ms = %health.latency_ms,
+                                    "Service health check"
+                                );
+                            }
+                        }
+                    }
+                    Err(e) => tracing::error!("Health check discovery failed: {}", e),
+                }
+            }
+        })
+    }
+}

--- a/backend/src/service/communication/load_balancer.rs
+++ b/backend/src/service/communication/load_balancer.rs
@@ -1,0 +1,66 @@
+//! Load balancer for selecting service endpoints
+//! Supports round-robin and random strategies
+
+use crate::service::communication::service_discovery::{ServiceDiscovery, ServiceInfo};
+use rand::seq::SliceRandom;
+use rand::thread_rng;
+use std::ops::Deref;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+#[derive(Debug, Clone)]
+pub enum LoadBalancerStrategy {
+    RoundRobin,
+    Random,
+}
+
+pub struct LoadBalancer {
+    discovery: ServiceDiscovery,
+    strategy: LoadBalancerStrategy,
+    services: Arc<RwLock<Vec<ServiceInfo>>>,
+    rr_index: Arc<RwLock<usize>>,
+}
+
+impl LoadBalancer {
+    pub fn new(discovery: ServiceDiscovery, strategy: LoadBalancerStrategy) -> Self {
+        Self {
+            discovery,
+            strategy,
+            services: Arc::new(RwLock::new(Vec::new())),
+            rr_index: Arc::new(RwLock::new(0)),
+        }
+    }
+
+    /// Refresh the internal service list from discovery
+    pub async fn refresh(&self, service_name: &str) -> redis::RedisResult<()> {
+        let services = self.discovery.discover_services(service_name).await?;
+        let mut guard = self.services.write().await;
+        *guard = services;
+        Ok(())
+    }
+
+    /// Select next endpoint URL based on strategy
+    pub async fn select_endpoint(&self) -> Option<String> {
+        let services = self.services.read().await;
+        if services.is_empty() {
+            return None;
+        }
+        match self.strategy {
+            LoadBalancerStrategy::RoundRobin => {
+                let mut index = self.rr_index.write().await;
+                let selected = services.get(*index).cloned();
+                *index = (*index + 1) % services.len();
+                selected.map(|s| format!("http://{}:{}", s.host, s.port))
+            }
+            LoadBalancerStrategy::Random => {
+                let mut rng = thread_rng();
+                let services_slice: &Vec<ServiceInfo> = services.deref();
+                services_slice
+                    .as_slice()
+                    .choose(&mut rng)
+                    .cloned()
+                    .map(|s| format!("http://{}:{}", s.host, s.port))
+            }
+        }
+    }
+}

--- a/backend/src/service/communication/message_queue.rs
+++ b/backend/src/service/communication/message_queue.rs
@@ -1,0 +1,171 @@
+//! Redis-based message queue for inter-service communication
+//! Implements pub/sub and work queue patterns
+
+use redis::{AsyncCommands, RedisResult};
+use futures_util::StreamExt;
+use serde::{Deserialize, Serialize};
+use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::sync::mpsc;
+use uuid::Uuid;
+
+/// Message envelope for queue operations
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QueueMessage {
+    pub id: String,
+    pub topic: String,
+    pub payload: String,
+    pub timestamp: u64,
+    pub retry_count: u32,
+    pub max_retries: u32,
+}
+
+impl QueueMessage {
+    pub fn new(topic: String, payload: String) -> Self {
+        Self {
+            id: Uuid::new_v4().to_string(),
+            topic,
+            payload,
+            timestamp: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+            retry_count: 0,
+            max_retries: 3,
+        }
+    }
+
+    pub fn with_max_retries(mut self, max_retries: u32) -> Self {
+        self.max_retries = max_retries;
+        self
+    }
+
+    pub fn can_retry(&self) -> bool {
+        self.retry_count < self.max_retries
+    }
+
+    pub fn increment_retry(&mut self) {
+        self.retry_count += 1;
+    }
+}
+
+/// Redis-based message queue implementation
+pub struct MessageQueue {
+    redis_client: redis::Client,
+}
+
+impl MessageQueue {
+    pub fn new(redis_url: &str) -> RedisResult<Self> {
+        let redis_client = redis::Client::open(redis_url)?;
+        Ok(Self { redis_client })
+    }
+
+    /// Publish a message to a topic (pub/sub pattern)
+    pub async fn publish(&self, topic: &str, payload: &str) -> RedisResult<()> {
+        let mut conn = self.redis_client.get_async_connection().await?;
+        let message = QueueMessage::new(topic.to_string(), payload.to_string());
+        let serialized = serde_json::to_string(&message).unwrap();
+        conn.publish(topic, serialized).await?;
+        Ok(())
+    }
+
+    /// Subscribe to a topic (pub/sub pattern)
+    pub async fn subscribe(
+        &self,
+        topics: Vec<String>,
+        sender: mpsc::UnboundedSender<QueueMessage>,
+    ) -> RedisResult<()> {
+        let mut conn = self.redis_client.get_async_connection().await?;
+        let mut pubsub = conn.into_pubsub();
+        
+        for topic in &topics {
+            pubsub.subscribe(topic).await?;
+        }
+
+        loop {
+            let msg = pubsub.on_message().next().await;
+            if let Some(msg) = msg {
+                if let Ok(payload) = msg.get_payload::<String>() {
+                    if let Ok(queue_message) = serde_json::from_str::<QueueMessage>(&payload) {
+                        if sender.send(queue_message).is_err() {
+                            break; // Receiver dropped
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Enqueue a message to a work queue (work queue pattern)
+    pub async fn enqueue(&self, queue_name: &str, message: &QueueMessage) -> RedisResult<()> {
+        let mut conn = self.redis_client.get_async_connection().await?;
+        let serialized = serde_json::to_string(message).unwrap();
+        conn.lpush(queue_name, serialized).await?;
+        Ok(())
+    }
+
+    /// Dequeue a message from a work queue (blocking)
+    pub async fn dequeue(&self, queue_name: &str, timeout: u64) -> RedisResult<Option<QueueMessage>> {
+        let mut conn = self.redis_client.get_async_connection().await?;
+        let result: Option<(String, String)> = conn.brpop(queue_name, timeout).await?;
+        
+        if let Some((_, payload)) = result {
+            if let Ok(message) = serde_json::from_str::<QueueMessage>(&payload) {
+                return Ok(Some(message));
+            }
+        }
+        Ok(None)
+    }
+
+    /// Move failed message to dead letter queue
+    pub async fn move_to_dlq(&self, message: &QueueMessage) -> RedisResult<()> {
+        let dlq_name = format!("{}_dlq", message.topic);
+        self.enqueue(&dlq_name, message).await
+    }
+
+    /// Process messages from a queue with retry logic
+    pub async fn process_queue<F, Fut>(
+        &self,
+        queue_name: &str,
+        processor: F,
+    ) -> RedisResult<()>
+    where
+        F: Fn(QueueMessage) -> Fut + Send + Sync + 'static,
+        Fut: std::future::Future<Output = Result<(), String>> + Send,
+    {
+        loop {
+            if let Some(mut message) = self.dequeue(queue_name, 5).await? {
+                match processor(message.clone()).await {
+                    Ok(()) => {
+                        tracing::info!("Successfully processed message: {}", message.id);
+                    }
+                    Err(e) => {
+                        tracing::error!("Failed to process message {}: {}", message.id, e);
+                        message.increment_retry();
+                        
+                        if message.can_retry() {
+                            // Re-queue for retry
+                            self.enqueue(queue_name, &message).await?;
+                        } else {
+                            // Move to dead letter queue
+                            self.move_to_dlq(&message).await?;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Get queue length
+    pub async fn queue_length(&self, queue_name: &str) -> RedisResult<u64> {
+        let mut conn = self.redis_client.get_async_connection().await?;
+        conn.llen(queue_name).await
+    }
+
+    /// Clear a queue
+    pub async fn clear_queue(&self, queue_name: &str) -> RedisResult<()> {
+        let mut conn = self.redis_client.get_async_connection().await?;
+        conn.del(queue_name).await?;
+        Ok(())
+    }
+}

--- a/backend/src/service/communication/mod.rs
+++ b/backend/src/service/communication/mod.rs
@@ -1,0 +1,41 @@
+//! Communication module for inter-service communication
+//! Provides service discovery, message queuing, circuit breakers,
+//! load balancing, and health checking for microservices architecture
+
+pub mod service_discovery;
+pub mod message_queue;
+pub mod circuit_breaker;
+pub mod load_balancer;
+pub mod grpc_client;
+pub mod health_checker;
+
+pub use service_discovery::ServiceDiscovery;
+pub use message_queue::MessageQueue;
+pub use circuit_breaker::CircuitBreaker;
+pub use load_balancer::LoadBalancer;
+pub use grpc_client::GrpcClient;
+pub use health_checker::HealthChecker;
+
+use std::time::Duration;
+
+/// Configuration for communication services
+#[derive(Clone, Debug)]
+pub struct CommunicationConfig {
+    pub redis_url: String,
+    pub service_timeout: Duration,
+    pub health_check_interval: Duration,
+    pub circuit_breaker_threshold: u32,
+    pub circuit_breaker_timeout: Duration,
+}
+
+impl Default for CommunicationConfig {
+    fn default() -> Self {
+        Self {
+            redis_url: "redis://localhost:6379".to_string(),
+            service_timeout: Duration::from_secs(30),
+            health_check_interval: Duration::from_secs(10),
+            circuit_breaker_threshold: 5,
+            circuit_breaker_timeout: Duration::from_secs(60),
+        }
+    }
+}

--- a/backend/src/service/communication/service_discovery.rs
+++ b/backend/src/service/communication/service_discovery.rs
@@ -1,0 +1,168 @@
+//! Service discovery implementation using Redis
+//! Manages service registration and discovery for microservices
+
+use redis::{AsyncCommands, RedisResult};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tokio::time;
+use uuid::Uuid;
+
+/// Service information for discovery
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ServiceInfo {
+    pub service_id: String,
+    pub service_name: String,
+    pub host: String,
+    pub port: u16,
+    pub health_endpoint: String,
+    pub tags: Vec<String>,
+    pub last_heartbeat: u64,
+}
+
+impl ServiceInfo {
+    pub fn new(service_name: String, host: String, port: u16) -> Self {
+        Self {
+            service_id: Uuid::new_v4().to_string(),
+            service_name,
+            host,
+            port,
+            health_endpoint: "/health".to_string(),
+            tags: Vec::new(),
+            last_heartbeat: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+        }
+    }
+
+    pub fn with_tags(mut self, tags: Vec<String>) -> Self {
+        self.tags = tags;
+        self
+    }
+
+    pub fn with_health_endpoint(mut self, endpoint: String) -> Self {
+        self.health_endpoint = endpoint;
+        self
+    }
+
+    pub fn update_heartbeat(&mut self) {
+        self.last_heartbeat = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+    }
+
+    pub fn is_healthy(&self, timeout_secs: u64) -> bool {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        now - self.last_heartbeat < timeout_secs
+    }
+}
+
+/// Service discovery using Redis for registration and lookup
+#[derive(Clone)]
+pub struct ServiceDiscovery {
+    redis_client: redis::Client,
+    redis_url: String,
+    service_ttl: Duration,
+}
+
+impl ServiceDiscovery {
+    pub fn new(redis_url: &str) -> RedisResult<Self> {
+        let redis_client = redis::Client::open(redis_url)?;
+        Ok(Self {
+            redis_client,
+            redis_url: redis_url.to_string(),
+            service_ttl: Duration::from_secs(30),
+        })
+    }
+
+    /// Register a service with discovery
+    pub async fn register_service(&self, service_info: &ServiceInfo) -> RedisResult<()> {
+        let mut conn = self.redis_client.get_async_connection().await?;
+        let key = format!("services:{}:{}", service_info.service_name, service_info.service_id);
+        let value = serde_json::to_string(service_info).unwrap();
+        
+        conn.set_ex(&key, value, self.service_ttl.as_secs() as u64).await?;
+        Ok(())
+    }
+
+    /// Discover services by name
+    pub async fn discover_services(&self, service_name: &str) -> RedisResult<Vec<ServiceInfo>> {
+        let mut conn = self.redis_client.get_async_connection().await?;
+        let pattern = format!("services:{}:*", service_name);
+        let keys: Vec<String> = conn.keys(pattern).await?;
+        
+        let mut services = Vec::new();
+        for key in keys {
+            if let Ok(value) = conn.get::<_, String>(&key).await {
+                if let Ok(service_info) = serde_json::from_str::<ServiceInfo>(&value) {
+                    if service_info.is_healthy(60) { // 60 second timeout
+                        services.push(service_info);
+                    }
+                }
+            }
+        }
+        
+        Ok(services)
+    }
+
+    /// Update service heartbeat
+    pub async fn heartbeat(&self, service_info: &mut ServiceInfo) -> RedisResult<()> {
+        service_info.update_heartbeat();
+        self.register_service(service_info).await
+    }
+
+    /// Remove a service from discovery
+    pub async fn deregister_service(&self, service_name: &str, service_id: &str) -> RedisResult<()> {
+        let mut conn = self.redis_client.get_async_connection().await?;
+        let key = format!("services:{}:{}", service_name, service_id);
+        conn.del(&key).await?;
+        Ok(())
+    }
+
+    /// Get all services grouped by name
+    pub async fn get_all_services(&self) -> RedisResult<HashMap<String, Vec<ServiceInfo>>> {
+        let mut conn = self.redis_client.get_async_connection().await?;
+        let keys: Vec<String> = conn.keys("services:*").await?;
+        
+        let mut services_map: HashMap<String, Vec<ServiceInfo>> = HashMap::new();
+        
+        for key in keys {
+            if let Ok(value) = conn.get::<_, String>(&key).await {
+                if let Ok(service_info) = serde_json::from_str::<ServiceInfo>(&value) {
+                    if service_info.is_healthy(60) {
+                        services_map
+                            .entry(service_info.service_name.clone())
+                            .or_insert_with(Vec::new)
+                            .push(service_info);
+                    }
+                }
+            }
+        }
+        
+        Ok(services_map)
+    }
+
+    /// Start background heartbeat task
+    pub async fn start_heartbeat_task(
+        &self,
+        mut service_info: ServiceInfo,
+        interval: Duration,
+    ) -> tokio::task::JoinHandle<()> {
+        let discovery = Self::new(&self.redis_url).unwrap();
+        
+        tokio::spawn(async move {
+            let mut interval_timer = time::interval(interval);
+            loop {
+                interval_timer.tick().await;
+                if let Err(e) = discovery.heartbeat(&mut service_info).await {
+                    tracing::error!("Failed to send heartbeat: {}", e);
+                }
+            }
+        })
+    }
+}

--- a/backend/src/service/mod.rs
+++ b/backend/src/service/mod.rs
@@ -1,6 +1,7 @@
 // Service layer module for ArenaX
 pub mod tournament_service;
 pub mod match_service;
+pub mod communication;
 
 pub use tournament_service::TournamentService;
 pub use match_service::MatchService;


### PR DESCRIPTION
## 📋 Summary

Introduces a robust communication layer for microservices:

* 🔎 Redis-based service discovery and message queue
* 🛡️ Circuit breaker to prevent cascading failures
* ⚖️ Load balancer with round-robin and random strategies
* 🔗 gRPC client with circuit breaker and load balancer integration
* ❤️ Health checker for HTTP-based service liveness and latency

---

## 🔧 Changes

### New Module: `backend/src/service/communication/`

* `service_discovery.rs` → register/discover/heartbeat/deregister services
* `message_queue.rs` → pub/sub, work queue, DLQ and retries
* `circuit_breaker.rs` → closed/open/half-open with thresholds and stats
* `load_balancer.rs` → round-robin and random endpoint selection
* `grpc_client.rs` → channel acquisition with circuit breaker; `E: From<anyhow::Error>`
* `health_checker.rs` → periodic `/health` probes with latency and status

### Module Export

* `pub mod communication;` in `backend/src/service/mod.rs`

### Dependencies (`backend/Cargo.toml`)

* `redis = "0.24"`, features = `["tokio-comp"]`
* `tonic = "0.10"`
* `prost = "0.12"`
* `reqwest = "0.11"`, features = `["json", "rustls-tls"]`
* `rand = "0.8"`

### Fixes

* Derive `Clone` for `ServiceDiscovery`
* Use `get_async_connection()` for Redis
* `GrpcClient::call_with` error conversion via `From<anyhow::Error>`
* Random selection uses `SliceRandom` on `&[ServiceInfo]`

---

## 📝 Implementation Notes

* Endpoint format for load balancer: `http://{host}:{port}`
* Health checker uses `reqwest::Client`, assumes GET `{health_endpoint}` returns 2xx for healthy
* gRPC client uses `tonic::transport::Endpoint` with `connect_timeout` and `tcp_nodelay`

---

## 🧪 Testing

```bash
# Build
cargo build
```

Optional runtime checks:

* Register a few services via `ServiceDiscovery` and verify `discover_services`.
* Pub/sub test with `MessageQueue::publish` / `subscribe`.
* Validate circuit breaker opens after threshold failures.
* Confirm `LoadBalancer` selects endpoints as expected.

---

## ⚠️ Risks

* Redis must be reachable for discovery and queue operations.
* gRPC consumers need error types implementing `From<anyhow::Error>`.

---

## 🔮 Follow-ups

* Wire communication module into `backend/src/main.rs` for actual service usage.
* Add integration tests for discovery and queue flows.
* Consider HTTPS endpoints and mTLS for gRPC if needed.

---

## ✅ Checklist

* [x] Dependencies updated in `backend/Cargo.toml`
* [x] New module exported via `service/mod.rs`
* [x] Build passes: `cargo build`
* [x] No breaking changes to existing services’ APIs

closes #8 
