### PR TITLE
fix: structured logging and observability improvements (#393)

### DIFF
--- a/server/src/config/database.ts
+++ b/server/src/config/database.ts
@@ -1,5 +1,7 @@
 import { PrismaClient } from '@prisma/client';
 import { Prisma } from '@prisma/client';
+import { logger } from '../services/logger.service';
+import { metricsService } from '../services/metrics.service';
 
 // Database connection pool configuration
 const poolConfig = {
@@ -37,16 +39,31 @@ let connectionCount = 0;
 prisma.$use(async (params: Prisma.MiddlewareParams, next: (params: Prisma.MiddlewareParams) => Promise<any>) => {
   const before = Date.now();
   connectionCount++;
-  
+
+  const model = params.model ?? 'unknown';
+  const action = params.action;
+
   try {
     const result = await next(params);
-    const after = Date.now();
-    
+    const durationMs = Date.now() - before;
+    const durationSec = durationMs / 1000;
+
+    metricsService.recordDbQuery(action, model, durationSec, 'success');
+
     if (process.env.NODE_ENV === 'development') {
-      console.log(`Query: ${params.model}.${params.action} took ${after - before}ms`);
+      logger.debug('DB query', { model, action, durationMs });
     }
-    
+
+    if (durationMs > 500) {
+      logger.warn('Slow DB query detected', { model, action, durationMs });
+    }
+
     return result;
+  } catch (err) {
+    const durationMs = Date.now() - before;
+    metricsService.recordDbQuery(action, model, durationMs / 1000, 'error');
+    logger.error('DB query failed', { model, action, durationMs, error: err });
+    throw err;
   } finally {
     connectionCount--;
   }
@@ -58,7 +75,7 @@ export async function checkDatabaseHealth(): Promise<boolean> {
     await prisma.$queryRaw`SELECT 1`;
     return true;
   } catch (error) {
-    console.error('Database health check failed:', error);
+    logger.error('Database health check failed', { error });
     return false;
   }
 }
@@ -74,7 +91,7 @@ export function getConnectionStats() {
 // Graceful shutdown
 export async function disconnectDatabase(): Promise<void> {
   await prisma.$disconnect();
-  console.log('Database connection closed');
+  logger.info('Database connection closed');
 }
 
 export default prisma;

--- a/server/src/controllers/match.controller.ts
+++ b/server/src/controllers/match.controller.ts
@@ -1,20 +1,20 @@
-import { Request, Response } from 'express';
+import { Request, Response, NextFunction } from 'express';
 import { MatchService } from '../services/match.service';
 
 const matchService = new MatchService();
 
-export const reportScore = async (req: Request, res: Response): Promise<void> => {
+export const reportScore = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     try {
         const { id } = req.params;
         const { winnerId } = req.body;
         const match = await matchService.reportScore(id, winnerId);
         res.status(200).json(match);
     } catch (error) {
-        res.status(500).json({ error: (error as Error).message });
+        next(error);
     }
 };
 
-export const raiseDispute = async (req: Request, res: Response): Promise<void> => {
+export const raiseDispute = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     try {
         const { id } = req.params;
         const { reason, evidenceUrls } = req.body;
@@ -24,6 +24,6 @@ export const raiseDispute = async (req: Request, res: Response): Promise<void> =
         });
         res.status(201).json(dispute);
     } catch (error) {
-        res.status(500).json({ error: (error as Error).message });
+        next(error);
     }
 };

--- a/server/src/middleware/auth.middleware.ts
+++ b/server/src/middleware/auth.middleware.ts
@@ -9,6 +9,7 @@ import { authConfig } from '../config/auth.config';
 import { getDatabaseClient } from '../services/database.service';
 import { AuthenticatedUser } from '../types/auth.types';
 import { HttpError } from '../utils/http-error';
+import { logger } from '../services/logger.service';
 
 interface JwtPayload {
     sub: string;
@@ -45,11 +46,13 @@ export const configurePassport = (
                     });
 
                     if (!user) {
+                        logger.warn('JWT authentication failed: user not found', { sub: payload.sub });
                         return done(null, false);
                     }
 
                     return done(null, user as AuthenticatedUser);
                 } catch (error) {
+                    logger.error('JWT strategy error', { error });
                     return done(error as Error, false);
                 }
             }
@@ -69,10 +72,16 @@ export const authenticateJWT = (
         { session: false },
         (err: Error | null, user: Express.User | false) => {
             if (err) {
+                logger.error('JWT authentication error', { error: err, path: req.originalUrl });
                 return next(err);
             }
 
             if (!user) {
+                (req.log ?? logger).warn('Unauthorized request', {
+                    method: req.method,
+                    path: req.originalUrl,
+                    ip: req.ip
+                });
                 return next(new HttpError(401, 'Unauthorized'));
             }
 

--- a/server/src/services/auth.service.ts
+++ b/server/src/services/auth.service.ts
@@ -10,6 +10,7 @@ import {
 import { HttpError } from '../utils/http-error';
 import stellarWalletService from './stellar-wallet.service';
 import emailService from './email.service';
+import { logger } from './logger.service';
 
 const BCRYPT_ROUNDS = 12;
 const MAX_USERNAME_LENGTH = 24;
@@ -286,11 +287,21 @@ export const registerUser = async (input: RegisterInput) => {
             try {
                 await emailService.sendVerificationEmail(normalizedEmail, verificationToken);
             } catch (emailError) {
-                console.error('Failed to send verification email:', emailError);
+                logger.warn('Failed to send verification email', {
+                    userId: createdUser.id,
+                    email: normalizedEmail,
+                    error: emailError
+                });
                 // Don't fail registration if email fails
             }
 
             const tokens = await issueSessionTokens(createdUser);
+
+            logger.info('User registered', {
+                userId: createdUser.id,
+                username: createdUser.username,
+                provider: 'EMAIL'
+            });
 
             return {
                 user: mapUserToSafeUser(createdUser),
@@ -330,10 +341,13 @@ export const loginUser = async (input: LoginInput) => {
 
     const isPasswordValid = await bcrypt.compare(input.password, user.passwordHash);
     if (!isPasswordValid) {
+        logger.warn('Failed login attempt', { email: normalizedEmail });
         throw new HttpError(401, 'Invalid credentials');
     }
 
     const tokens = await issueSessionTokens(user);
+
+    logger.info('User logged in', { userId: user.id, username: user.username });
 
     return {
         user: mapUserToSafeUser(user),
@@ -367,6 +381,10 @@ export const refreshSession = async (input: RefreshInput) => {
     if (storedToken.revokedAt) {
         if (storedToken.replacedByTokenId) {
             await revokeTokenFamily(storedToken.familyId);
+            logger.warn('Refresh token reuse detected — token family revoked', {
+                userId: storedToken.userId,
+                familyId: storedToken.familyId
+            });
             throw new HttpError(
                 401,
                 'Refresh token reuse detected, please login again'
@@ -419,6 +437,7 @@ export const logoutUser = async (input: LogoutInput): Promise<void> => {
             where: { id: storedToken.id },
             data: { revokedAt: new Date() }
         });
+        logger.info('User logged out', { userId: storedToken.userId });
     }
 };
 
@@ -634,13 +653,18 @@ export const verifyEmail = async (input: VerifyEmailInput) => {
         }
     });
     
-    // Send welcome email
     try {
         await emailService.sendWelcomeEmail(user.email, user.username);
     } catch (emailError) {
-        console.error('Failed to send welcome email:', emailError);
+        logger.warn('Failed to send welcome email', {
+            userId: user.id,
+            email: user.email,
+            error: emailError
+        });
         // Don't fail verification if welcome email fails
     }
+
+    logger.info('Email verified', { userId: user.id });
     
     return { message: 'Email verified successfully' };
 };
@@ -679,12 +703,15 @@ export const forgotPassword = async (input: ForgotPasswordInput) => {
     try {
         await emailService.sendPasswordResetEmail(normalizedEmail, resetToken);
     } catch (emailError) {
-        console.error('Failed to send password reset email:', emailError);
+        logger.warn('Failed to send password reset email', {
+            userId: user.id,
+            email: normalizedEmail,
+            error: emailError
+        });
         // Don't fail if email fails
     }
-    // In production, store reset token in database and send email
-    // For now, we'll just log it
-    console.log('[Auth] Password reset token for', normalizedEmail, ':', resetToken);
+
+    logger.info('Password reset requested', { userId: user.id });
     
     return { message: 'If the email exists, a reset link has been sent' };
 };


### PR DESCRIPTION
# fix: structured logging and observability improvements (#393)

## Summary

Closes #393

Replaces unstructured `console.log` / `console.error` calls with the
project's Winston logger, wires Prometheus DB metrics that were defined
but never populated, and ensures all errors flow through the centralized
error handler so Sentry captures them consistently.

---

## Changes

### `server/src/config/database.ts`
- Imported `logger` and `metricsService` at the top of the file.
- Replaced `console.log` query-timing output with `logger.debug` (dev
  only) and a `logger.warn` for slow queries (>500 ms) that includes
  structured `{ model, action, durationMs }` context.
- **Wired `metricsService.recordDbQuery()`** into the Prisma middleware
  on both the success and error paths — `db_queries_total` and
  `db_query_duration_seconds` Prometheus metrics were previously always
  zero because the call was never made.
- Replaced `console.error` in `checkDatabaseHealth()` with
  `logger.error`.
- Replaced `console.log` in `disconnectDatabase()` with `logger.info`.

### `server/src/services/auth.service.ts`
- Imported `logger` from `./logger.service`.
- Added structured `logger.info` events for key auth lifecycle moments:
  - `User registered` (userId, username, provider)
  - `User logged in` (userId, username)
  - `User logged out` (userId)
  - `Email verified` (userId)
  - `Password reset requested` (userId)
- Added `logger.warn` for:
  - Failed login attempt (email only — no password in logs)
  - Refresh token reuse detected with family revocation (userId,
    familyId)
  - Non-fatal email send failures (verification, welcome, password reset)
    — previously swallowed silently with `console.error`
- **Removed a `console.log` that printed a plaintext password reset
  token** — a security issue regardless of environment.
- Replaced all remaining `console.error` calls with `logger.warn`
  (non-fatal email failures) carrying structured context.

### `server/src/controllers/match.controller.ts`
- Updated `reportScore` and `raiseDispute` signatures from
  `(req, res)` to `(req, res, next)`.
- Replaced `res.status(500).json({ error: ... })` with `next(error)` in
  both handlers so errors flow through the centralized `errorHandler`
  middleware, which logs via Winston, captures in Sentry, and returns a
  consistent `{ error: { code, message, status, requestId } }` shape.

### `server/src/middleware/auth.middleware.ts`
- Imported `logger` from `../services/logger.service`.
- JWT strategy callback now logs `logger.warn` when a token references a
  user that no longer exists (`{ sub }`) and `logger.error` when the
  strategy itself throws.
- `authenticateJWT` now logs `logger.warn` on every unauthorized request
  with `{ method, path, ip }` context (uses `req.log` child logger when
  available for request-ID correlation), and `logger.error` when the
  passport callback errors.

---

## What was tested

- TypeScript diagnostics: no errors on all four modified files
  (`getDiagnostics` returned clean for each).
- Verified no `console.*` calls remain in any of the four changed files.
- Confirmed `metricsService.recordDbQuery` signature matches the existing
  `MetricsService` implementation (`operation`, `table`, `duration`,
  `'success' | 'error'`).
- Confirmed `match.controller.ts` route handler signatures are compatible
  with Express `RequestHandler` after adding `next`.

## What was not verified

- Full integration test against a running database (environment
  constraints — `tsc` not on PATH in this environment).
- Prometheus scrape endpoint (`/api/metrics`) returning non-zero DB
  metric values end-to-end.

---

## Checklist

- [x] Closes the linked issue
- [x] No plaintext secrets logged
- [x] Errors route through centralized handler (Sentry capture included)
- [x] DB metrics now populated in Prometheus
- [x] Auth events (login, logout, register, token reuse) are observable
- [x] Slow DB queries (>500 ms) emit a structured warning
- [x] `pr-393.md` is covered by the `pr-*.md` pattern in `.gitignore`
- [x] `.kiro/` directory is covered by `.gitignore`
