### PR TITLE
feat: Implement ArenaX landing page

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,75 +1,18 @@
 import { AppLayout } from "@/components/layout/AppLayout";
-import { Button } from "@/components/ui/Button";
-import {
-  Card,
-  CardHeader,
-  CardTitle,
-  CardContent,
-  CardFooter,
-} from "@/components/ui/Card";
+import { HeroSection } from "@/components/landing/HeroSection";
+import { FeatureSection } from "@/components/landing/FeatureSection";
+import { HowItWorksSection } from "@/components/landing/HowItWorksSection";
+import { CTASection } from "@/components/landing/CTASection";
 
 export default function Home() {
   return (
     <AppLayout>
-      <section className="space-y-6 pb-8 pt-6 md:pb-12 md:pt-10 lg:py-32">
-        <div className="container flex max-w-[64rem] flex-col items-center gap-4 text-center">
-          <h1 className="font-heading text-3xl sm:text-5xl md:text-6xl lg:text-7xl">
-            Competitive Gaming Evolved.
-          </h1>
-          <p className="max-w-[42rem] leading-normal text-muted-foreground sm:text-xl sm:leading-8">
-            Join the ultimate platform for esports tournaments. Compete, win,
-            and rank up. Now featuring a robust Light & Dark mode system.
-          </p>
-          <div className="space-x-4">
-            <Button size="lg">Get Started</Button>
-            <Button variant="outline" size="lg">
-              View Tournaments
-            </Button>
-          </div>
-        </div>
-      </section>
-
-      <section className="container grid lg:grid-cols-3 gap-6 py-8 md:py-12 lg:py-24">
-        <Card>
-          <CardHeader>
-            <CardTitle>Global Theming</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p>Fully integrated dark mode with persistent state.</p>
-          </CardContent>
-          <CardFooter>
-            <Button variant="secondary" className="w-full">
-              Explore
-            </Button>
-          </CardFooter>
-        </Card>
-        <Card>
-          <CardHeader>
-            <CardTitle>Modern Stack</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p>Built with Next.js 14, TailwindCSS, and Shadcn UI principles.</p>
-          </CardContent>
-          <CardFooter>
-            <Button variant="secondary" className="w-full">
-              Explore
-            </Button>
-          </CardFooter>
-        </Card>
-        <Card>
-          <CardHeader>
-            <CardTitle>Performance</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p>Optimized for speed and accessibility out of the box.</p>
-          </CardContent>
-          <CardFooter>
-            <Button variant="secondary" className="w-full">
-              Explore
-            </Button>
-          </CardFooter>
-        </Card>
-      </section>
+      <div className="flex flex-col gap-8 md:gap-12">
+        <HeroSection />
+        <FeatureSection />
+        <HowItWorksSection />
+        <CTASection />
+      </div>
     </AppLayout>
   );
 }

--- a/frontend/src/components/landing/CTASection.tsx
+++ b/frontend/src/components/landing/CTASection.tsx
@@ -1,0 +1,33 @@
+import { Button } from "@/components/ui/Button";
+import Link from "next/link";
+
+export function CTASection() {
+  return (
+    <section className="container py-8 md:py-12 lg:py-24">
+      <div className="relative rounded-3xl bg-primary px-6 py-16 md:px-12 md:py-24 overflow-hidden">
+        <div className="relative z-10 mx-auto flex max-w-[58rem] flex-col items-center gap-4 text-center text-primary-foreground">
+          <h2 className="font-heading text-3xl font-bold leading-[1.1] sm:text-3xl md:text-6xl">
+            Ready to Start Winning?
+          </h2>
+          <p className="max-w-[42rem] leading-normal text-primary-foreground/80 sm:text-xl sm:leading-8">
+            Join thousands of gamers already competing on ArenaX. Sign up today
+            and get your first tournament entry free.
+          </p>
+          <Link href="/register" className="w-full sm:w-auto">
+            <Button
+              size="lg"
+              variant="secondary"
+              className="mt-4 h-12 w-full px-8 text-lg sm:w-auto"
+            >
+              Create Free Account
+            </Button>
+          </Link>
+        </div>
+
+        {/* Background shapes */}
+        <div className="absolute top-0 left-0 -translate-x-1/2 -translate-y-1/2 w-96 h-96 bg-white/10 rounded-full blur-3xl" />
+        <div className="absolute bottom-0 right-0 translate-x-1/2 translate-y-1/2 w-96 h-96 bg-white/10 rounded-full blur-3xl" />
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/landing/FeatureSection.tsx
+++ b/frontend/src/components/landing/FeatureSection.tsx
@@ -1,0 +1,72 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/Card";
+import { Trophy, Zap, Shield, Users, Wallet, Swords } from "lucide-react";
+
+const features = [
+  {
+    title: "Instant Payouts",
+    description:
+      "Win and withdraw instantly via Stripe, Bank Transfer, or Crypto.",
+    icon: Wallet,
+  },
+  {
+    title: "Anti-Cheat Protection",
+    description: "AI-driven cheat detection ensures fair play in every match.",
+    icon: Shield,
+  },
+  {
+    title: "Daily Tournaments",
+    description:
+      "Join automated tournaments for your favorite games every day.",
+    icon: Trophy,
+  },
+  {
+    title: "Skill-Based Matchmaking",
+    description:
+      "Compete against players of your skill level for fair matches.",
+    icon: Swords,
+  },
+  {
+    title: "Community Driven",
+    description: "Create your own tournaments and build a following.",
+    icon: Users,
+  },
+  {
+    title: "Lightning Fast",
+    description: "Built on Stellar for low-cost, high-speed transactions.",
+    icon: Zap,
+  },
+];
+
+export function FeatureSection() {
+  return (
+    <section className="container space-y-6 py-8 md:py-12 lg:py-24 bg-muted/50 rounded-3xl my-8">
+      <div className="mx-auto flex max-w-[58rem] flex-col items-center space-y-4 text-center">
+        <h2 className="font-heading text-3xl leading-[1.1] sm:text-3xl md:text-6xl">
+          Features designed for <span className="text-primary">Gamers</span>
+        </h2>
+        <p className="max-w-[85%] leading-normal text-muted-foreground sm:text-lg sm:leading-7">
+          ArenaX combines cutting-edge technology with seamless user experience
+          to bring you the best competitive platform.
+        </p>
+      </div>
+      <div className="mx-auto grid justify-center gap-4 sm:grid-cols-2 md:max-w-[64rem] md:grid-cols-3">
+        {features.map((feature) => (
+          <Card
+            key={feature.title}
+            className="bg-background border-none shadow-sm transition-all hover:shadow-md"
+          >
+            <CardHeader>
+              <feature.icon className="h-10 w-10 text-primary mb-2" />
+              <CardTitle className="text-xl">{feature.title}</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm text-muted-foreground">
+                {feature.description}
+              </p>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/landing/HeroSection.tsx
+++ b/frontend/src/components/landing/HeroSection.tsx
@@ -1,0 +1,44 @@
+import { Button } from "@/components/ui/Button";
+import Link from "next/link";
+
+export function HeroSection() {
+  return (
+    <section className="relative overflow-hidden bg-background pb-16 pt-20 md:pb-32 md:pt-32 lg:pb-40 lg:pt-40">
+      <div className="container relative z-10 flex max-w-[64rem] flex-col items-center gap-4 text-center">
+        <div className="inline-flex items-center rounded-lg bg-muted px-3 py-1 text-sm font-medium">
+          🎉 <span className="ml-1">Season 1 is now live</span>
+        </div>
+        <h1 className="font-heading text-4xl font-bold tracking-tight sm:text-5xl md:text-6xl lg:text-7xl">
+          Competitive Gaming <br className="hidden sm:inline" />
+          <span className="text-primary">Evolved</span>
+        </h1>
+        <p className="max-w-[42rem] leading-normal text-muted-foreground sm:text-xl sm:leading-8">
+          Join the ultimate platform for amateur gamers. Compete in daily
+          tournaments, get instant payouts, and build your reputation on the
+          blockchain.
+        </p>
+        <div className="flex w-full flex-col gap-4 sm:w-auto sm:flex-row">
+          <Link href="/register" className="w-full sm:w-auto">
+            <Button size="lg" className="h-11 w-full px-8 sm:w-auto">
+              Start Competing
+            </Button>
+          </Link>
+          <Link href="/tournaments" className="w-full sm:w-auto">
+            <Button
+              variant="outline"
+              size="lg"
+              className="h-11 w-full px-8 sm:w-auto"
+            >
+              View Tournaments
+            </Button>
+          </Link>
+        </div>
+      </div>
+
+      {/* Background decoration */}
+      <div className="absolute left-1/2 top-1/2 -z-10 h-[600px] w-[600px] -translate-x-1/2 -translate-y-1/2 opacity-20 dark:opacity-10">
+        <div className="h-full w-full rounded-full bg-primary blur-[100px]" />
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/landing/HowItWorksSection.tsx
+++ b/frontend/src/components/landing/HowItWorksSection.tsx
@@ -1,0 +1,58 @@
+const steps = [
+  {
+    number: "01",
+    title: "Sign Up",
+    description:
+      "Create an account in seconds using your email or social login.",
+  },
+  {
+    number: "02",
+    title: "Join Tournament",
+    description: "Browse daily tournaments for your game and skill level.",
+  },
+  {
+    number: "03",
+    title: "Compete & Win",
+    description:
+      "Play your matches and report scores with our automated system.",
+  },
+  {
+    number: "04",
+    title: "Get Paid",
+    description:
+      "Receive your prize money instantly to your preferred local wallet.",
+  },
+];
+
+export function HowItWorksSection() {
+  return (
+    <section className="container py-8 md:py-12 lg:py-24">
+      <div className="mx-auto flex max-w-[58rem] flex-col items-center justify-center gap-4 text-center">
+        <h2 className="font-heading text-3xl leading-[1.1] sm:text-3xl md:text-6xl">
+          How it Works
+        </h2>
+        <p className="max-w-[85%] leading-normal text-muted-foreground sm:text-lg sm:leading-7">
+          Start your journey to becoming a pro gamer in four simple steps.
+        </p>
+      </div>
+      <div className="mx-auto grid justify-center gap-8 sm:grid-cols-2 md:max-w-[64rem] md:grid-cols-4 mt-12">
+        {steps.map((step) => (
+          <div
+            key={step.number}
+            className="relative flex flex-col items-center text-center gap-2 px-4"
+          >
+            <span className="text-6xl font-bold text-muted/30 absolute -top-8 select-none">
+              {step.number}
+            </span>
+            <div className="relative z-10 flex flex-col items-center gap-2">
+              <h3 className="font-bold text-xl">{step.title}</h3>
+              <p className="text-sm text-muted-foreground">
+                {step.description}
+              </p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { ThemeToggle } from "@/components/ThemeToggle";
+import { MobileNav } from "@/components/layout/MobileNav";
 import { Button } from "@/components/ui/Button";
 
 interface AppLayoutProps {
@@ -36,6 +37,7 @@ export function AppLayout({ children }: AppLayoutProps) {
             </div>
             <nav className="flex items-center">
               <ThemeToggle />
+              <MobileNav />
             </nav>
           </div>
         </div>

--- a/frontend/src/components/layout/MobileNav.tsx
+++ b/frontend/src/components/layout/MobileNav.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { Button } from "@/components/ui/Button";
+import { Menu, X, Trophy } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export function MobileNav() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <div className="md:hidden">
+      <Button
+        variant="ghost"
+        size="sm"
+        className="px-2"
+        onClick={() => setIsOpen(!isOpen)}
+        aria-label="Toggle Menu"
+      >
+        {isOpen ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
+      </Button>
+
+      {isOpen && (
+        <div className="fixed inset-0 top-14 z-50 grid h-[calc(100vh-3.5rem)] grid-flow-row auto-rows-max overflow-auto p-6 pb-32 bg-background animate-in slide-in-from-bottom-80 md:hidden">
+          <div className="relative z-20 grid gap-6 rounded-md p-4 bg-popover text-popover-foreground shadow-md border">
+            <Link
+              href="/"
+              className="flex items-center space-x-2"
+              onClick={() => setIsOpen(false)}
+            >
+              <Trophy className="h-6 w-6" />
+              <span className="font-bold">ArenaX</span>
+            </Link>
+            <nav className="grid grid-flow-row auto-rows-max text-sm">
+              <Link
+                href="/tournaments"
+                className={cn(
+                  "flex w-full items-center rounded-md p-2 text-sm font-medium hover:underline",
+                )}
+                onClick={() => setIsOpen(false)}
+              >
+                Tournaments
+              </Link>
+              <Link
+                href="/uikit"
+                className={cn(
+                  "flex w-full items-center rounded-md p-2 text-sm font-medium hover:underline",
+                )}
+                onClick={() => setIsOpen(false)}
+              >
+                UI Kit
+              </Link>
+            </nav>
+            <div className="flex flex-col gap-2 mt-4">
+              <Link href="/login" onClick={() => setIsOpen(false)}>
+                <Button variant="ghost" className="w-full justify-start">
+                  Login
+                </Button>
+              </Link>
+              <Link href="/register" onClick={() => setIsOpen(false)}>
+                <Button className="w-full">Sign Up</Button>
+              </Link>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
I have successfully designed and implemented the new landing page for ArenaX.

Changes
Landing Page Components
I created a directory src/components/landing and added the following components:

HeroSection
: Features a bold headline, value proposition, and primary/secondary CTAs. Includes a subtle background glow.
FeatureSection
: Displays key platform features (Instant Payouts, Anti-cheat, etc.) in a responsive grid using lucide-react icons.
HowItWorksSection
: A step-by-step guide (Sign Up -> Join -> Compete -> Paid) to educate new users.
CTASection
: A final high-contrast call to action to encourage sign-ups.
Main Page Update
Updated page.tsx to assemble these components within the AppLayout

closes #53 