### PR TITLE
feat(tournaments): integrate API for tournament joining and registrat…

### DIFF
--- a/frontend/src/__tests__/join-tournament-button.test.tsx
+++ b/frontend/src/__tests__/join-tournament-button.test.tsx
@@ -1,0 +1,95 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { JoinTournamentButton } from "@/components/tournaments/JoinTournamentButton";
+import { Tournament } from "@/types/tournament";
+
+const mockPush = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush, back: jest.fn() }),
+}));
+
+const mockNotify = jest.fn();
+
+jest.mock("@/contexts/NotificationContext", () => ({
+  useNotifications: () => ({
+    notify: mockNotify,
+  }),
+}));
+
+const mockJoinTournament = jest.fn();
+
+jest.mock("@/lib/api", () => ({
+  api: {
+    joinTournament: mockJoinTournament,
+  },
+}));
+
+const baseTournament: Tournament = {
+  id: "t1",
+  name: "ArenaX Showdown",
+  description: "A public tournament",
+  gameType: "Battle Arena",
+  tournamentType: "single_elimination",
+  entryFee: 10,
+  prizePool: 500,
+  maxParticipants: 16,
+  currentParticipants: 8,
+  status: "registration_open",
+  visibility: "public",
+  startTime: new Date().toISOString(),
+  endTime: new Date(Date.now() + 1000 * 60 * 60).toISOString(),
+  createdBy: "org-1",
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+describe("JoinTournamentButton", () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+    mockNotify.mockClear();
+    mockJoinTournament.mockClear();
+    localStorage.clear();
+  });
+
+  it("shows sign-in prompt when unauthenticated and opens modal", () => {
+    render(<JoinTournamentButton tournament={baseTournament} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /join tournament/i }));
+
+    expect(screen.getByText(/you need to be signed in/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /sign in/i })).toBeInTheDocument();
+  });
+
+  it("calls api.joinTournament and persists joined state when authenticated", async () => {
+    localStorage.setItem("auth_token", "token-123");
+    mockJoinTournament.mockResolvedValue({});
+
+    render(<JoinTournamentButton tournament={baseTournament} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /join tournament/i }));
+    fireEvent.click(screen.getByRole("button", { name: /confirm join/i }));
+
+    await waitFor(() => expect(mockJoinTournament).toHaveBeenCalledWith(baseTournament.id));
+
+    expect(screen.getByText(/successfully joined/i)).toBeInTheDocument();
+    expect(localStorage.getItem(`tournament-joined-${baseTournament.id}`)).toBe("true");
+    expect(mockNotify).toHaveBeenCalledWith(expect.objectContaining({
+      title: "Tournament Joined",
+    }));
+  });
+
+  it("displays an error message when the join API fails", async () => {
+    localStorage.setItem("auth_token", "token-123");
+    mockJoinTournament.mockRejectedValue(new Error("Payment required"));
+
+    render(<JoinTournamentButton tournament={baseTournament} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /join tournament/i }));
+    fireEvent.click(screen.getByRole("button", { name: /confirm join/i }));
+
+    await waitFor(() => expect(mockJoinTournament).toHaveBeenCalled());
+    expect(screen.getByText(/unable to join tournament/i)).toBeInTheDocument();
+    expect(screen.getByText(/payment required/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/tournaments/[id]/page.tsx
+++ b/frontend/src/app/tournaments/[id]/page.tsx
@@ -2,18 +2,18 @@
 
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type { ReactNode } from "react";
 import { TournamentHeader } from "@/components/tournaments/TournamentHeader";
 import { TournamentRules } from "@/components/tournaments/TournamentRules";
 import { TournamentParticipants } from "@/components/tournaments/TournamentParticipants";
 import { JoinTournamentButton } from "@/components/tournaments/JoinTournamentButton";
 import { SingleEliminationBracket } from "@/components/bracket/SingleEliminationBracket";
-import { mockTournaments } from "@/data/mockTournaments";
 import { generateMockBracket } from "@/data/mockBracket";
 import { ArrowLeft, RadioTower, ShieldAlert, Swords, Trophy } from "lucide-react";
 import { Button } from "@/components/ui/Button";
 import { useAuth } from "@/hooks/useAuth";
+import { api } from "@/lib/api";
 
 export default function TournamentDetailsPage() {
   const params = useParams();
@@ -21,11 +21,41 @@ export default function TournamentDetailsPage() {
   const { user } = useAuth();
   const tournamentId = params.id as string;
   const currentUserId = user?.id ?? "user-123";
+  const [tournament, setTournament] = useState<any | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [fetchError, setFetchError] = useState<string | null>(null);
 
-  const tournament = useMemo(
-    () => mockTournaments.find((candidate) => candidate.id === tournamentId),
-    [tournamentId],
-  );
+  useEffect(() => {
+    let active = true;
+
+    const loadTournament = async () => {
+      setIsLoading(true);
+      setFetchError(null);
+
+      try {
+        const data = await api.getTournament(tournamentId);
+        if (active) {
+          setTournament(data);
+        }
+      } catch (error) {
+        if (active) {
+          setFetchError(
+            error instanceof Error ? error.message : "Unable to load tournament.",
+          );
+        }
+      } finally {
+        if (active) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    loadTournament();
+
+    return () => {
+      active = false;
+    };
+  }, [tournamentId]);
 
   const bracketData = useMemo(() => {
     if (!tournament) {
@@ -38,6 +68,28 @@ export default function TournamentDetailsPage() {
 
     return null;
   }, [currentUserId, tournament]);
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-background px-4">
+        <div className="text-center">
+          <p className="text-lg font-medium text-foreground">Loading tournament details...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (fetchError) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-background px-4">
+        <div className="text-center">
+          <h1 className="mb-2 text-3xl font-bold text-foreground">Unable to load tournament</h1>
+          <p className="mb-6 text-muted-foreground">{fetchError}</p>
+          <Button onClick={() => router.push("/tournaments")}>Back to Tournaments</Button>
+        </div>
+      </div>
+    );
+  }
 
   if (!tournament) {
     return (

--- a/frontend/src/app/tournaments/[id]/register/page.tsx
+++ b/frontend/src/app/tournaments/[id]/register/page.tsx
@@ -1,21 +1,73 @@
 "use client";
 
-import { useMemo } from "react";
+import { useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
-import { mockTournaments } from "@/data/mockTournaments";
 import { RegistrationForm } from "@/components/tournaments/RegistrationForm";
 import { Button } from "@/components/ui/Button";
 import { ArrowLeft, AlertCircle } from "lucide-react";
+import { api } from "@/lib/api";
 
 export default function TournamentRegisterPage() {
   const params = useParams();
   const router = useRouter();
   const tournamentId = params.id as string;
+  const [tournament, setTournament] = useState<any | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [fetchError, setFetchError] = useState<string | null>(null);
 
-  const tournament = useMemo(
-    () => mockTournaments.find((t) => t.id === tournamentId),
-    [tournamentId],
-  );
+  useEffect(() => {
+    let active = true;
+
+    const loadTournament = async () => {
+      setIsLoading(true);
+      setFetchError(null);
+
+      try {
+        const data = await api.getTournament(tournamentId);
+        if (active) {
+          setTournament(data);
+        }
+      } catch (error) {
+        if (active) {
+          setFetchError(
+            error instanceof Error ? error.message : "Unable to load tournament.",
+          );
+        }
+      } finally {
+        if (active) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    loadTournament();
+
+    return () => {
+      active = false;
+    };
+  }, [tournamentId]);
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-background px-4">
+        <div className="text-center">
+          <p className="text-lg font-medium text-foreground">Loading tournament details...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (fetchError) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-background px-4">
+        <div className="text-center">
+          <h1 className="mb-2 text-2xl font-bold text-foreground">Unable to load tournament</h1>
+          <p className="mb-6 text-muted-foreground">{fetchError}</p>
+          <Button onClick={() => router.push("/tournaments")}>Back to Tournaments</Button>
+        </div>
+      </div>
+    );
+  }
 
   if (!tournament) {
     return (

--- a/frontend/src/components/tournaments/JoinTournamentButton.tsx
+++ b/frontend/src/components/tournaments/JoinTournamentButton.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Tournament } from "@/types/tournament";
 import { Button } from "@/components/ui/Button";
 import { useRouter } from "next/navigation";
 import { LogIn, CheckCircle, AlertCircle, Clock, Users, X } from "lucide-react";
 import { useNotifications } from "@/contexts/NotificationContext";
+import { api } from "@/lib/api";
 
 interface JoinTournamentButtonProps {
   tournament: Tournament;
@@ -21,6 +22,7 @@ export function JoinTournamentButton({
     "idle" | "confirming" | "success" | "error"
   >("idle");
   const [isJoined, setIsJoined] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   // Determine button state
   const isFull = tournament.currentParticipants >= tournament.maxParticipants;
@@ -75,45 +77,58 @@ export function JoinTournamentButton({
 
   const buttonState = getButtonState();
 
+  useEffect(() => {
+    const joined = localStorage.getItem(`tournament-joined-${tournament.id}`);
+    setIsJoined(joined === "true");
+  }, [tournament.id]);
+
   const handleJoinClick = () => {
-    // Check if user is authenticated (mock check)
     const isAuthenticated = localStorage.getItem("auth_token") !== null;
 
+    setShowModal(true);
+    setErrorMessage(null);
+
     if (!isAuthenticated) {
-      setShowModal(true);
       setJoinStatus("idle");
       return;
     }
 
-    setShowModal(true);
-    setJoinStatus("confirming");
+    setJoinStatus("idle");
   };
 
   const handleConfirmJoin = async () => {
     setJoinStatus("confirming");
+    setErrorMessage(null);
 
-    // Simulate API call
-    await new Promise((resolve) => setTimeout(resolve, 1500));
+    try {
+      await api.joinTournament(tournament.id);
+      setJoinStatus("success");
+      setIsJoined(true);
+      localStorage.setItem(`tournament-joined-${tournament.id}`, "true");
 
-    setJoinStatus("success");
-    setIsJoined(true);
+      notify({
+        type: "match",
+        title: "Tournament Joined",
+        message: `You've joined ${tournament.name}. We'll notify you when your match is ready.`,
+        link: `/tournaments/${tournament.id}`,
+        linkLabel: "View Tournament",
+        persistent: true,
+        toast: true,
+        toastDuration: 5000,
+      });
 
-    notify({
-      type: "match",
-      title: "Tournament Joined",
-      message: `You've joined ${tournament.name}. We'll notify you when your match is ready.`,
-      link: `/tournaments/${tournament.id}`,
-      linkLabel: "View Tournament",
-      persistent: true,
-      toast: true,
-      toastDuration: 5000,
-    });
-
-    // Auto-close after 2 seconds
-    setTimeout(() => {
-      setShowModal(false);
-      setJoinStatus("idle");
-    }, 2000);
+      setTimeout(() => {
+        setShowModal(false);
+        setJoinStatus("idle");
+      }, 2000);
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Unable to join tournament. Please try again.";
+      setErrorMessage(message);
+      setJoinStatus("error");
+    }
   };
 
   const handleLoginRedirect = () => {
@@ -276,6 +291,13 @@ export function JoinTournamentButton({
                 </>
               )}
 
+              {joinStatus === "error" && (
+                <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-900 dark:border-red-900 dark:bg-red-950/20 dark:text-red-100">
+                  <p className="font-semibold">Unable to join tournament</p>
+                  <p className="mt-2">{errorMessage}</p>
+                </div>
+              )}
+
               {/* Success State */}
               {joinStatus === "success" && (
                 <>
@@ -341,6 +363,21 @@ export function JoinTournamentButton({
                   </Button>
                   <Button onClick={handleConfirmJoin} className="flex-1">
                     Confirm Join
+                  </Button>
+                </>
+              )}
+
+              {joinStatus === "error" && localStorage.getItem("auth_token") && (
+                <>
+                  <Button
+                    variant="secondary"
+                    onClick={() => setShowModal(false)}
+                    className="flex-1"
+                  >
+                    Close
+                  </Button>
+                  <Button onClick={handleConfirmJoin} className="flex-1">
+                    Retry
                   </Button>
                 </>
               )}

--- a/frontend/src/components/tournaments/RegistrationForm.tsx
+++ b/frontend/src/components/tournaments/RegistrationForm.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/Button";
 import { Input } from "@/components/ui/Input";
 import { CheckCircle, AlertCircle, Loader2 } from "lucide-react";
 import { useNotifications } from "@/contexts/NotificationContext";
+import { api } from "@/lib/api";
 
 interface RegistrationFormProps {
   tournament: Tournament;
@@ -30,6 +31,7 @@ export function RegistrationForm({ tournament, onSuccess, onCancel }: Registrati
   });
   const [errors, setErrors] = useState<Partial<FormState & { submit: string }>>({});
   const [status, setStatus] = useState<"idle" | "submitting" | "success">("idle");
+  const [submitError, setSubmitError] = useState<string | null>(null);
 
   const validate = (): boolean => {
     const next: typeof errors = {};
@@ -43,25 +45,35 @@ export function RegistrationForm({ tournament, onSuccess, onCancel }: Registrati
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    setSubmitError(null);
     if (!validate()) return;
 
     setStatus("submitting");
-    // Simulate API call
-    await new Promise((r) => setTimeout(r, 1500));
-    setStatus("success");
 
-    notify({
-      type: "match",
-      title: "Registration Confirmed",
-      message: `You're registered for ${tournament.name}. Check your email for details.`,
-      link: `/tournaments/${tournament.id}`,
-      linkLabel: "View Tournament",
-      persistent: true,
-      toast: true,
-      toastDuration: 6000,
-    });
+    try {
+      await api.joinTournament(tournament.id);
+      setStatus("success");
 
-    onSuccess?.();
+      notify({
+        type: "match",
+        title: "Registration Confirmed",
+        message: `You're registered for ${tournament.name}. Check your email for details.`,
+        link: `/tournaments/${tournament.id}`,
+        linkLabel: "View Tournament",
+        persistent: true,
+        toast: true,
+        toastDuration: 6000,
+      });
+
+      onSuccess?.();
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Unable to complete registration. Please try again.";
+      setSubmitError(message);
+      setStatus("idle");
+    }
   };
 
   if (status === "success") {
@@ -160,6 +172,13 @@ export function RegistrationForm({ tournament, onSuccess, onCancel }: Registrati
           />
         </div>
       </div>
+
+      {submitError ? (
+        <div className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-900 dark:border-red-900 dark:bg-red-950/20 dark:text-red-100">
+          <p className="font-semibold">Registration failed</p>
+          <p className="mt-1">{submitError}</p>
+        </div>
+      ) : null}
 
       {/* Rules agreement */}
       <label className="flex cursor-pointer items-start gap-3">

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -98,7 +98,7 @@ class ApiClient {
   }
 
   async joinTournament(id: string) {
-    return this.request(`/tournaments/${id}/join`, {
+    return this.request(`/tournaments/${id}/register`, {
       method: "POST",
     });
   }


### PR DESCRIPTION
closes #321 

## PR Documentation

### Summary
Fixed the tournament join flow and registration flow for ArenaX frontend so it uses real backend data and registration API calls instead of mock timers and hardcoded tournament lookup.

### What changed

- api.ts
  - Updated `joinTournament` to call `/tournaments/:id/register` instead of a fake `/join` endpoint.

- JoinTournamentButton.tsx
  - Replaced fake `setTimeout` join simulation with `api.joinTournament(...)`.
  - Added API error handling and retry state.
  - Persisted joined status in `localStorage` so the UI survives navigation.
  - Fixed modal flow for authenticated users so confirm button appears correctly.

- page.tsx
  - Replaced mock tournament lookup with real backend fetch using `params.id`.
  - Added loading and error states for tournament detail page.
  - Kept bracket and details rendering once the API response arrives.

- page.tsx
  - Replaced mock tournament lookup with real backend fetch using `params.id`.
  - Added loading and error states for the registration page.

- RegistrationForm.tsx
  - Replaced fake form submit delay with real `api.joinTournament(...)`.
  - Added submit-error feedback.

- join-tournament-button.test.tsx
  - Added tests for:
    - unauthenticated join prompt
    - authenticated join success and persistence
    - API failure error handling

### Acceptance criteria addressed

- Tournament data now resolves by `params.id` on both details and registration pages.
- Join flow now performs a real API call to backend registration.
- Join status is persisted in browser storage.
- Loading/error states added for page fetches.
- Fake payment/join timeout removed from join flow.

### Notes
- Test file added, but local Jest execution could not be run in this workspace because `frontend/node_modules` is not installed.