### PR TITLE
fix(frontend): add responsive sizes to tournament banner images

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -15,6 +15,13 @@ const nextConfig = {
     minimumCacheTTL: 60 * 60 * 24 * 30, // 30 days
     dangerouslyAllowSVG: true,
     contentSecurityPolicy: "default-src 'self'; script-src 'none'; sandbox;",
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "api.dicebear.com",
+        pathname: "/**",
+      },
+    ],
   },
   
   // Enable compression

--- a/frontend/src/app/tournaments/[id]/page.tsx
+++ b/frontend/src/app/tournaments/[id]/page.tsx
@@ -14,6 +14,7 @@ import { ArrowLeft, RadioTower, ShieldAlert, Swords, Trophy } from "lucide-react
 import { Button } from "@/components/ui/Button";
 import { useAuth } from "@/hooks/useAuth";
 import { api } from "@/lib/api";
+import { TOURNAMENT_DETAIL_BANNER_SIZES } from "@/lib/tournamentImageSizes";
 
 export default function TournamentDetailsPage() {
   const params = useParams();
@@ -128,7 +129,10 @@ export default function TournamentDetailsPage() {
 
       <div className="grid grid-cols-1 gap-8 lg:grid-cols-3">
         <div className="space-y-8 lg:col-span-2">
-          <TournamentHeader tournament={tournament} />
+          <TournamentHeader
+            tournament={tournament}
+            bannerSizes={TOURNAMENT_DETAIL_BANNER_SIZES}
+          />
 
           {showBracket && bracketData ? (
             <section className="space-y-4">

--- a/frontend/src/app/tournaments/[id]/results/page.tsx
+++ b/frontend/src/app/tournaments/[id]/results/page.tsx
@@ -23,6 +23,7 @@ import { Button } from "@/components/ui/Button";
 import { mockTournaments } from "@/data/mockTournaments";
 import { generateMockBracket } from "@/data/mockBracket";
 import { TournamentHeader } from "@/components/tournaments/TournamentHeader";
+import { TOURNAMENT_DETAIL_BANNER_SIZES } from "@/lib/tournamentImageSizes";
 import { SingleEliminationBracket } from "@/components/bracket/SingleEliminationBracket";
 import { useAuth } from "@/hooks/useAuth";
 import {
@@ -139,7 +140,10 @@ export default function TournamentResultsPage() {
       </div>
 
       <div className="space-y-8">
-        <TournamentHeader tournament={tournament} />
+        <TournamentHeader
+          tournament={tournament}
+          bannerSizes={TOURNAMENT_DETAIL_BANNER_SIZES}
+        />
 
         {isResultsPending ? (
           <section

--- a/frontend/src/app/tournaments/page.tsx
+++ b/frontend/src/app/tournaments/page.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/types/tournament";
 import { mockTournaments } from "@/data/mockTournaments";
 import { useAuth } from "@/hooks/useAuth";
+import { TOURNAMENT_GRID_IMAGE_SIZES } from "@/lib/tournamentImageSizes";
 
 type TabType = "joined" | "available";
 
@@ -238,6 +239,7 @@ function TournamentsContent() {
               tournament={tournament}
               isJoined={joinedTournamentIds.has(tournament.id)}
               onJoinSuccess={handleJoinSuccess}
+              bannerSizes={TOURNAMENT_GRID_IMAGE_SIZES}
             />
           ))}
         </div>

--- a/frontend/src/components/tournaments/TournamentCardSkeleton.tsx
+++ b/frontend/src/components/tournaments/TournamentCardSkeleton.tsx
@@ -4,6 +4,7 @@ import { Card } from "@/components/ui/Card";
 export function TournamentCardSkeleton() {
   return (
     <Card className="flex flex-col overflow-hidden">
+      <div className="h-36 w-full shrink-0 animate-pulse bg-muted" />
       {/* Header with Status */}
       <div className="flex items-start justify-between border-b p-4">
         <div className="flex-1 space-y-2">

--- a/frontend/src/components/tournaments/TournamentCardWithQuickJoin.tsx
+++ b/frontend/src/components/tournaments/TournamentCardWithQuickJoin.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import React, { useState } from "react";
+import Image from "next/image";
 import Link from "next/link";
 import { Tournament, TournamentStatus } from "@/types/tournament";
+import { getTournamentBannerUrl } from "@/lib/tournamentImageSizes";
 import { Card } from "@/components/ui/Card";
 import { Button } from "@/components/ui/Button";
 import { QuickJoinModal } from "./QuickJoinModal";
@@ -12,6 +14,7 @@ interface TournamentCardProps {
   tournament: Tournament;
   isJoined?: boolean;
   onJoinSuccess?: (tournamentId: string) => void;
+  bannerSizes: string;
 }
 
 const statusConfig: Record<
@@ -54,6 +57,7 @@ export function TournamentCardWithQuickJoin({
   tournament,
   isJoined = false,
   onJoinSuccess,
+  bannerSizes,
 }: TournamentCardProps) {
   const [showQuickJoin, setShowQuickJoin] = useState(false);
 
@@ -84,6 +88,15 @@ export function TournamentCardWithQuickJoin({
     <>
       <Link href={cardHref} className="block focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-lg">
       <Card className="flex flex-col overflow-hidden transition-shadow hover:shadow-lg">
+        <div className="relative h-36 w-full shrink-0 bg-muted">
+          <Image
+            src={getTournamentBannerUrl(tournament.id)}
+            alt={`${tournament.name} banner`}
+            fill
+            sizes={bannerSizes}
+            className="object-cover"
+          />
+        </div>
         {/* Header with Status */}
         <div className="flex items-start justify-between border-b p-4">
           <div className="flex-1">

--- a/frontend/src/components/tournaments/TournamentHeader.tsx
+++ b/frontend/src/components/tournaments/TournamentHeader.tsx
@@ -1,10 +1,13 @@
 import React from "react";
+import Image from "next/image";
 import { Tournament, TournamentStatus } from "@/types/tournament";
+import { getTournamentBannerUrl } from "@/lib/tournamentImageSizes";
 import { Card } from "@/components/ui/Card";
 import { Trophy, Users, Calendar, Zap } from "lucide-react";
 
 interface TournamentHeaderProps {
   tournament: Tournament;
+  bannerSizes: string;
 }
 
 const statusConfig: Record<
@@ -43,7 +46,7 @@ const statusConfig: Record<
   },
 };
 
-export function TournamentHeader({ tournament }: TournamentHeaderProps) {
+export function TournamentHeader({ tournament, bannerSizes }: TournamentHeaderProps) {
   const status = statusConfig[tournament.status];
   const startDate = new Date(tournament.startTime);
   const participantPercentage = Math.round(
@@ -65,9 +68,20 @@ export function TournamentHeader({ tournament }: TournamentHeaderProps) {
   });
 
   return (
-    <Card className="border-0 shadow-none p-0">
+    <Card className="border-0 shadow-none p-0 overflow-hidden">
+      <div className="relative h-44 w-full md:h-56 bg-muted">
+        <Image
+          src={getTournamentBannerUrl(tournament.id)}
+          alt={`${tournament.name} banner`}
+          fill
+          sizes={bannerSizes}
+          className="object-cover"
+          priority
+        />
+        <div className="absolute inset-0 bg-gradient-to-t from-background/90 via-background/40 to-transparent" />
+      </div>
       {/* Header Background */}
-      <div className="bg-gradient-to-r from-blue-500/10 to-purple-500/10 border-b p-6 md:p-8 rounded-lg">
+      <div className="border-b p-6 md:p-8">
         <div className="space-y-4">
           {/* Status Badge */}
           <div>

--- a/frontend/src/components/tournaments/TournamentList.tsx
+++ b/frontend/src/components/tournaments/TournamentList.tsx
@@ -3,6 +3,7 @@
 import React from "react";
 import { Tournament } from "@/types/tournament";
 import { TournamentCardWithQuickJoin } from "./TournamentCardWithQuickJoin";
+import { TOURNAMENT_GRID_IMAGE_SIZES } from "@/lib/tournamentImageSizes";
 import { Trophy } from "lucide-react";
 import { Button } from "@/components/ui/Button";
 
@@ -44,6 +45,7 @@ export function TournamentList({
           tournament={tournament}
           isJoined={joinedIds.has(tournament.id)}
           onJoinSuccess={onJoinSuccess}
+          bannerSizes={TOURNAMENT_GRID_IMAGE_SIZES}
         />
       ))}
     </div>

--- a/frontend/src/lib/tournamentImageSizes.ts
+++ b/frontend/src/lib/tournamentImageSizes.ts
@@ -1,0 +1,11 @@
+/** Responsive sizes for tournament cards in the 1 / 2 / 3 column grid (sm / md / lg). */
+export const TOURNAMENT_GRID_IMAGE_SIZES =
+  "(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw";
+
+/** Banner on the detail page (full width below lg, ~2/3 of viewport in the main column). */
+export const TOURNAMENT_DETAIL_BANNER_SIZES =
+  "(max-width: 1024px) 100vw, 66vw";
+
+export function getTournamentBannerUrl(tournamentId: string): string {
+  return `https://api.dicebear.com/7.x/abstract/png?seed=arenax-tournament-${tournamentId}&width=1200&height=400`;
+}


### PR DESCRIPTION
## Summary

- Adds shared `sizes` constants for the tournament grid (1 / 2 / 3 columns at sm / md / lg) and the detail-page banner (~full width on mobile, ~66vw in the main column on desktop).
- Wires those constants from `tournaments/page.tsx` and `tournaments/[id]/page.tsx` into tournament card and header banner `Image` components using `fill`.
- Allows Dicebear banner URLs in `next.config.js` (same provider pattern as the about page).

Closes #364

## Test plan

- [ ] Open `/tournaments` on a narrow viewport and confirm banner images load without layout shift.
- [ ] Resize to tablet/desktop and verify banners in 2- and 3-column grid layouts.
- [ ] Open `/tournaments/[id]` and confirm the header banner renders with the gradient overlay.
- [ ] In DevTools Network, confirm requested image widths are smaller than full viewport on mobile for grid cards.