### PR TITLE
fix(frontend): type tournament page status without keyof casts

### DIFF
--- a/frontend/src/app/tournaments/page.tsx
+++ b/frontend/src/app/tournaments/page.tsx
@@ -12,11 +12,21 @@ import {
   TournamentStatus,
   Tournament,
   TournamentFilters,
+  TournamentPageStatus,
+  TOURNAMENT_PAGE_STATUS_COLORS,
+  TOURNAMENT_PAGE_STATUSES,
+  toTournamentPageStatus,
 } from "@/types/tournament";
 import { mockTournaments } from "@/data/mockTournaments";
 import { useAuth } from "@/hooks/useAuth";
 
 type TabType = "joined" | "available";
+
+const statusColors = TOURNAMENT_PAGE_STATUS_COLORS;
+
+function getStatusStyles(pageStatus: TournamentPageStatus) {
+  return statusColors[pageStatus];
+}
 
 function TournamentsContent() {
   const { user } = useAuth();
@@ -88,6 +98,13 @@ function TournamentsContent() {
     if (filters.status) {
       tournaments = tournaments.filter(
         (tournament) => tournament.status === filters.status,
+      );
+    }
+
+    if (filters.pageStatus) {
+      tournaments = tournaments.filter(
+        (tournament) =>
+          toTournamentPageStatus(tournament.status) === filters.pageStatus,
       );
     }
 
@@ -216,12 +233,25 @@ function TournamentsContent() {
         />
       </div>
 
-      <div className="flex items-center justify-between mb-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between mb-4">
         <p className="text-sm text-muted-foreground">
           {filteredTournaments.length} tournament
           {filteredTournaments.length !== 1 ? "s" : ""} found
           {activeTab === "joined" ? " (joined)" : " (available)"}
         </p>
+        <div className="flex flex-wrap gap-2" aria-label="Tournament status legend">
+          {TOURNAMENT_PAGE_STATUSES.map((pageStatus) => {
+            const { badgeClass, label } = getStatusStyles(pageStatus);
+            return (
+              <span
+                key={pageStatus}
+                className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${badgeClass}`}
+              >
+                {label}
+              </span>
+            );
+          })}
+        </div>
       </div>
 
       {isLoading ? (

--- a/frontend/src/types/tournament.ts
+++ b/frontend/src/types/tournament.ts
@@ -26,6 +26,50 @@ export type TournamentStatus =
   | 'completed'
   | 'cancelled';
 
+/** Simplified status buckets for the tournaments list UI (badges, colors, filters). */
+export type TournamentPageStatus = 'ongoing' | 'upcoming' | 'completed';
+
+export const TOURNAMENT_PAGE_STATUSES: TournamentPageStatus[] = [
+  'ongoing',
+  'upcoming',
+  'completed',
+];
+
+export const TOURNAMENT_PAGE_STATUS_COLORS: Record<
+  TournamentPageStatus,
+  { badgeClass: string; label: string }
+> = {
+  ongoing: {
+    badgeClass:
+      'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-200',
+    label: 'Ongoing',
+  },
+  upcoming: {
+    badgeClass:
+      'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-200',
+    label: 'Upcoming',
+  },
+  completed: {
+    badgeClass:
+      'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-200',
+    label: 'Completed',
+  },
+};
+
+export function toTournamentPageStatus(status: TournamentStatus): TournamentPageStatus {
+  if (status === 'in_progress') {
+    return 'ongoing';
+  }
+  if (status === 'completed' || status === 'cancelled') {
+    return 'completed';
+  }
+  return 'upcoming';
+}
+
+export function isTournamentPageStatus(value: string): value is TournamentPageStatus {
+  return (TOURNAMENT_PAGE_STATUSES as readonly string[]).includes(value);
+}
+
 export type TournamentVisibility =
   | 'public'
   | 'private'
@@ -51,6 +95,8 @@ export interface CreateTournamentRequest {
 export interface TournamentFilters {
   gameType?: string;
   status?: TournamentStatus;
+  /** Filter by simplified list status (ongoing / upcoming / completed). */
+  pageStatus?: TournamentPageStatus;
   visibility?: TournamentVisibility;
   tournamentType?: TournamentType;
   minEntryFee?: number;


### PR DESCRIPTION
## Summary

- Introduces `TournamentPageStatus` (`ongoing` | `upcoming` | `completed`) and a typed `TOURNAMENT_PAGE_STATUS_COLORS` map.
- Adds `toTournamentPageStatus()` to map API `TournamentStatus` values into page buckets.
- Updates the tournaments page to use typed status colors and filtering without `as keyof typeof` casts.

Closes #367

## Test plan

- [ ] Open `/tournaments` and confirm the status legend renders (Ongoing, Upcoming, Completed).
- [ ] Confirm tournament cards still show correct detailed status labels.
- [ ] Run `npm run build` in `frontend` and verify no type errors on status color lookup.
- [ ] (Optional) In TS, confirm `statusColors["invalid"]` is rejected by the compiler.