### PR TITLE
feat: add notification settings and realtime ui

### DIFF
--- a/frontend/src/app/notifications/settings/page.tsx
+++ b/frontend/src/app/notifications/settings/page.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import type { ComponentType } from "react";
+import { useMemo } from "react";
+import {
+  AlertCircle,
+  AlertTriangle,
+  CheckCircle,
+  Info,
+  Trophy,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useNotifications } from "@/contexts/NotificationContext";
+import { NotificationType } from "@/types/notification";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/Card";
+import { Button } from "@/components/ui/Button";
+
+const preferenceConfig: Array<{
+  type: NotificationType;
+  label: string;
+  description: string;
+  icon: ComponentType<{ className?: string }>;
+}> = [
+  {
+    type: "match",
+    label: "Match updates",
+    description: "Found matches, score changes, and dispute alerts.",
+    icon: Trophy,
+  },
+  {
+    type: "success",
+    label: "Success",
+    description: "Confirmed actions and positive outcomes.",
+    icon: CheckCircle,
+  },
+  {
+    type: "info",
+    label: "Info",
+    description: "General platform updates and helpful tips.",
+    icon: Info,
+  },
+  {
+    type: "warning",
+    label: "Warnings",
+    description: "Potential issues that might need attention.",
+    icon: AlertTriangle,
+  },
+  {
+    type: "error",
+    label: "Errors",
+    description: "Critical failures or blocked actions.",
+    icon: AlertCircle,
+  },
+];
+
+function PreferenceToggle({
+  checked,
+  onChange,
+}: {
+  checked: boolean;
+  onChange: (next: boolean) => void;
+}) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      className={cn(
+        "relative inline-flex h-6 w-11 items-center rounded-full border transition-colors",
+        checked
+          ? "bg-primary border-primary/60"
+          : "bg-muted border-border"
+      )}
+      onClick={() => onChange(!checked)}
+    >
+      <span
+        className={cn(
+          "inline-block h-5 w-5 transform rounded-full bg-background shadow-sm transition-transform",
+          checked ? "translate-x-5" : "translate-x-0.5"
+        )}
+      />
+    </button>
+  );
+}
+
+export default function NotificationSettingsPage() {
+  const { preferences, updatePreference, setAllPreferences } = useNotifications();
+
+  const enabledCount = useMemo(
+    () => preferenceConfig.filter((item) => preferences[item.type]).length,
+    [preferences]
+  );
+
+  return (
+    <div className="py-8 max-w-3xl mx-auto space-y-6 animate-in fade-in duration-500">
+      <Card>
+        <CardHeader>
+          <CardTitle>Notification Settings</CardTitle>
+          <CardDescription>
+            Choose which alerts you want to receive in real time. These settings
+            apply to new notifications only.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {preferenceConfig.map((item) => {
+            const Icon = item.icon;
+            const enabled = preferences[item.type];
+            return (
+              <div
+                key={item.type}
+                className={cn(
+                  "flex items-center justify-between gap-4 rounded-lg border px-4 py-3 transition-colors",
+                  enabled ? "bg-card" : "bg-muted/40"
+                )}
+              >
+                <div className="flex items-start gap-3">
+                  <div
+                    className={cn(
+                      "mt-0.5 flex h-9 w-9 items-center justify-center rounded-md border",
+                      enabled ? "border-primary/30 bg-primary/10" : "border-border"
+                    )}
+                  >
+                    <Icon className={cn("h-4 w-4", enabled ? "text-primary" : "text-muted-foreground")} />
+                  </div>
+                  <div>
+                    <p className="font-medium">{item.label}</p>
+                    <p className="text-sm text-muted-foreground">
+                      {item.description}
+                    </p>
+                  </div>
+                </div>
+                <PreferenceToggle
+                  checked={enabled}
+                  onChange={(next) => updatePreference(item.type, next)}
+                />
+              </div>
+            );
+          })}
+        </CardContent>
+        <CardFooter className="flex flex-wrap items-center justify-between gap-3">
+          <p className="text-xs text-muted-foreground">
+            {enabledCount} of {preferenceConfig.length} categories enabled.
+          </p>
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => setAllPreferences(false)}
+            >
+              Mute all
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => setAllPreferences(true)}
+            >
+              Enable all
+            </Button>
+          </div>
+        </CardFooter>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/components/layout/MobileHeaderActions.tsx
+++ b/frontend/src/components/layout/MobileHeaderActions.tsx
@@ -10,7 +10,7 @@ export function MobileHeaderActions() {
   const { user } = useAuth();
   return (
     <div className="flex items-center gap-2 md:hidden">
-      <NotificationBell />
+      {user && <NotificationBell />}
       {user && <UserMenu />}
       <ThemeToggle />
       <MobileNav />

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -71,7 +71,7 @@ export function Navbar() {
         </nav>
       </div>
       <div className="flex items-center gap-2">
-        <NotificationBell />
+        {user && <NotificationBell />}
         {user && <UserMenu />}
         {authItems.map((item) => {
           const isActive = isActiveRoute(pathname, item.href);

--- a/frontend/src/components/layout/UserMenu.tsx
+++ b/frontend/src/components/layout/UserMenu.tsx
@@ -4,7 +4,7 @@ import { useRef, useEffect, useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { usePathname } from "next/navigation";
-import { LogOut, User, Wallet } from "lucide-react";
+import { Bell, LogOut, User, Wallet } from "lucide-react";
 import { useAuth } from "@/hooks/useAuth";
 import { cn } from "@/lib/utils";
 
@@ -86,6 +86,18 @@ export function UserMenu() {
           >
             <Wallet className="h-4 w-4" />
             Wallet
+          </Link>
+          <Link
+            href="/notifications/settings"
+            className={cn(
+              "flex items-center gap-2 px-3 py-2 text-sm hover:bg-muted/60 transition-colors",
+              isActiveRoute(pathname, "/notifications") && "bg-muted/60"
+            )}
+            role="menuitem"
+            onClick={() => setOpen(false)}
+          >
+            <Bell className="h-4 w-4" />
+            Notifications
           </Link>
           <button
             type="button"

--- a/frontend/src/components/notifications/NotificationBell.tsx
+++ b/frontend/src/components/notifications/NotificationBell.tsx
@@ -2,7 +2,7 @@
 
 import { useRef, useEffect, useState } from "react";
 import Link from "next/link";
-import { Bell, CheckCheck, Trash2, Loader2, RefreshCw } from "lucide-react";
+import { Bell, CheckCheck, Trash2, Loader2, RefreshCw, Settings } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useNotifications } from "@/contexts/NotificationContext";
 import { Button } from "@/components/ui/Button";
@@ -200,6 +200,20 @@ export function NotificationBell({ className, onClose }: NotificationBellProps) 
                 ))}
               </ul>
             )}
+          </div>
+
+          <div className="border-t p-2">
+            <Link
+              href="/notifications/settings"
+              className="flex items-center gap-2 rounded-md px-2 py-1.5 text-xs font-medium text-muted-foreground hover:text-foreground hover:bg-muted/60 transition-colors"
+              onClick={() => {
+                setIsOpen(false);
+                onClose?.();
+              }}
+            >
+              <Settings className="h-3.5 w-3.5" />
+              Notification settings
+            </Link>
           </div>
         </div>
       )}

--- a/frontend/src/contexts/NotificationContext.tsx
+++ b/frontend/src/contexts/NotificationContext.tsx
@@ -12,12 +12,23 @@ import {
   PersistentNotification,
   ToastNotification,
   NotificationType,
+  NotificationPreferences,
 } from "@/types/notification";
 import { api } from "@/lib/api";
 import { useAuth } from "@/hooks/useAuth";
 
 const PERSISTENT_STORAGE_KEY = "arenax_notifications";
+const PREFERENCES_STORAGE_KEY = "arenax_notification_preferences";
 const MAX_LOCAL_NOTIFICATIONS = 50;
+const MAX_TOASTS = 4;
+
+const DEFAULT_PREFERENCES: NotificationPreferences = {
+  info: true,
+  success: true,
+  warning: true,
+  error: true,
+  match: true,
+};
 
 interface NotificationContextType {
   // Persistent notifications (from API or localStorage fallback)
@@ -46,6 +57,11 @@ interface NotificationContextType {
     toast?: boolean;
     toastDuration?: number;
   }) => void;
+
+  // User preferences
+  preferences: NotificationPreferences;
+  updatePreference: (type: NotificationType, enabled: boolean) => void;
+  setAllPreferences: (enabled: boolean) => void;
 }
 
 const NotificationContext = createContext<NotificationContextType | undefined>(
@@ -78,6 +94,27 @@ function saveLocalNotifications(notifications: PersistentNotification[]) {
   }
 }
 
+function loadPreferences(): NotificationPreferences {
+  if (typeof window === "undefined") return DEFAULT_PREFERENCES;
+  try {
+    const stored = localStorage.getItem(PREFERENCES_STORAGE_KEY);
+    if (!stored) return DEFAULT_PREFERENCES;
+    const parsed = JSON.parse(stored) as Partial<NotificationPreferences>;
+    return { ...DEFAULT_PREFERENCES, ...parsed };
+  } catch {
+    return DEFAULT_PREFERENCES;
+  }
+}
+
+function savePreferences(preferences: NotificationPreferences) {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(PREFERENCES_STORAGE_KEY, JSON.stringify(preferences));
+  } catch {
+    // Ignore storage errors
+  }
+}
+
 function generateId() {
   return `notif_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
 }
@@ -88,7 +125,15 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
     PersistentNotification[]
   >(loadLocalNotifications);
   const [toasts, setToasts] = useState<ToastNotification[]>([]);
+  const [preferences, setPreferences] = useState<NotificationPreferences>(
+    loadPreferences
+  );
   const toastTimeouts = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+  const preferencesRef = useRef(preferences);
+
+  useEffect(() => {
+    preferencesRef.current = preferences;
+  }, [preferences]);
 
   const unreadCount = persistentNotifications.filter((n) => !n.read).length;
 
@@ -105,6 +150,7 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
           type: (n.type as PersistentNotification["type"]) ?? "info",
         }));
         setPersistentNotifications(mapped);
+        saveLocalNotifications(mapped);
       }
     } catch {
       setPersistentNotifications(loadLocalNotifications());
@@ -125,9 +171,8 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
         );
         if (user?.id) {
           api.markNotificationRead(id).catch(() => {});
-        } else {
-          saveLocalNotifications(updated);
         }
+        saveLocalNotifications(updated);
         return updated;
       });
     },
@@ -139,9 +184,8 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
       const updated = prev.map((n) => ({ ...n, read: true }));
       if (user?.id) {
         api.markAllNotificationsRead().catch(() => {});
-      } else {
-        saveLocalNotifications(updated);
       }
+      saveLocalNotifications(updated);
       return updated;
     });
   }, [user?.id]);
@@ -152,9 +196,8 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
         const updated = prev.filter((n) => n.id !== id);
         if (user?.id) {
           api.deleteNotification(id).catch(() => {});
-        } else {
-          saveLocalNotifications(updated);
         }
+        saveLocalNotifications(updated);
         return updated;
       });
     },
@@ -170,7 +213,10 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
         createdAt: Date.now(),
         duration: toast.duration ?? 5000,
       };
-      setToasts((prev) => [...prev.filter((t) => t.id !== id), fullToast]);
+      setToasts((prev) => {
+        const next = [...prev.filter((t) => t.id !== id), fullToast];
+        return next.slice(-MAX_TOASTS);
+      });
 
       if (fullToast.duration && fullToast.duration > 0) {
         const timeout = setTimeout(() => {
@@ -214,6 +260,8 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
         toastDuration = 5000,
       } = params;
 
+      if (!preferencesRef.current[type]) return;
+
       if (showToast) {
         addToast({ type, title, message, duration: toastDuration });
       }
@@ -238,16 +286,159 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
               message: message ?? "",
               link,
               linkLabel,
-            }).catch(() => saveLocalNotifications(updated));
-          } else {
-            saveLocalNotifications(updated);
+            }).catch(() => {});
           }
+          saveLocalNotifications(updated);
           return updated;
         });
       }
     },
     [addToast, user?.id]
   );
+
+  const updatePreference = useCallback(
+    (type: NotificationType, enabled: boolean) => {
+      setPreferences((prev) => {
+        const next = { ...prev, [type]: enabled };
+        savePreferences(next);
+        return next;
+      });
+    },
+    []
+  );
+
+  const setAllPreferences = useCallback((enabled: boolean) => {
+    const next = Object.keys(DEFAULT_PREFERENCES).reduce((acc, key) => {
+      acc[key as NotificationType] = enabled;
+      return acc;
+    }, {} as NotificationPreferences);
+    setPreferences(next);
+    savePreferences(next);
+  }, []);
+
+  const handleIncomingNotification = useCallback(
+    (notification: PersistentNotification) => {
+      if (!preferencesRef.current[notification.type]) return;
+
+      setPersistentNotifications((prev) => {
+        const next = [
+          notification,
+          ...prev.filter((existing) => existing.id !== notification.id),
+        ];
+
+        if (!user?.id) {
+          saveLocalNotifications(next);
+        }
+        return next;
+      });
+
+      const allowToast = notification.metadata?.toast !== false;
+      if (allowToast) {
+        addToast({
+          type: notification.type,
+          title: notification.title,
+          message: notification.message,
+          duration: 5000,
+        });
+      }
+    },
+    [addToast, user?.id]
+  );
+
+  useEffect(() => {
+    if (!user?.id || typeof window === "undefined") return;
+
+    let ws: WebSocket | null = null;
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    let retry = 0;
+    let closed = false;
+
+    const buildWsUrl = () => {
+      const protocol = window.location.protocol === "https:" ? "wss" : "ws";
+      const token =
+        localStorage.getItem("auth_token") ??
+        sessionStorage.getItem("auth_token");
+      const qs = token ? `?token=${encodeURIComponent(token)}` : "";
+      return `${protocol}://${window.location.host}/ws/notifications${qs}`;
+    };
+
+    const scheduleReconnect = () => {
+      if (closed) return;
+      const delay = Math.min(10000, 1000 * 2 ** retry);
+      retry += 1;
+      reconnectTimer = setTimeout(connect, delay);
+    };
+
+    const normalizeNotification = (input: any): PersistentNotification | null => {
+      if (!input) return null;
+      const candidate = input.notification ?? input.payload ?? input.data ?? input;
+      if (!candidate) return null;
+
+      const type = (candidate.type as NotificationType) ?? "info";
+      const title =
+        (candidate.title as string | undefined) ??
+        (candidate.message as string | undefined) ??
+        "Notification";
+
+      return {
+        id: (candidate.id as string | undefined) ?? generateId(),
+        type,
+        title,
+        message: (candidate.message as string | undefined) ?? "",
+        link: candidate.link as string | undefined,
+        linkLabel: candidate.linkLabel as string | undefined,
+        read: (candidate.read as boolean | undefined) ?? false,
+        createdAt:
+          (candidate.createdAt as string | undefined) ??
+          new Date().toISOString(),
+        metadata: candidate.metadata as Record<string, unknown> | undefined,
+      };
+    };
+
+    const handleMessage = (raw: string) => {
+      try {
+        const parsed = JSON.parse(raw);
+        if (parsed?.type === "ping") {
+          ws?.send(JSON.stringify({ type: "pong" }));
+          return;
+        }
+        const notification = normalizeNotification(parsed);
+        if (notification) handleIncomingNotification(notification);
+      } catch {
+        // Ignore non-JSON messages
+      }
+    };
+
+    const connect = () => {
+      if (closed) return;
+      try {
+        ws = new WebSocket(buildWsUrl());
+      } catch {
+        scheduleReconnect();
+        return;
+      }
+
+      ws.onopen = () => {
+        retry = 0;
+      };
+      ws.onmessage = (event) => handleMessage(event.data);
+      ws.onclose = () => {
+        if (closed) return;
+        scheduleReconnect();
+      };
+      ws.onerror = () => {
+        ws?.close();
+      };
+    };
+
+    connect();
+
+    return () => {
+      closed = true;
+      if (reconnectTimer) clearTimeout(reconnectTimer);
+      ws?.close();
+    };
+  }, [handleIncomingNotification, user?.id]);
 
   const value: NotificationContextType = {
     persistentNotifications,
@@ -260,6 +451,9 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
     addToast,
     removeToast,
     notify,
+    preferences,
+    updatePreference,
+    setAllPreferences,
   };
 
   return (

--- a/frontend/src/types/notification.ts
+++ b/frontend/src/types/notification.ts
@@ -2,6 +2,8 @@
 
 export type NotificationType = "info" | "success" | "warning" | "error" | "match";
 
+export type NotificationPreferences = Record<NotificationType, boolean>;
+
 export interface PersistentNotification {
   id: string;
   type: NotificationType;


### PR DESCRIPTION
Closed: #142 

## Summary

Adds the notification settings page and improves the notification UI/UX, including authenticated-only access to the bell.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor / cleanup
- [ ] Docs / config only

## Related issues

Closes #142

## Changes

- Added notification settings page with per‑type toggles.
- Added settings link in the bell dropdown and notifications link in the user menu.
- Hid notification bell for unauthenticated users to keep UI clean.
- Persisted notification state locally for consistent unread counts across sessions.

## Testing

- [ ] Unit tests pass (`cargo test` / `npm test`)
- [ ] Contracts tests pass (`cargo test` in `contracts/`)
- [ ] Manually tested locally
- [ ] Migration tested against a fresh DB

## Checklist

- [x] Code follows project conventions
- [x] No secrets or PII committed
- [ ] Migrations are reversible (`.down.sql` exists)
- [ ] Contract changes are backward-compatible or versioned
- [ ] CI passes

#142 