### PR TITLE
fix: automate backend database migrations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,58 @@ jobs:
     - name: Build
       run: npm run build
 
+  # Backend database migration CI
+  backend-migrations:
+    name: Backend Migrations
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:14
+        env:
+          POSTGRES_USER: arenax
+          POSTGRES_PASSWORD: arenax
+          POSTGRES_DB: arenax_ci
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U arenax -d arenax_ci"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgres://arenax:arenax@localhost:5432/arenax_ci
+    defaults:
+      run:
+        working-directory: ./backend
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Cache cargo
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          ~/.cargo/bin/sqlx
+        key: ${{ runner.os }}-cargo-sqlx-cli-${{ hashFiles('backend/Cargo.lock') }}
+
+    - name: Install SQLx CLI
+      run: |
+        if ! command -v sqlx >/dev/null 2>&1; then
+          cargo install sqlx-cli --version 0.8.6 --no-default-features --features rustls,postgres --locked
+        fi
+
+    - name: Verify migration files
+      run: ./scripts/verify-migrations.sh
+
+    - name: Apply migrations
+      run: ./scripts/migrate.sh
+
   # Contracts CI (Rust)
   contracts:
     name: Contracts

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -9,6 +9,7 @@ target/
 *.db
 *.sqlite
 *.sqlite3
+backups/
 
 # Logs
 *.log

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -10,7 +10,7 @@ uuid = { version = "1.0", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 thiserror = "1.0"
 tokio = { version = "1.0", features = ["full"] }
-sqlx = { version = "0.8.6", features = ["runtime-tokio-rustls", "postgres", "uuid", "chrono", "rust_decimal"] }
+sqlx = { version = "0.8.6", features = ["runtime-tokio-rustls", "postgres", "uuid", "chrono", "rust_decimal", "migrate"] }
 validator = { version = "0.20.0", features = ["derive"] }
 rust_decimal = { version = "1.40.0", features = ["db-postgres"] }
 actix-web = "4.12.1"

--- a/backend/MIGRATIONS.md
+++ b/backend/MIGRATIONS.md
@@ -1,0 +1,97 @@
+# Backend Database Migrations
+
+The Rust backend uses SQLx migrations from `backend/migrations` as the source of truth for PostgreSQL schema changes.
+
+## Naming
+
+Every backend migration must be committed as a pair:
+
+```text
+YYYYMMDDHHMMSS_snake_case_description.up.sql
+YYYYMMDDHHMMSS_snake_case_description.down.sql
+```
+
+Use one timestamp per logical schema change. Do not edit an already-applied migration; create a new migration instead.
+
+## Local Workflow
+
+Set `DATABASE_URL` to the target PostgreSQL database before running any command:
+
+```bash
+export DATABASE_URL=postgres://arenax:arenax@localhost:5432/arenax
+```
+
+Create a migration:
+
+```bash
+cd backend
+sqlx migrate add -r add_example_table
+```
+
+Validate naming and up/down pairs:
+
+```bash
+cd backend
+./scripts/verify-migrations.sh
+```
+
+Apply pending migrations:
+
+```bash
+cd backend
+./scripts/migrate.sh
+```
+
+Check migration status:
+
+```bash
+cd backend
+./scripts/migration-status.sh
+```
+
+## Startup Enforcement
+
+The backend runs SQLx migrations during startup by default. Startup fails if:
+
+- the database cannot be reached,
+- a migration is dirty,
+- an applied migration is missing locally,
+- an applied migration checksum differs from the committed migration,
+- a pending migration fails.
+
+Set `BACKEND_MIGRATION_MODE=disabled` only for controlled maintenance tasks where migrations are applied by a separate deployment step.
+
+## CI/CD
+
+CI validates backend migration filenames and up/down pairs, then applies all migrations to a clean PostgreSQL service using SQLx. Deployment pipelines should run the same migration command before starting new backend instances:
+
+```bash
+cd backend
+./scripts/migrate.sh
+```
+
+Because application startup also validates migrations, schema drift blocks the backend from serving traffic.
+
+## Rollback And Backups
+
+For shared, staging, or production databases, create a backup before reverting migrations:
+
+```bash
+cd backend
+./scripts/backup-database.sh
+```
+
+The backup script writes a custom-format `pg_dump` file into `backend/backups`, which is git-ignored.
+
+To revert the latest migration:
+
+```bash
+cd backend
+./scripts/rollback-last-migration.sh
+```
+
+Rollback is intentionally interactive. For production incidents, prefer restoring from a verified backup when data-destructive down migrations are involved.
+
+## Other Components
+
+Server Prisma migrations remain under `server/prisma/migrations` and should not be mixed into `backend/migrations`. Soroban contract storage changes must be documented with the contract change and coordinated with backend migrations when the backend depends on indexed contract data.

--- a/backend/README.md
+++ b/backend/README.md
@@ -115,7 +115,7 @@ cp .env.example .env
 # Edit .env with your configuration
 
 # Run database migrations
-sqlx migrate run
+./scripts/migrate.sh
 
 # Start the backend server
 cargo run
@@ -149,9 +149,12 @@ cargo clippy
 ./test_ci_locally.sh
 
 # Database operations
-sqlx migrate add <migration_name>
-sqlx migrate run
-sqlx migrate revert
+sqlx migrate add -r <migration_name>
+./scripts/verify-migrations.sh
+./scripts/migrate.sh
+./scripts/migration-status.sh
+./scripts/backup-database.sh
+./scripts/rollback-last-migration.sh
 
 # Stellar integration testing
 ./scripts/test_stellar.sh
@@ -162,6 +165,7 @@ sqlx migrate revert
 ```env
 # Database
 DATABASE_URL=postgres://user:pass@localhost:5432/arenax
+BACKEND_MIGRATION_MODE=run
 REDIS_URL=redis://localhost:6379
 
 # Storage
@@ -185,6 +189,8 @@ SOROBAN_CONTRACT_REPUTATION=CBXXX...
 # AI
 AI_MODEL_PATH=./models/anti_cheat.tflite
 ```
+
+`BACKEND_MIGRATION_MODE` defaults to `run`, which applies and validates SQLx migrations during backend startup. Use `disabled` only when migrations are applied by a separate deployment step. See [MIGRATIONS.md](MIGRATIONS.md) for the full migration workflow, rollback process, and CI expectations.
 
 ## Code Organization & Architecture
 

--- a/backend/env.example
+++ b/backend/env.example
@@ -2,6 +2,7 @@
 
 # Database
 DATABASE_URL=postgres://user:pass@localhost:5432/arenax
+BACKEND_MIGRATION_MODE=run
 REDIS_URL=redis://localhost:6379
 
 # Storage

--- a/backend/scripts/backup-database.sh
+++ b/backend/scripts/backup-database.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+if [ -z "${DATABASE_URL:-}" ]; then
+  echo "DATABASE_URL must be set before creating a backup." >&2
+  exit 1
+fi
+
+backup_dir="${BACKUP_DIR:-./backups}"
+mkdir -p "$backup_dir"
+
+timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+output="$backup_dir/arenax-$timestamp.dump"
+
+pg_dump "$DATABASE_URL" --format=custom --no-owner --no-acl --file="$output"
+
+echo "Database backup written to $output"

--- a/backend/scripts/migrate.sh
+++ b/backend/scripts/migrate.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+if [ -z "${DATABASE_URL:-}" ]; then
+  echo "DATABASE_URL must be set before running migrations." >&2
+  exit 1
+fi
+
+./scripts/verify-migrations.sh ./migrations
+sqlx migrate run --source ./migrations

--- a/backend/scripts/migration-status.sh
+++ b/backend/scripts/migration-status.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+if [ -z "${DATABASE_URL:-}" ]; then
+  echo "DATABASE_URL must be set before checking migration status." >&2
+  exit 1
+fi
+
+sqlx migrate info --source ./migrations

--- a/backend/scripts/rollback-last-migration.sh
+++ b/backend/scripts/rollback-last-migration.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+if [ -z "${DATABASE_URL:-}" ]; then
+  echo "DATABASE_URL must be set before rolling back migrations." >&2
+  exit 1
+fi
+
+echo "About to revert the latest applied backend migration."
+echo "Create a database backup first for shared, staging, or production databases."
+read -r -p "Type 'revert latest' to continue: " confirmation
+
+if [ "$confirmation" != "revert latest" ]; then
+  echo "Rollback cancelled."
+  exit 1
+fi
+
+sqlx migrate revert --source ./migrations

--- a/backend/scripts/verify-migrations.sh
+++ b/backend/scripts/verify-migrations.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MIGRATIONS_DIR="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/migrations}"
+
+if [ ! -d "$MIGRATIONS_DIR" ]; then
+  echo "Migration directory not found: $MIGRATIONS_DIR" >&2
+  exit 1
+fi
+
+declare -A up_versions=()
+declare -A down_versions=()
+
+while IFS= read -r -d '' file; do
+  name="$(basename "$file")"
+
+  if [[ ! "$name" =~ ^[0-9]{14}_[a-z0-9_]+\.(up|down)\.sql$ ]]; then
+    echo "Invalid migration filename: $name" >&2
+    echo "Expected: <14 digit timestamp>_<snake_case_name>.(up|down).sql" >&2
+    exit 1
+  fi
+
+  version="${name%%_*}"
+  direction="${name##*.}"
+  direction="${name%.*}"
+  direction="${direction##*.}"
+
+  if [ "$direction" = "up" ]; then
+    if [ -n "${up_versions[$version]:-}" ]; then
+      echo "Duplicate up migration version: $version" >&2
+      exit 1
+    fi
+    up_versions[$version]="$name"
+  else
+    if [ -n "${down_versions[$version]:-}" ]; then
+      echo "Duplicate down migration version: $version" >&2
+      exit 1
+    fi
+    down_versions[$version]="$name"
+  fi
+done < <(find "$MIGRATIONS_DIR" -maxdepth 1 -type f -name '*.sql' -print0)
+
+for version in "${!up_versions[@]}"; do
+  if [ -z "${down_versions[$version]:-}" ]; then
+    echo "Missing down migration for ${up_versions[$version]}" >&2
+    exit 1
+  fi
+done
+
+for version in "${!down_versions[@]}"; do
+  if [ -z "${up_versions[$version]:-}" ]; then
+    echo "Missing up migration for ${down_versions[$version]}" >&2
+    exit 1
+  fi
+done
+
+echo "Verified ${#up_versions[@]} backend migration pair(s) in $MIGRATIONS_DIR"

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -17,6 +17,26 @@ pub struct Config {
 #[derive(Debug, Deserialize, Clone)]
 pub struct DatabaseConfig {
     pub url: String,
+    pub migration_mode: MigrationMode,
+}
+
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+pub enum MigrationMode {
+    Run,
+    Disabled,
+}
+
+impl MigrationMode {
+    fn from_env_value(value: &str) -> Result<Self, anyhow::Error> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "run" | "auto" | "true" | "1" => Ok(Self::Run),
+            "disabled" | "disable" | "off" | "false" | "0" => Ok(Self::Disabled),
+            other => anyhow::bail!(
+                "invalid BACKEND_MIGRATION_MODE value `{}`; expected `run` or `disabled`",
+                other
+            ),
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -76,6 +96,9 @@ impl Config {
         dotenvy::dotenv().ok();
 
         let database_url = env::var("DATABASE_URL")?;
+        let migration_mode = env::var("BACKEND_MIGRATION_MODE")
+            .map(|value| MigrationMode::from_env_value(&value))
+            .unwrap_or(Ok(MigrationMode::Run))?;
         let redis_url = env::var("REDIS_URL")?;
         let s3_endpoint = env::var("S3_ENDPOINT")?;
         let s3_access_key = env::var("S3_ACCESS_KEY")?;
@@ -98,7 +121,10 @@ impl Config {
         let rate_limit_window: u64 = env::var("RATE_LIMIT_WINDOW")?.parse()?;
 
         Ok(Config {
-            database: DatabaseConfig { url: database_url },
+            database: DatabaseConfig {
+                url: database_url,
+                migration_mode,
+            },
             redis: RedisConfig { url: redis_url },
             storage: StorageConfig {
                 s3_endpoint,

--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -1,8 +1,11 @@
 use crate::api_error::ApiError;
-use crate::config::Config;
+use crate::config::{Config, MigrationMode};
 use sqlx::{postgres::PgPoolOptions, PgPool};
+use tracing::info;
 
 pub type DbPool = PgPool;
+
+static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("./migrations");
 
 pub async fn create_pool(config: &Config) -> Result<DbPool, sqlx::Error> {
     PgPoolOptions::new()
@@ -16,5 +19,23 @@ pub async fn health_check(pool: &DbPool) -> Result<(), ApiError> {
         .execute(pool)
         .await
         .map_err(|e| ApiError::DatabaseError(e))?;
+    Ok(())
+}
+
+pub async fn run_startup_migrations(
+    config: &Config,
+    pool: &DbPool,
+) -> Result<(), sqlx::migrate::MigrateError> {
+    match config.database.migration_mode {
+        MigrationMode::Run => {
+            info!("Running database migrations before backend startup");
+            MIGRATOR.run(pool).await?;
+            info!("Database migrations are up to date");
+        }
+        MigrationMode::Disabled => {
+            info!("Skipping database migrations because BACKEND_MIGRATION_MODE=disabled");
+        }
+    }
+
     Ok(())
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -16,7 +16,7 @@ mod orchestrator;
 mod telemetry;
 
 use crate::config::Config;
-use crate::db::create_pool;
+use crate::db::{create_pool, run_startup_migrations};
 use crate::middleware::cors_middleware;
 use crate::middleware::idempotency_middleware::IdempotencyMiddleware;
 use crate::middleware::security::{SecurityConfig, SecurityMiddleware};
@@ -39,6 +39,10 @@ async fn main() -> io::Result<()> {
     let db_pool = create_pool(&config)
         .await
         .expect("Failed to create database pool");
+
+    run_startup_migrations(&config, &db_pool)
+        .await
+        .expect("Failed to run database migrations");
 
     // Spawn the Reaper — forfeits players who miss the reporting deadline
     let reaper = Arc::new(ReaperService::new(db_pool.clone()));


### PR DESCRIPTION
## Summary

Standardizes backend database migrations around SQLx and adds automation for startup validation, CI verification, local migration execution, backup, and rollback workflows.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / cleanup
- [x] Docs / config only

## Related issues

Closes https://github.com/Arenax-gaming/ArenaX/issues/388

## Changes

- Added backend startup migration enforcement with `sqlx::migrate!()` so schema drift, dirty migrations, checksum mismatches, and pending migration failures stop the Rust backend from serving traffic
- Added `BACKEND_MIGRATION_MODE=run|disabled`, defaulting to `run`, for controlled deployments where migrations may be handled by a separate step
- Added backend migration scripts for verification, applying migrations, status checks, backups, and guarded rollback
- Added CI coverage that validates backend migration filenames/pairs and applies all migrations to a clean PostgreSQL service
- Documented the backend migration workflow, rollback/backup process, local commands, CI expectations, and separation from Prisma/Soroban migration concerns

## Testing

- [ ] Unit tests pass (`cargo test` / `npm test`)
- [ ] Contracts tests pass (`cargo test` in `contracts/`)
- [x] Migration file validation passes (`backend/scripts/verify-migrations.sh`)
- [ ] Migration tested against a fresh DB

Notes:
- `sqlx-cli 0.8.6` and `pg_dump` are installed locally.
- Local migration status could not connect because `backend/.env` points to `postgresql://localhost/arenax_dev`, but local Postgres refused the connection.
- `cargo check` is currently blocked by pre-existing unrelated syntax errors in `backend/src/service/tournament_service.rs`.

## Checklist

- [x] Code follows project conventions
- [x] No secrets or PII committed
- [x] Migrations are reversible (`.down.sql` exists)
- [x] Migration automation documented
- [ ] CI passes
