### PR TITLE
Fix: Loading, Error & Empty States Across All Data-Driven Pages

### DIFF
--- a/frontend/src/app/admin/disputes/page.tsx
+++ b/frontend/src/app/admin/disputes/page.tsx
@@ -1,29 +1,37 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useCallback } from "react";
 import { api } from "@/lib/api";
 import { ProtectedPage } from "@/components/navigation/ProtectedPage";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/Card";
 import { Button } from "@/components/ui/Button";
+import { PageError } from "@/components/common/PageError";
+import { ListItemSkeleton, PageHeaderSkeleton } from "@/components/common/PageSkeleton";
+import { ShieldAlert } from "lucide-react";
+import { EmptyState } from "@/components/common/EmptyState";
 
 export default function DisputeDashboard() {
   const [disputes, setDisputes] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    fetchDisputes();
-  }, []);
-
-  const fetchDisputes = async () => {
+  const fetchDisputes = useCallback(async () => {
+    setLoading(true);
+    setError(null);
     try {
       const data = await api.getDisputes();
       setDisputes(data as any[]);
-    } catch (error) {
-      console.error("Failed to fetch disputes:", error);
+    } catch (err) {
+      console.error("Failed to fetch disputes:", err);
+      setError((err as Error).message ?? "Failed to load disputes.");
     } finally {
       setLoading(false);
     }
-  };
+  }, []);
+
+  useEffect(() => {
+    fetchDisputes();
+  }, [fetchDisputes]);
 
   const handleResolve = async (id: string, status: "RESOLVED" | "DISMISSED", winnerOverrideId?: string) => {
     try {
@@ -32,13 +40,40 @@ export default function DisputeDashboard() {
         resolution: status === "RESOLVED" ? "Admin override applied" : "Dispute dismissed",
         winnerOverrideId,
       });
-      fetchDisputes(); // Refresh list
-    } catch (error) {
-      alert("Failed to resolve dispute: " + (error as Error).message);
+      fetchDisputes();
+    } catch (err) {
+      alert("Failed to resolve dispute: " + (err as Error).message);
     }
   };
 
-  if (loading) return <div className="p-8 text-center text-xl font-medium">Loading disputes...</div>;
+  if (loading) {
+    return (
+      <ProtectedPage requiredRole="admin">
+        <div className="container mx-auto p-6 space-y-8">
+          <PageHeaderSkeleton />
+          <div className="grid gap-6">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <ListItemSkeleton key={i} />
+            ))}
+          </div>
+        </div>
+      </ProtectedPage>
+    );
+  }
+
+  if (error) {
+    return (
+      <ProtectedPage requiredRole="admin">
+        <div className="container mx-auto p-6">
+          <PageError
+            title="Failed to load disputes"
+            message={error}
+            onRetry={fetchDisputes}
+          />
+        </div>
+      </ProtectedPage>
+    );
+  }
 
   return (
     <ProtectedPage requiredRole="admin">
@@ -54,11 +89,12 @@ export default function DisputeDashboard() {
 
       <div className="grid gap-6">
         {disputes.length === 0 ? (
-          <Card className="bg-muted/50 border-dashed border-2">
-            <CardContent className="flex flex-col items-center justify-center h-40 text-muted-foreground">
-              <p>No open disputes at this time.</p>
-            </CardContent>
-          </Card>
+          <EmptyState
+            icon={ShieldAlert}
+            title="No open disputes"
+            description="There are no disputes requiring review at this time."
+            size="lg"
+          />
         ) : (
           disputes.map((dispute) => (
             <Card key={dispute.id} className="overflow-hidden border-2 border-indigo-100 dark:border-indigo-900 shadow-lg hover:shadow-xl transition-shadow duration-300">

--- a/frontend/src/app/admin/error.tsx
+++ b/frontend/src/app/admin/error.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useEffect } from "react";
+import { PageError } from "@/components/common/PageError";
+
+export default function AdminError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("[AdminPage]", error);
+  }, [error]);
+
+  return (
+    <div className="container mx-auto p-6 flex min-h-[60vh] items-center justify-center">
+      <PageError
+        title="Admin panel error"
+        message="Something went wrong loading this admin page. Try again or contact support if the problem persists."
+        onRetry={reset}
+      />
+    </div>
+  );
+}

--- a/frontend/src/app/admin/governance/page.tsx
+++ b/frontend/src/app/admin/governance/page.tsx
@@ -1,29 +1,37 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useCallback } from "react";
 import { api } from "@/lib/api";
 import { ProtectedPage } from "@/components/navigation/ProtectedPage";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle, CardFooter } from "@/components/ui/Card";
 import { Button } from "@/components/ui/Button";
+import { PageError } from "@/components/common/PageError";
+import { CardSkeleton, PageHeaderSkeleton } from "@/components/common/PageSkeleton";
+import { EmptyState } from "@/components/common/EmptyState";
+import { FileText } from "lucide-react";
 
 export default function GovernanceDashboard() {
   const [proposals, setProposals] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    fetchProposals();
-  }, []);
-
-  const fetchProposals = async () => {
+  const fetchProposals = useCallback(async () => {
+    setLoading(true);
+    setError(null);
     try {
       const data = await api.getProposals();
       setProposals(data);
-    } catch (error) {
-      console.error("Failed to fetch proposals:", error);
+    } catch (err) {
+      console.error("Failed to fetch proposals:", err);
+      setError((err as Error).message ?? "Failed to load proposals.");
     } finally {
       setLoading(false);
     }
-  };
+  }, []);
+
+  useEffect(() => {
+    fetchProposals();
+  }, [fetchProposals]);
 
   const handleStartVoting = async (id: string) => {
     await api.startVoting(id);
@@ -40,7 +48,38 @@ export default function GovernanceDashboard() {
     fetchProposals();
   };
 
-  if (loading) return <div className="p-8 text-center text-xl font-medium">Loading proposals...</div>;
+  // ── Loading skeleton ──────────────────────────────────────────────────────
+  if (loading) {
+    return (
+      <ProtectedPage requiredRole="admin">
+        <div className="container mx-auto p-6 space-y-8">
+          <div className="flex items-center justify-between">
+            <PageHeaderSkeleton />
+          </div>
+          <div className="grid md:grid-cols-2 gap-6">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <CardSkeleton key={i} lines={4} hasFooter />
+            ))}
+          </div>
+        </div>
+      </ProtectedPage>
+    );
+  }
+
+  // ── Error state ───────────────────────────────────────────────────────────
+  if (error) {
+    return (
+      <ProtectedPage requiredRole="admin">
+        <div className="container mx-auto p-6">
+          <PageError
+            title="Failed to load proposals"
+            message={error}
+            onRetry={fetchProposals}
+          />
+        </div>
+      </ProtectedPage>
+    );
+  }
 
   return (
     <ProtectedPage requiredRole="admin">
@@ -61,9 +100,14 @@ export default function GovernanceDashboard() {
 
       <div className="grid md:grid-cols-2 gap-6">
         {proposals.length === 0 ? (
-           <div className="col-span-full py-20 text-center text-muted-foreground border-2 border-dashed rounded-xl">
-             No proposals found.
-           </div>
+          <div className="col-span-full">
+            <EmptyState
+              icon={FileText}
+              title="No proposals found"
+              description="There are no governance proposals yet. Create one to get started."
+              size="lg"
+            />
+          </div>
         ) : (
           proposals.map((proposal) => (
             <Card key={proposal.id} className="group border-2 hover:border-indigo-400 dark:hover:border-indigo-600 transition-all duration-300 shadow-sm hover:shadow-xl">

--- a/frontend/src/app/admin/kyc/page.tsx
+++ b/frontend/src/app/admin/kyc/page.tsx
@@ -7,6 +7,10 @@ import { ProtectedPage } from "@/components/navigation/ProtectedPage";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/Card";
 import { Button } from "@/components/ui/Button";
 import { Input } from "@/components/ui/Input";
+import { PageError } from "@/components/common/PageError";
+import { ListItemSkeleton, PageHeaderSkeleton, Skeleton } from "@/components/common/PageSkeleton";
+import { EmptyState } from "@/components/common/EmptyState";
+import { FileText } from "lucide-react";
 
 type KycStatus = "PENDING" | "APPROVED" | "REJECTED" | "ESCALATED";
 
@@ -26,6 +30,7 @@ interface KycReview {
 export default function KycDashboard() {
   const [reviews, setReviews] = useState<KycReview[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [filterStatus, setFilterStatus] = useState<KycStatus | "ALL">("ALL");
   const [selectedReview, setSelectedReview] = useState<KycReview | null>(null);
   const [decisionNotes, setDecisionNotes] = useState("");
@@ -33,12 +38,14 @@ export default function KycDashboard() {
 
   const fetchReviews = useCallback(async () => {
     setLoading(true);
+    setError(null);
     try {
       const params = filterStatus !== "ALL" ? { status: filterStatus } : {};
       const data = await api.getKycReviews(params);
       setReviews((data as any).reviews || []);
-    } catch (error) {
-      console.error("Failed to fetch KYC reviews:", error);
+    } catch (err) {
+      console.error("Failed to fetch KYC reviews:", err);
+      setError((err as Error).message ?? "Failed to load KYC reviews.");
     } finally {
       setLoading(false);
     }
@@ -55,8 +62,6 @@ export default function KycDashboard() {
     }
 
     setIsSubmitting(true);
-    
-    // Optimistic Update
     const previousReviews = [...reviews];
     setReviews(reviews.map((r: KycReview) => r.id === id ? { ...r, status } : r));
     if (selectedReview?.id === id) {
@@ -64,25 +69,70 @@ export default function KycDashboard() {
     }
 
     try {
-      await api.processKycReview(id, {
-        status,
-        notes: decisionNotes,
-      });
+      await api.processKycReview(id, { status, notes: decisionNotes });
       setDecisionNotes("");
       setSelectedReview(null);
-      // Re-fetch to ensure sync
       fetchReviews();
-    } catch (error) {
-      // Rollback on failure
+    } catch (err) {
       setReviews(previousReviews);
-      alert("Failed to process KYC review: " + (error as Error).message);
+      alert("Failed to process KYC review: " + (err as Error).message);
     } finally {
       setIsSubmitting(false);
     }
   };
 
+  // ── Loading skeleton ──────────────────────────────────────────────────────
   if (loading && reviews.length === 0) {
-    return <div className="p-8 text-center text-xl font-medium">Loading KYC reviews...</div>;
+    return (
+      <ProtectedPage requiredRole="admin">
+        <div className="container mx-auto p-6 space-y-8">
+          <PageHeaderSkeleton />
+          <div className="grid lg:grid-cols-3 gap-8">
+            <div className="lg:col-span-1 space-y-4">
+              {Array.from({ length: 5 }).map((_, i) => (
+                <ListItemSkeleton key={i} />
+              ))}
+            </div>
+            <div className="lg:col-span-2">
+              <div className="rounded-3xl border bg-card p-8 space-y-6">
+                <div className="flex items-center justify-between">
+                  <div className="space-y-2">
+                    <Skeleton className="h-8 w-40" />
+                    <Skeleton className="h-4 w-56" />
+                  </div>
+                  <Skeleton className="h-10 w-24 rounded-md" />
+                </div>
+                <div className="grid sm:grid-cols-2 gap-4">
+                  <Skeleton className="aspect-video rounded-xl" />
+                  <Skeleton className="aspect-video rounded-xl" />
+                </div>
+                <Skeleton className="h-24 w-full rounded-xl" />
+                <div className="flex gap-3">
+                  <Skeleton className="h-10 flex-1 rounded-md" />
+                  <Skeleton className="h-10 flex-1 rounded-md" />
+                  <Skeleton className="h-10 w-32 rounded-md" />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </ProtectedPage>
+    );
+  }
+
+  // ── Error state ───────────────────────────────────────────────────────────
+  if (error) {
+    return (
+      <ProtectedPage requiredRole="admin">
+        <div className="container mx-auto p-6">
+          <PageError
+            title="Failed to load KYC reviews"
+            message={error}
+            onRetry={fetchReviews}
+          />
+        </div>
+      </ProtectedPage>
+    );
   }
 
   return (
@@ -118,11 +168,12 @@ export default function KycDashboard() {
         {/* Review List */}
         <div className="lg:col-span-1 space-y-4 max-h-[calc(100vh-250px)] overflow-y-auto pr-2">
           {reviews.length === 0 ? (
-            <Card className="bg-muted/50 border-dashed border-2">
-              <CardContent className="flex flex-col items-center justify-center h-40 text-muted-foreground text-center">
-                <p>No reviews found for this status.</p>
-              </CardContent>
-            </Card>
+            <EmptyState
+              icon={FileText}
+              title="No reviews found"
+              description={filterStatus === "ALL" ? "There are no KYC reviews in the queue." : `No reviews with status "${filterStatus}".`}
+              size="sm"
+            />
           ) : (
             reviews.map((review: KycReview) => (
               <Card 

--- a/frontend/src/app/admin/loading.tsx
+++ b/frontend/src/app/admin/loading.tsx
@@ -1,0 +1,27 @@
+import {
+  PageHeaderSkeleton,
+  ListItemSkeleton,
+  TableSkeleton,
+  Skeleton,
+} from "@/components/common/PageSkeleton";
+
+/**
+ * Shared loading skeleton for all /admin/* routes.
+ * Each sub-page has its own inline skeleton too, but this catches
+ * the initial navigation before the page component mounts.
+ */
+export default function AdminLoading() {
+  return (
+    <div className="container mx-auto p-6 space-y-8">
+      <PageHeaderSkeleton />
+      {/* Generic content area — shows a table skeleton as a neutral placeholder */}
+      <TableSkeleton rows={8} cols={5} />
+      {/* Card list below */}
+      <div className="grid gap-4">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <ListItemSkeleton key={i} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/dashboard/error.tsx
+++ b/frontend/src/app/dashboard/error.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useEffect } from "react";
+import { PageError } from "@/components/common/PageError";
+
+export default function DashboardError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("[DashboardPage]", error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center">
+      <PageError
+        title="Dashboard unavailable"
+        message="We couldn't load your dashboard data. Try refreshing the page."
+        onRetry={reset}
+      />
+    </div>
+  );
+}

--- a/frontend/src/app/dashboard/loading.tsx
+++ b/frontend/src/app/dashboard/loading.tsx
@@ -1,0 +1,41 @@
+import {
+  Skeleton,
+  StatRowSkeleton,
+  CardSkeleton,
+} from "@/components/common/PageSkeleton";
+
+export default function DashboardLoading() {
+  return (
+    <div className="space-y-6">
+      {/* Welcome header */}
+      <div className="flex items-center gap-4">
+        <Skeleton className="h-12 w-12 rounded-full shrink-0" />
+        <div className="space-y-2">
+          <Skeleton className="h-6 w-48" />
+          <Skeleton className="h-4 w-32" />
+        </div>
+      </div>
+
+      {/* Stats row */}
+      <StatRowSkeleton count={4} />
+
+      {/* Main grid */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {/* Left column */}
+        <div className="lg:col-span-2 space-y-6">
+          <CardSkeleton lines={5} />
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+            <CardSkeleton lines={4} />
+            <CardSkeleton lines={4} />
+          </div>
+        </div>
+        {/* Right sidebar */}
+        <div className="space-y-6">
+          <CardSkeleton lines={3} hasFooter />
+          <CardSkeleton lines={4} />
+          <CardSkeleton lines={3} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/leaderboard/error.tsx
+++ b/frontend/src/app/leaderboard/error.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useEffect } from "react";
+import { PageError } from "@/components/common/PageError";
+
+export default function LeaderboardError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("[LeaderboardPage]", error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center">
+      <PageError
+        title="Failed to load leaderboard"
+        message="We couldn't fetch the rankings. Check your connection and try again."
+        onRetry={reset}
+      />
+    </div>
+  );
+}

--- a/frontend/src/app/leaderboard/loading.tsx
+++ b/frontend/src/app/leaderboard/loading.tsx
@@ -1,0 +1,31 @@
+import {
+  PageHeaderSkeleton,
+  Skeleton,
+  TableSkeleton,
+} from "@/components/common/PageSkeleton";
+
+export default function LeaderboardLoading() {
+  return (
+    <div className="space-y-6">
+      <PageHeaderSkeleton />
+      {/* Filter card */}
+      <Skeleton className="h-28 w-full rounded-lg" />
+      {/* Rankings card */}
+      <div className="rounded-lg border bg-card shadow-sm p-6 space-y-4">
+        <Skeleton className="h-5 w-32" />
+        <TableSkeleton rows={25} cols={6} />
+        {/* Pagination row */}
+        <div className="flex items-center justify-between pt-2">
+          <Skeleton className="h-4 w-48" />
+          <div className="flex gap-2">
+            <Skeleton className="h-8 w-8 rounded-md" />
+            {Array.from({ length: 5 }).map((_, i) => (
+              <Skeleton key={i} className="h-8 w-8 rounded-md" />
+            ))}
+            <Skeleton className="h-8 w-8 rounded-md" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/matches/[id]/error.tsx
+++ b/frontend/src/app/matches/[id]/error.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { PageError } from "@/components/common/PageError";
+
+export default function MatchHubError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  const router = useRouter();
+
+  useEffect(() => {
+    console.error("[MatchHubPage]", error);
+  }, [error]);
+
+  return (
+    <div className="min-h-screen bg-background flex items-center justify-center px-4">
+      <PageError
+        title="Failed to load match"
+        message="We couldn't fetch the match data. The match may no longer exist or there was a connection issue."
+        onRetry={reset}
+        retryLabel="Reload match"
+      />
+    </div>
+  );
+}

--- a/frontend/src/app/matches/[id]/loading.tsx
+++ b/frontend/src/app/matches/[id]/loading.tsx
@@ -1,0 +1,102 @@
+import { Skeleton } from "@/components/common/PageSkeleton";
+
+export default function MatchHubLoading() {
+  return (
+    <div className="min-h-screen bg-background px-4 py-8">
+      <div className="mx-auto max-w-7xl space-y-6">
+        {/* Back button */}
+        <Skeleton className="h-8 w-16 rounded-md" />
+
+        <div className="grid gap-6 xl:grid-cols-[1.35fr_0.95fr]">
+          {/* Left — match hero + feed */}
+          <div className="space-y-6">
+            {/* Hero card */}
+            <div className="rounded-[32px] border bg-muted/30 p-6 space-y-6">
+              <div className="space-y-2">
+                <Skeleton className="h-3 w-24" />
+                <Skeleton className="h-8 w-64" />
+                <Skeleton className="h-4 w-48" />
+              </div>
+              {/* VS row */}
+              <div className="grid gap-4 md:grid-cols-[1fr_auto_1fr]">
+                <div className="rounded-[28px] border p-5 space-y-4">
+                  <div className="flex items-center gap-3">
+                    <Skeleton className="h-14 w-14 rounded-2xl" />
+                    <div className="space-y-2">
+                      <Skeleton className="h-5 w-28" />
+                      <Skeleton className="h-3 w-20" />
+                    </div>
+                  </div>
+                  <div className="grid grid-cols-3 gap-2">
+                    {Array.from({ length: 3 }).map((_, i) => (
+                      <Skeleton key={i} className="h-12 rounded-2xl" />
+                    ))}
+                  </div>
+                </div>
+                <div className="flex items-center justify-center">
+                  <Skeleton className="h-10 w-16 rounded-full" />
+                </div>
+                <div className="rounded-[28px] border p-5 space-y-4">
+                  <div className="flex items-center gap-3">
+                    <Skeleton className="h-14 w-14 rounded-2xl" />
+                    <div className="space-y-2">
+                      <Skeleton className="h-5 w-28" />
+                      <Skeleton className="h-3 w-20" />
+                    </div>
+                  </div>
+                  <div className="grid grid-cols-3 gap-2">
+                    {Array.from({ length: 3 }).map((_, i) => (
+                      <Skeleton key={i} className="h-12 rounded-2xl" />
+                    ))}
+                  </div>
+                </div>
+              </div>
+              {/* Stats row */}
+              <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+                {Array.from({ length: 4 }).map((_, i) => (
+                  <Skeleton key={i} className="h-16 rounded-2xl" />
+                ))}
+              </div>
+            </div>
+
+            {/* Feed + context */}
+            <div className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
+              <div className="rounded-[32px] border bg-card p-6 space-y-4">
+                <Skeleton className="h-4 w-40" />
+                {Array.from({ length: 4 }).map((_, i) => (
+                  <Skeleton key={i} className="h-20 rounded-2xl" />
+                ))}
+              </div>
+              <div className="rounded-[32px] border bg-card p-6 space-y-4">
+                <Skeleton className="h-4 w-32" />
+                {Array.from({ length: 4 }).map((_, i) => (
+                  <Skeleton key={i} className="h-10 rounded-md" />
+                ))}
+              </div>
+            </div>
+          </div>
+
+          {/* Right — score reporting */}
+          <div className="space-y-6">
+            <div className="rounded-[32px] border bg-card p-6 space-y-4">
+              <Skeleton className="h-4 w-40" />
+              <Skeleton className="h-16 rounded-2xl" />
+              <div className="grid gap-4 sm:grid-cols-2">
+                <Skeleton className="h-16 rounded-md" />
+                <Skeleton className="h-16 rounded-md" />
+              </div>
+              <Skeleton className="h-10 w-full rounded-md" />
+              <Skeleton className="h-10 w-full rounded-md" />
+            </div>
+            <div className="rounded-[32px] border bg-card p-6 space-y-4">
+              <Skeleton className="h-4 w-36" />
+              {Array.from({ length: 2 }).map((_, i) => (
+                <Skeleton key={i} className="h-16 rounded-2xl" />
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/profile/error.tsx
+++ b/frontend/src/app/profile/error.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useEffect } from "react";
+import { PageError } from "@/components/common/PageError";
+
+export default function ProfileError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("[ProfilePage]", error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center">
+      <PageError
+        title="Failed to load profile"
+        message="We couldn't fetch your profile data. Try refreshing the page."
+        onRetry={reset}
+      />
+    </div>
+  );
+}

--- a/frontend/src/app/profile/loading.tsx
+++ b/frontend/src/app/profile/loading.tsx
@@ -1,0 +1,38 @@
+import { Skeleton, CardSkeleton } from "@/components/common/PageSkeleton";
+
+export default function ProfileLoading() {
+  return (
+    <div className="py-4 space-y-8">
+      {/* Profile header card */}
+      <div className="flex flex-col md:flex-row gap-8 items-start md:items-center bg-card border rounded-xl p-8 shadow-sm">
+        <Skeleton className="h-32 w-32 rounded-full shrink-0" />
+        <div className="flex-1 space-y-3">
+          <Skeleton className="h-9 w-48" />
+          <Skeleton className="h-4 w-64" />
+          <div className="flex gap-4 mt-4">
+            <Skeleton className="h-14 w-24 rounded-lg" />
+            <Skeleton className="h-14 w-24 rounded-lg" />
+          </div>
+          <Skeleton className="h-8 w-28 rounded-md mt-2" />
+        </div>
+      </div>
+
+      {/* Main grid */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+        <div className="lg:col-span-2 space-y-8">
+          {/* ELO chart */}
+          <div className="rounded-lg border bg-card shadow-sm p-6 space-y-3">
+            <Skeleton className="h-5 w-32" />
+            <Skeleton className="h-48 w-full rounded-md" />
+          </div>
+          {/* Bio */}
+          <CardSkeleton lines={4} />
+        </div>
+        {/* Match history */}
+        <div className="space-y-8">
+          <CardSkeleton lines={6} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/tournaments/error.tsx
+++ b/frontend/src/app/tournaments/error.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useEffect } from "react";
+import { PageError } from "@/components/common/PageError";
+
+export default function TournamentsError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("[TournamentsPage]", error);
+  }, [error]);
+
+  return (
+    <div className="min-h-screen px-4 py-8 bg-background flex items-center justify-center">
+      <PageError
+        title="Failed to load tournaments"
+        message="We couldn't fetch the tournament list. Check your connection and try again."
+        onRetry={reset}
+      />
+    </div>
+  );
+}

--- a/frontend/src/app/tournaments/loading.tsx
+++ b/frontend/src/app/tournaments/loading.tsx
@@ -1,0 +1,22 @@
+import { TournamentCardSkeleton } from "@/components/tournaments/TournamentCardSkeleton";
+import { PageHeaderSkeleton, Skeleton } from "@/components/common/PageSkeleton";
+
+export default function TournamentsLoading() {
+  return (
+    <div className="min-h-screen px-4 py-8 bg-background space-y-8">
+      <PageHeaderSkeleton />
+      {/* Tab strip */}
+      <div className="flex justify-center">
+        <Skeleton className="h-10 w-64 rounded-lg" />
+      </div>
+      {/* Filter bar */}
+      <Skeleton className="h-24 w-full rounded-lg" />
+      {/* Card grid */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <TournamentCardSkeleton key={i} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/wallet/error.tsx
+++ b/frontend/src/app/wallet/error.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useEffect } from "react";
+import { PageError } from "@/components/common/PageError";
+
+export default function WalletError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("[WalletPage]", error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center">
+      <PageError
+        title="Wallet unavailable"
+        message="We couldn't load your wallet data. Check your connection and try again."
+        onRetry={reset}
+      />
+    </div>
+  );
+}

--- a/frontend/src/app/wallet/loading.tsx
+++ b/frontend/src/app/wallet/loading.tsx
@@ -1,0 +1,39 @@
+import { Skeleton, StatRowSkeleton, CardSkeleton } from "@/components/common/PageSkeleton";
+
+export default function WalletLoading() {
+  return (
+    <div className="space-y-6">
+      {/* Page header */}
+      <div className="space-y-2">
+        <Skeleton className="h-8 w-32" />
+        <Skeleton className="h-4 w-56" />
+      </div>
+
+      {/* Balance cards */}
+      <StatRowSkeleton count={3} />
+
+      {/* Connect card + action buttons */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <CardSkeleton lines={3} hasFooter />
+        <CardSkeleton lines={3} hasFooter />
+      </div>
+
+      {/* Transaction history */}
+      <div className="rounded-lg border bg-card shadow-sm p-6 space-y-4">
+        <Skeleton className="h-5 w-40" />
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div key={i} className="flex items-center justify-between py-2 border-b last:border-0">
+            <div className="flex items-center gap-3">
+              <Skeleton className="h-8 w-8 rounded-full" />
+              <div className="space-y-1">
+                <Skeleton className="h-4 w-32" />
+                <Skeleton className="h-3 w-20" />
+              </div>
+            </div>
+            <Skeleton className="h-5 w-20" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/common/PageError.tsx
+++ b/frontend/src/components/common/PageError.tsx
@@ -1,0 +1,71 @@
+/**
+ * PageError — reusable full-page / in-page error state.
+ *
+ * Used both by Next.js error.tsx boundary files and inline inside
+ * client components that catch API errors themselves.
+ */
+import React from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/Button";
+import { cn } from "@/lib/utils";
+
+interface PageErrorProps {
+  /** Short headline shown in bold. Defaults to "Something went wrong". */
+  title?: string;
+  /** Optional detail message — e.g. the error.message from the boundary. */
+  message?: string;
+  /** Called when the user clicks "Try again". */
+  onRetry?: () => void;
+  /** Label for the retry button. Defaults to "Try again". */
+  retryLabel?: string;
+  /** Extra Tailwind classes on the outer wrapper. */
+  className?: string;
+  /** Whether the retry button is in a loading state. */
+  retrying?: boolean;
+}
+
+export function PageError({
+  title = "Something went wrong",
+  message,
+  onRetry,
+  retryLabel = "Try again",
+  className,
+  retrying = false,
+}: PageErrorProps) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col items-center justify-center py-16 px-4 text-center",
+        className
+      )}
+      role="alert"
+      aria-live="assertive"
+    >
+      <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-destructive/10">
+        <AlertTriangle
+          className="h-8 w-8 text-destructive"
+          aria-hidden="true"
+        />
+      </div>
+
+      <h2 className="mb-2 text-xl font-semibold text-foreground">{title}</h2>
+
+      {message && (
+        <p className="mb-6 max-w-md text-sm text-muted-foreground">{message}</p>
+      )}
+
+      {onRetry && (
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onRetry}
+          loading={retrying}
+          className="gap-2"
+        >
+          <RefreshCw className="h-4 w-4" aria-hidden="true" />
+          {retryLabel}
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/common/PageSkeleton.tsx
+++ b/frontend/src/components/common/PageSkeleton.tsx
@@ -1,0 +1,188 @@
+/**
+ * PageSkeleton — reusable skeleton building blocks.
+ *
+ * Provides a base `Skeleton` pulse block plus higher-level
+ * composites used by loading.tsx files and inline loaders.
+ */
+import React from "react";
+import { cn } from "@/lib/utils";
+import { Card, CardContent, CardHeader } from "@/components/ui/Card";
+
+// ---------------------------------------------------------------------------
+// Primitive
+// ---------------------------------------------------------------------------
+
+interface SkeletonProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export function Skeleton({ className, ...props }: SkeletonProps) {
+  return (
+    <div
+      className={cn("animate-pulse rounded-md bg-muted", className)}
+      aria-hidden="true"
+      {...props}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Card skeleton — generic card with a header + body lines
+// ---------------------------------------------------------------------------
+
+interface CardSkeletonProps {
+  lines?: number;
+  className?: string;
+  hasFooter?: boolean;
+}
+
+export function CardSkeleton({
+  lines = 3,
+  className,
+  hasFooter = false,
+}: CardSkeletonProps) {
+  return (
+    <Card className={cn("overflow-hidden", className)} aria-hidden="true">
+      <CardHeader className="space-y-2 pb-3">
+        <Skeleton className="h-5 w-2/3" />
+        <Skeleton className="h-3 w-1/3" />
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {Array.from({ length: lines }).map((_, i) => (
+          <Skeleton
+            key={i}
+            className={cn("h-4", i === lines - 1 ? "w-3/4" : "w-full")}
+          />
+        ))}
+        {hasFooter && (
+          <div className="pt-2">
+            <Skeleton className="h-9 w-full rounded-md" />
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Table skeleton — header row + N body rows
+// ---------------------------------------------------------------------------
+
+interface TableSkeletonProps {
+  rows?: number;
+  cols?: number;
+  className?: string;
+}
+
+export function TableSkeleton({
+  rows = 5,
+  cols = 5,
+  className,
+}: TableSkeletonProps) {
+  return (
+    <div
+      className={cn("overflow-x-auto rounded-xl border border-border", className)}
+      aria-hidden="true"
+    >
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b bg-muted/50">
+            {Array.from({ length: cols }).map((_, i) => (
+              <th key={i} className="px-4 py-3">
+                <Skeleton className="h-3 w-16" />
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {Array.from({ length: rows }).map((_, r) => (
+            <tr key={r} className="border-b">
+              {Array.from({ length: cols }).map((_, c) => (
+                <td key={c} className="px-4 py-3">
+                  <Skeleton
+                    className={cn(
+                      "h-4",
+                      c === 0 ? "w-8" : c === 1 ? "w-28" : "w-16"
+                    )}
+                  />
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page header skeleton
+// ---------------------------------------------------------------------------
+
+export function PageHeaderSkeleton({ className }: { className?: string }) {
+  return (
+    <div className={cn("space-y-2", className)} aria-hidden="true">
+      <Skeleton className="h-9 w-64" />
+      <Skeleton className="h-4 w-96 max-w-full" />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Stat card row skeleton (e.g. dashboard stats)
+// ---------------------------------------------------------------------------
+
+export function StatRowSkeleton({
+  count = 4,
+  className,
+}: {
+  count?: number;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "grid gap-4",
+        count === 3 && "grid-cols-1 sm:grid-cols-3",
+        count === 4 && "grid-cols-2 sm:grid-cols-4",
+        count === 6 && "grid-cols-2 sm:grid-cols-3 xl:grid-cols-6",
+        className
+      )}
+      aria-hidden="true"
+    >
+      {Array.from({ length: count }).map((_, i) => (
+        <Card key={i}>
+          <CardHeader className="pb-1 pt-4 px-4">
+            <Skeleton className="h-3 w-20" />
+          </CardHeader>
+          <CardContent className="px-4 pb-4">
+            <Skeleton className="h-7 w-24" />
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// List item skeleton (e.g. dispute cards, KYC queue items)
+// ---------------------------------------------------------------------------
+
+export function ListItemSkeleton({ className }: { className?: string }) {
+  return (
+    <Card className={cn("border-2", className)} aria-hidden="true">
+      <CardHeader className="pb-3">
+        <div className="flex items-start justify-between gap-2">
+          <div className="space-y-2 flex-1">
+            <Skeleton className="h-5 w-1/2" />
+            <Skeleton className="h-3 w-1/3" />
+          </div>
+          <Skeleton className="h-6 w-20 rounded-full" />
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-3/4" />
+        <Skeleton className="h-9 w-full rounded-md mt-2" />
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary

No page had a skeleton loader, a UI error state, or a consistent empty state.
All data was hardcoded so these states were never triggered — but they are
required before any real API is wired in. This PR adds two shared primitives
(`PageError`, `PageSkeleton`), Next.js `loading.tsx` / `error.tsx` boundary
files for every key route segment, and upgrades the three admin pages that
already make real API calls (disputes, KYC, governance) from bare text strings
to proper skeleton + error UI.

## Type of change

- [x] Bug fix
- [x] New feature
- [x] UX improvement

## Related issues

Closes #325 *(loading, error, and empty states missing across all pages)*

---

## Changes

### New shared primitives

| File | Description |
|------|-------------|
| `frontend/src/components/common/PageError.tsx` | Reusable error state component. Shows an `AlertTriangle` icon, a bold title, an optional detail message, and an optional "Try again" `Button` with a `loading` spinner. Used by both `error.tsx` boundary files and inline inside client components. |
| `frontend/src/components/common/PageSkeleton.tsx` | Reusable skeleton building blocks: `Skeleton` (base pulse block), `CardSkeleton`, `TableSkeleton`, `PageHeaderSkeleton`, `StatRowSkeleton`, `ListItemSkeleton`. All use `animate-pulse` and `bg-muted`. `aria-hidden="true"` on every element so screen readers skip them. |

### New `loading.tsx` files (Next.js App Router)

Each file is a **Server Component** that renders immediately on navigation,
before the page's data fetch completes. Next.js streams it to the browser
while the page suspends.

| File | Skeleton shape |
|------|----------------|
| `app/tournaments/loading.tsx` | Page header + tab strip + filter bar + 6× `TournamentCardSkeleton` grid |
| `app/leaderboard/loading.tsx` | Page header + filter card + table (25 rows × 6 cols) + pagination row |
| `app/dashboard/loading.tsx` | Avatar + welcome text + 4-stat row + 2-col main grid with card skeletons |
| `app/profile/loading.tsx` | Avatar circle + username/stats + ELO chart placeholder + bio + match history |
| `app/wallet/loading.tsx` | Page header + 3-stat row + 2 action cards + 6-row transaction list |
| `app/matches/[id]/loading.tsx` | Full match hub layout: hero card with VS row + feed + context + score panel |
| `app/admin/loading.tsx` | Shared for all `/admin/*` sub-routes: header + table + 3 list item cards |

### New `error.tsx` files (Next.js App Router)

Each file is a **Client Component** (`"use client"`) that receives the thrown
`Error` and a `reset` callback from Next.js. It logs the error and renders
`PageError` with a "Try again" button that calls `reset()`.

| File | Title shown |
|------|-------------|
| `app/tournaments/error.tsx` | "Failed to load tournaments" |
| `app/leaderboard/error.tsx` | "Failed to load leaderboard" |
| `app/dashboard/error.tsx` | "Dashboard unavailable" |
| `app/profile/error.tsx` | "Failed to load profile" |
| `app/wallet/error.tsx` | "Wallet unavailable" |
| `app/matches/[id]/error.tsx` | "Failed to load match" |
| `app/admin/error.tsx` | "Admin panel error" (shared for all `/admin/*`) |

### Modified admin pages (real API calls → proper states)

All three pages previously used a bare `"Loading…"` text string and swallowed
errors silently with `console.error`. They now have:

| Page | Before | After |
|------|--------|-------|
| `admin/disputes/page.tsx` | `"Loading disputes..."` text, no error UI, dashed card empty state | Skeleton (3× `ListItemSkeleton`), `PageError` with retry, `EmptyState` component |
| `admin/kyc/page.tsx` | `"Loading KYC reviews..."` text, no error UI, dashed card empty state | Skeleton (5× `ListItemSkeleton` + detail pane), `PageError` with retry, `EmptyState` component |
| `admin/governance/page.tsx` | `"Loading proposals..."` text, no error UI, plain text empty state | Skeleton (4× `CardSkeleton`), `PageError` with retry, `EmptyState` component |

All three also had `fetchX` defined as a plain `async function` inside the
component body (not stable across renders). They are now wrapped in
`useCallback` with correct deps so `useEffect` doesn't re-run on every render.

---

## Architecture

### Two-layer approach

```
Navigation to /tournaments
        │
        ▼
  app/tournaments/loading.tsx   ← Server Component, streams immediately
  (skeleton grid)
        │
        ▼  (data fetch completes or throws)
        │
   ┌────┴────────────────────────────────────────────────────┐
   │ Success                    │ Unhandled throw             │
   ▼                            ▼                             │
  page.tsx renders         app/tournaments/error.tsx          │
  (real data)              (PageError + reset button)         │
                                                              │
  ┌───────────────────────────────────────────────────────────┘
  │ API call fails inside client component (useEffect/fetch)
  ▼
  Inline PageError rendered by the component itself
  (disputes, kyc, governance — they catch their own errors)
```

### `PageError` props

```tsx
<PageError
  title="Failed to load disputes"       // required
  message={error}                        // optional detail
  onRetry={fetchDisputes}                // optional — shows retry button
  retryLabel="Try again"                 // optional, default "Try again"
  retrying={false}                       // optional — spinner on button
  className="..."                        // optional
/>
```

### `PageSkeleton` exports

```tsx
// Primitive
<Skeleton className="h-4 w-32" />

// Composites
<CardSkeleton lines={3} hasFooter />
<TableSkeleton rows={25} cols={6} />
<PageHeaderSkeleton />
<StatRowSkeleton count={4} />
<ListItemSkeleton />
```

### Empty states

The existing `EmptyState` component (`@/components/common/EmptyState`) was
already used in the tournaments page. It is now also used in:
- `admin/disputes` — "No open disputes"
- `admin/kyc` — "No reviews found" (with filter-aware description)
- `admin/governance` — "No proposals found"

---

## Files changed summary

```
# New shared primitives
frontend/src/components/common/PageError.tsx              ← NEW
frontend/src/components/common/PageSkeleton.tsx           ← NEW

# loading.tsx — Next.js route segment files
frontend/src/app/tournaments/loading.tsx                  ← NEW
frontend/src/app/leaderboard/loading.tsx                  ← NEW
frontend/src/app/dashboard/loading.tsx                    ← NEW
frontend/src/app/profile/loading.tsx                      ← NEW
frontend/src/app/wallet/loading.tsx                       ← NEW
frontend/src/app/matches/[id]/loading.tsx                 ← NEW
frontend/src/app/admin/loading.tsx                        ← NEW

# error.tsx — Next.js route segment files
frontend/src/app/tournaments/error.tsx                    ← NEW
frontend/src/app/leaderboard/error.tsx                    ← NEW
frontend/src/app/dashboard/error.tsx                      ← NEW
frontend/src/app/profile/error.tsx                        ← NEW
frontend/src/app/wallet/error.tsx                         ← NEW
frontend/src/app/matches/[id]/error.tsx                   ← NEW
frontend/src/app/admin/error.tsx                          ← NEW

# Admin pages — upgraded from text strings to proper states
frontend/src/app/admin/disputes/page.tsx                  ← MODIFIED
frontend/src/app/admin/kyc/page.tsx                       ← MODIFIED
frontend/src/app/admin/governance/page.tsx                ← MODIFIED
```

---

## What was intentionally NOT changed

| Page | Reason |
|------|--------|
| `tournaments/page.tsx` | Already has `TournamentCardSkeleton` + `EmptyState` — no changes needed |
| `matches/[id]/page.tsx` | Already has "Match Not Found" empty state + WebSocket error banner — no changes needed |
| `dashboard/page.tsx` | Uses hardcoded mock data synchronously — no async fetch to fail. `loading.tsx` covers navigation delay |
| `profile/page.tsx` | Same — hardcoded mock. `loading.tsx` covers navigation delay |
| `wallet/page.tsx` | Thin wrapper around `WalletDashboard` — state logic lives inside that component |
| `admin/users/page.tsx` | Added in PR #322 — already has inline skeleton + error + empty state |
| `admin/tournaments/page.tsx` | Added in PR #322 — already has inline skeleton + error + empty state |
| `admin/finance/page.tsx` | Added in PR #322 — already has inline skeleton + error + empty state |

---

## Testing

- [x] TypeScript compiler (`npx tsc --noEmit`) — zero errors in all 19 new/modified files
- [x] Kiro diagnostics — no issues on any file
- [x] No new TypeScript errors introduced (all remaining errors are pre-existing in unrelated files)
- [x] `loading.tsx` files are Server Components (no `"use client"`) — correct for Next.js App Router
- [x] `error.tsx` files are Client Components (`"use client"`) — required by Next.js for error boundaries
- [x] `PageError` renders `role="alert"` and `aria-live="assertive"` for screen reader accessibility
- [x] All skeleton elements have `aria-hidden="true"` — screen readers skip them
- [x] `fetchDisputes`, `fetchProposals` wrapped in `useCallback` — no stale closure bugs
- [ ] Visual regression test for skeleton shapes — follow-up task
- [ ] Storybook stories for `PageError` and `PageSkeleton` — follow-up task

## Checklist

- [x] Code follows project conventions (matches style of existing `TournamentCardSkeleton`, `EmptyState`)
- [x] No secrets or PII committed
- [x] No migrations required (frontend-only change)
- [x] `loading.tsx` skeleton shapes match the real page layouts to prevent layout shift
- [x] `error.tsx` files log to `console.error` for observability
- [x] All `error.tsx` files expose the `reset` callback as the retry action
- [x] `EmptyState` used consistently across all list pages
- [x] `.kiro/` already in root `.gitignore` (added in PR #322)
- [x] `pr-*.md` already in root `.gitignore` (added in PR #322) — covers this file