### PR TITLE
fix: type-safe narrowing of params.id (string | string[]) in App Router pages

### DIFF
--- a/frontend/src/__tests__/match-hub-params.test.tsx
+++ b/frontend/src/__tests__/match-hub-params.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * Tests for params.id type-safe narrowing in the matches/[id] page.
+ * Verifies correct behaviour when params.id is a string and when it
+ * is a string array (Next.js App Router can provide either).
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+let mockUseParams = jest.fn(() => ({ id: 'unknown' }));
+const mockPush = jest.fn();
+const mockBack = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useParams: () => mockUseParams(),
+  useRouter: () => ({ push: mockPush, back: mockBack }),
+}));
+
+jest.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({ user: { id: 'user-123', username: 'TestUser' } }),
+}));
+
+jest.mock('@/hooks/useMatchWebSocket', () => ({
+  useMatchWebSocket: () => ({
+    isConnected: false,
+    lastUpdate: null,
+    connectionError: null,
+    reconnect: jest.fn(),
+  }),
+  useMatchScoreReporting: () => ({
+    reportScore: jest.fn(),
+    pendingReport: null,
+    isReporting: false,
+    conflictDetected: false,
+    conflictingReport: null,
+    clearConflict: jest.fn(),
+  }),
+}));
+
+import MatchHubPage from '@/app/matches/[id]/page';
+
+describe('MatchHubPage — params.id narrowing', () => {
+  beforeEach(() => {
+    mockPush.mockReset();
+    mockBack.mockReset();
+  });
+
+  it('shows "Match Not Found" for an unknown string id', () => {
+    mockUseParams = jest.fn(() => ({ id: 'definitely-not-real' }));
+    render(<MatchHubPage />);
+    expect(screen.getByText('Match Not Found')).toBeInTheDocument();
+  });
+
+  it('renders the match hub for a known string id', () => {
+    mockUseParams = jest.fn(() => ({ id: '1-match-13' }));
+    render(<MatchHubPage />);
+    expect(screen.getByText('Match Hub')).toBeInTheDocument();
+  });
+
+  it('handles params.id as a string array by using the first element', () => {
+    mockUseParams = jest.fn(() => ({ id: ['1-match-13', 'extra'] }));
+    render(<MatchHubPage />);
+    expect(screen.getByText('Match Hub')).toBeInTheDocument();
+  });
+
+  it('shows "Match Not Found" when params.id array contains an unknown id', () => {
+    mockUseParams = jest.fn(() => ({ id: ['definitely-not-real'] }));
+    render(<MatchHubPage />);
+    expect(screen.getByText('Match Not Found')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/tournament-results-page.test.tsx
+++ b/frontend/src/__tests__/tournament-results-page.test.tsx
@@ -49,13 +49,23 @@ describe('TournamentResultsPage (#324)', () => {
   });
 
   it('surfaces a link back to the live detail page even in the pending state', () => {
-    // Acceptance: "Page handles the case where results are not yet
-    // available". The detail-page link should be reachable from the
-    // pending state so users have a clear next step.
     mockUseParams = jest.fn(() => ({ id: '1' }));
     render(<TournamentResultsPage />);
     expect(
       screen.getByRole('link', { name: 'Tournament details' })
     ).toBeInTheDocument();
+  });
+
+  it('handles params.id as a string array by using the first element', () => {
+    // When Next.js provides params.id as string[], the first element is used.
+    mockUseParams = jest.fn(() => ({ id: ['1', 'extra'] }));
+    render(<TournamentResultsPage />);
+    expect(screen.getByTestId('results-pending')).toBeInTheDocument();
+  });
+
+  it('shows "Tournament Not Found" when params.id array contains an unknown id', () => {
+    mockUseParams = jest.fn(() => ({ id: ['definitely-not-real'] }));
+    render(<TournamentResultsPage />);
+    expect(screen.getByText('Tournament Not Found')).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/matches/[id]/page.tsx
+++ b/frontend/src/app/matches/[id]/page.tsx
@@ -31,7 +31,7 @@ export default function MatchHubPage() {
   const params = useParams();
   const router = useRouter();
   const { user } = useAuth();
-  const matchId = params.id as string;
+  const matchId = Array.isArray(params.id) ? params.id[0] : params.id;
   const currentUserId = user?.id ?? "user-123";
 
   const [match, setMatch] = useState(matchHubDetails[matchId] ?? null);

--- a/frontend/src/app/tournaments/[id]/bracket/page.tsx
+++ b/frontend/src/app/tournaments/[id]/bracket/page.tsx
@@ -14,7 +14,7 @@ export default function TournamentBracketPage() {
   const params = useParams();
   const router = useRouter();
   const { user } = useAuth();
-  const tournamentId = params.id as string;
+  const tournamentId = Array.isArray(params.id) ? params.id[0] : params.id;
   const currentUserId = user?.id ?? "user-123";
 
   const tournament = useMemo(

--- a/frontend/src/app/tournaments/[id]/page.tsx
+++ b/frontend/src/app/tournaments/[id]/page.tsx
@@ -22,7 +22,7 @@ export default function TournamentDetailsPage() {
   // #320: read the dynamic [id] route param and look up the tournament
   // by id. Unknown ids fall through to the "Tournament Not Found"
   // branch below rather than rendering a hardcoded fallback.
-  const tournamentId = params.id as string;
+  const tournamentId = Array.isArray(params.id) ? params.id[0] : params.id;
   const currentUserId = user?.id ?? "user-123";
   const [tournament, setTournament] = useState<any | null>(null);
   const [isLoading, setIsLoading] = useState(true);

--- a/frontend/src/app/tournaments/[id]/register/page.tsx
+++ b/frontend/src/app/tournaments/[id]/register/page.tsx
@@ -10,7 +10,7 @@ import { api } from "@/lib/api";
 export default function TournamentRegisterPage() {
   const params = useParams();
   const router = useRouter();
-  const tournamentId = params.id as string;
+  const tournamentId = Array.isArray(params.id) ? params.id[0] : params.id;
   const [tournament, setTournament] = useState<any | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [fetchError, setFetchError] = useState<string | null>(null);

--- a/frontend/src/app/tournaments/[id]/results/page.tsx
+++ b/frontend/src/app/tournaments/[id]/results/page.tsx
@@ -69,7 +69,7 @@ export default function TournamentResultsPage() {
   const params = useParams();
   const router = useRouter();
   const { user } = useAuth();
-  const tournamentId = params.id as string;
+  const tournamentId = Array.isArray(params.id) ? params.id[0] : params.id;
   const currentUserId = user?.id ?? "user-123";
 
   const tournament = useMemo(


### PR DESCRIPTION
## Summary

Fixes #368

All five Next.js App Router dynamic `[id]` pages were using `params.id as string` — a type assertion that silences TypeScript without actually handling the `string | string[]` union that `useParams()` returns. If Next.js ever provides the param as an array (e.g. catch-all routes, middleware rewrites), the assertion would silently pass a `string[]` where a `string` is expected, causing runtime failures.

## Changes

### Pages fixed
| File | Before | After |
|------|--------|-------|
| `tournaments/[id]/page.tsx` | `params.id as string` | `Array.isArray(params.id) ? params.id[0] : params.id` |
| `tournaments/[id]/bracket/page.tsx` | `params.id as string` | `Array.isArray(params.id) ? params.id[0] : params.id` |
| `tournaments/[id]/register/page.tsx` | `params.id as string` | `Array.isArray(params.id) ? params.id[0] : params.id` |
| `tournaments/[id]/results/page.tsx` | `params.id as string` | `Array.isArray(params.id) ? params.id[0] : params.id` |
| `matches/[id]/page.tsx` | `params.id as string` | `Array.isArray(params.id) ? params.id[0] : params.id` |

### Why this approach
- `Array.isArray` is a proper TypeScript type guard — after the check, both branches are narrowed to `string`, so no `as` cast is needed anywhere downstream.
- Behaviour is identical to the previous code when `params.id` is already a `string` (the normal App Router case).
- When `params.id` is a `string[]`, the first element is used — consistent with how Next.js constructs catch-all segments.
- No fallback default (e.g. `|| 'efb001'`) is introduced; existing not-found handling in each page covers the `undefined`/unmatched case.

## Tests

### Updated: `tournament-results-page.test.tsx`
Added two new cases on top of the existing three:
- `params.id` as `string[]` with a known id → renders correctly (uses first element)
- `params.id` as `string[]` with an unknown id → renders "Tournament Not Found"

### New: `match-hub-params.test.tsx`
Four tests covering the full matrix:
- `string` known id → renders match hub
- `string` unknown id → renders "Match Not Found"
- `string[]` known id → renders match hub (first element used)
- `string[]` unknown id → renders "Match Not Found"

All 9 new/updated tests pass. No existing tests were broken.

## Checklist
- [x] No `as string` type assertions on `params.id` remain in any App Router page
- [x] TypeScript narrowing is correct — no weakened type safety
- [x] Runtime behaviour is unchanged for the normal `string` case
- [x] Tests cover both `string` and `string[]` inputs
- [x] No new lint or type errors introduced