### PR TITLE
[BACKEND] - Add user profile and account management endpoints

### DIFF
--- a/backend/src/http/mod.rs
+++ b/backend/src/http/mod.rs
@@ -13,6 +13,7 @@ pub mod social_handler;
 pub mod staking_handler;
 pub mod analytics_handler;
 pub mod tournament_handler;
+pub mod users;
 
 // TODO: Add more HTTP modules as implemented:
 // pub mod auth;

--- a/backend/src/http/users.rs
+++ b/backend/src/http/users.rs
@@ -1,0 +1,125 @@
+use actix_web::{web, HttpRequest, HttpResponse, Result};
+use serde::Deserialize;
+use uuid::Uuid;
+
+use crate::api_error::ApiError;
+use crate::auth::middleware::ClaimsExt;
+use crate::service::UserService;
+
+#[derive(Deserialize)]
+pub struct UpdateProfileRequest {
+    pub username: Option<String>,
+    pub avatar_url: Option<String>,
+    pub display_name: Option<String>,
+    pub bio: Option<String>,
+}
+
+/// GET /api/users/{id}
+/// Get public user profile by ID
+pub async fn get_user_profile(
+    pool: web::Data<sqlx::PgPool>,
+    user_id: web::Path<Uuid>,
+) -> Result<HttpResponse, ApiError> {
+    let service = UserService::new(pool.get_ref().clone());
+    let profile = service.get_user_profile(*user_id).await?;
+
+    Ok(HttpResponse::Ok().json(serde_json::json!({
+        "success": true,
+        "data": profile
+    })))
+}
+
+/// GET /api/users/me
+/// Get authenticated user's own profile
+pub async fn get_current_user_profile(
+    pool: web::Data<sqlx::PgPool>,
+    req: HttpRequest,
+) -> Result<HttpResponse, ApiError> {
+    let user_id = req
+        .user_id()
+        .ok_or_else(|| ApiError::unauthorized("User not authenticated"))?;
+
+    let service = UserService::new(pool.get_ref().clone());
+    let user = service.get_current_user_profile(user_id).await?;
+
+    Ok(HttpResponse::Ok().json(serde_json::json!({
+        "success": true,
+        "data": user
+    })))
+}
+
+/// PUT /api/users/me
+/// Update authenticated user's profile
+pub async fn update_user_profile(
+    pool: web::Data<sqlx::PgPool>,
+    req: HttpRequest,
+    body: web::Json<UpdateProfileRequest>,
+) -> Result<HttpResponse, ApiError> {
+    let user_id = req
+        .user_id()
+        .ok_or_else(|| ApiError::unauthorized("User not authenticated"))?;
+
+    let service = UserService::new(pool.get_ref().clone());
+    let updated_user = service
+        .update_user_profile(
+            user_id,
+            body.username.clone(),
+            body.avatar_url.clone(),
+            body.display_name.clone(),
+            body.bio.clone(),
+        )
+        .await?;
+
+    Ok(HttpResponse::Ok().json(serde_json::json!({
+        "success": true,
+        "data": updated_user,
+        "message": "Profile updated successfully"
+    })))
+}
+
+/// GET /api/users/{id}/stats
+/// Get user stats including win/loss record and Elo history
+pub async fn get_user_stats(
+    pool: web::Data<sqlx::PgPool>,
+    user_id: web::Path<Uuid>,
+) -> Result<HttpResponse, ApiError> {
+    let service = UserService::new(pool.get_ref().clone());
+    let stats = service.get_user_stats(*user_id).await?;
+
+    Ok(HttpResponse::Ok().json(serde_json::json!({
+        "success": true,
+        "data": stats
+    })))
+}
+
+/// Configure user routes
+pub fn configure_routes(cfg: &mut web::ServiceConfig) {
+    cfg.service(
+        web::scope("/api/users")
+            .route("/{id}", web::get().to(get_user_profile))
+            .route("/me", web::get().to(get_current_user_profile))
+            .route("/me", web::put().to(update_user_profile))
+            .route("/{id}/stats", web::get().to(get_user_stats)),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_update_profile_request_deserialization() {
+        let json = r#"{"username":"new_username","avatar_url":"https://example.com/avatar.jpg"}"#;
+        let req: UpdateProfileRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.username, Some("new_username".to_string()));
+        assert_eq!(req.avatar_url, Some("https://example.com/avatar.jpg".to_string()));
+    }
+
+    #[test]
+    fn test_update_profile_request_partial() {
+        let json = r#"{"display_name":"John Doe"}"#;
+        let req: UpdateProfileRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.display_name, Some("John Doe".to_string()));
+        assert_eq!(req.username, None);
+    }
+}

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -190,6 +190,14 @@ async fn main() -> io::Result<()> {
                         web::scope("/tournaments")
                             .route("/{id}/statistics", web::get().to(crate::http::tournament_handler::get_tournament_statistics))
                     )
+                    // User endpoints
+                    .service(
+                        web::scope("/users")
+                            .route("/{id}", web::get().to(crate::http::users::get_user_profile))
+                            .route("/me", web::get().to(crate::http::users::get_current_user_profile))
+                            .route("/me", web::put().to(crate::http::users::update_user_profile))
+                            .route("/{id}/stats", web::get().to(crate::http::users::get_user_stats))
+                    )
                     // Matchmaking endpoints
                     .service(
                         web::scope("/matchmaking")
@@ -244,3 +252,7 @@ async fn main() -> io::Result<()> {
 
     server.await
 }
+
+
+
+

--- a/backend/src/service/mod.rs
+++ b/backend/src/service/mod.rs
@@ -16,6 +16,7 @@ pub mod soroban_service;
 pub mod staking_service;
 pub mod stellar_service;
 pub mod tournament_service;
+pub mod user_service;
 pub mod wallet_service;
 
 pub use governance_service::{
@@ -37,5 +38,6 @@ pub use soroban_service::{
 };
 pub use stellar_service::StellarService;
 pub use tournament_service::TournamentService;
+pub use user_service::UserService;
 pub use wallet_service::WalletService;
 pub use crate::realtime::event_bus::EventBus;

--- a/backend/src/service/user_service.rs
+++ b/backend/src/service/user_service.rs
@@ -1,0 +1,199 @@
+use chrono::{DateTime, Utc};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use crate::api_error::ApiError;
+use crate::models::match_models::{EloHistory, UserElo};
+use crate::models::user::{User, UserProfile};
+
+#[derive(Debug, Clone)]
+pub struct UserService {
+    pool: PgPool,
+}
+
+impl UserService {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    /// Get a user by ID
+    pub async fn get_user_by_id(&self, user_id: Uuid) -> Result<User, ApiError> {
+        let user = sqlx::query_as::<_, User>(
+            r#"
+            SELECT * FROM users WHERE id = $1
+            "#,
+        )
+        .bind(user_id)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(|e| {
+            if e.to_string().contains("not found") {
+                ApiError::not_found("User not found")
+            } else {
+                ApiError::internal_error(format!("Database error: {}", e))
+            }
+        })?;
+
+        Ok(user)
+    }
+
+    /// Get a user profile by ID (public view)
+    pub async fn get_user_profile(&self, user_id: Uuid) -> Result<UserProfile, ApiError> {
+        let user = self.get_user_by_id(user_id).await?;
+
+        let profile = UserProfile {
+            id: user.id,
+            username: user.username,
+            email: None, // Don't expose email in public profile
+            display_name: user.display_name,
+            avatar_url: user.avatar_url,
+            is_verified: user.is_verified,
+            created_at: user.created_at,
+            skill_score: user.reputation_score,
+            fair_play_score: user.reputation_score,
+            is_bad_actor: user.is_banned,
+        };
+
+        Ok(profile)
+    }
+
+    /// Get current user's full profile (authenticated view)
+    pub async fn get_current_user_profile(&self, user_id: Uuid) -> Result<User, ApiError> {
+        self.get_user_by_id(user_id).await
+    }
+
+    /// Update user profile
+    pub async fn update_user_profile(
+        &self,
+        user_id: Uuid,
+        username: Option<String>,
+        avatar_url: Option<String>,
+        display_name: Option<String>,
+        bio: Option<String>,
+    ) -> Result<User, ApiError> {
+        // Check if user exists
+        let _existing_user = self.get_user_by_id(user_id).await?;
+
+        // Build dynamic update query
+        let mut query = String::from("UPDATE users SET updated_at = $1");
+        let mut param_count = 1;
+        let mut params: Vec<String> = vec![Utc::now().to_string()];
+
+        if let Some(username) = &username {
+            param_count += 1;
+            query.push_str(&format!(", username = ${}", param_count));
+            params.push(username.clone());
+        }
+
+        if let Some(avatar_url) = &avatar_url {
+            param_count += 1;
+            query.push_str(&format!(", avatar_url = ${}", param_count));
+            params.push(avatar_url.clone());
+        }
+
+        if let Some(display_name) = &display_name {
+            param_count += 1;
+            query.push_str(&format!(", display_name = ${}", param_count));
+            params.push(display_name.clone());
+        }
+
+        if let Some(bio) = &bio {
+            param_count += 1;
+            query.push_str(&format!(", bio = ${}", param_count));
+            params.push(bio.clone());
+        }
+
+        param_count += 1;
+        query.push_str(&format!(" WHERE id = ${} RETURNING *", param_count));
+        params.push(user_id.to_string());
+
+        let mut query_builder = sqlx::query_as::<_, User>(&query);
+        for (i, param) in params.iter().enumerate() {
+            query_builder = query_builder.bind(param);
+        }
+
+        let updated_user = query_builder.fetch_one(&self.pool).await.map_err(|e| {
+            ApiError::internal_error(format!("Failed to update user: {}", e))
+        })?;
+
+        Ok(updated_user)
+    }
+
+    /// Get user stats including win/loss record and Elo history
+    pub async fn get_user_stats(&self, user_id: Uuid) -> Result<UserStats, ApiError> {
+        // Get user ELO data
+        let elo_data = sqlx::query_as::<_, UserElo>(
+            r#"
+            SELECT * FROM user_elo WHERE user_id = $1
+            "#,
+        )
+        .bind(user_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        // Get ELO history
+        let elo_history = sqlx::query_as::<_, EloHistory>(
+            r#"
+            SELECT * FROM elo_history 
+            WHERE user_id = $1 
+            ORDER BY created_at DESC 
+            LIMIT 50
+            "#,
+        )
+        .bind(user_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        let stats = if let Some(elo) = elo_data {
+            UserStats {
+                user_id,
+                current_rating: elo.current_rating,
+                peak_rating: elo.peak_rating,
+                games_played: elo.games_played,
+                wins: elo.wins,
+                losses: elo.losses,
+                draws: elo.draws,
+                win_rate: if elo.games_played > 0 {
+                    (elo.wins as f64 / elo.games_played as f64) * 100.0
+                } else {
+                    0.0
+                },
+                win_streak: elo.win_streak,
+                loss_streak: elo.loss_streak,
+                elo_history,
+            }
+        } else {
+            // Return default stats if no ELO data exists
+            UserStats {
+                user_id,
+                current_rating: 1000, // Default starting rating
+                peak_rating: 1000,
+                games_played: 0,
+                wins: 0,
+                losses: 0,
+                draws: 0,
+                win_rate: 0.0,
+                win_streak: 0,
+                loss_streak: 0,
+                elo_history: vec![],
+            }
+        };
+
+        Ok(stats)
+    }
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct UserStats {
+    pub user_id: Uuid,
+    pub current_rating: i32,
+    pub peak_rating: i32,
+    pub games_played: i32,
+    pub wins: i32,
+    pub losses: i32,
+    pub draws: i32,
+    pub win_rate: f64,
+    pub win_streak: i32,
+    pub loss_streak: i32,
+    pub elo_history: Vec<EloHistory>,
+}


### PR DESCRIPTION
## Issue Reference
Fixes #445 - [BACKEND] - No user profile or account management endpoints

## Summary
This PR implements user profile and account management endpoints to address issue #445. The User model exists in src/models/user.rs but was never exposed via HTTP. This implementation provides the necessary endpoints for clients to fetch profiles, update usernames, change avatars, and view their own account details.

## Implementation Comparison

### Required Endpoints (from #445)
- GET /api/users/{id} — public profile
- GET /api/users/me — authenticated user's own profile  
- PUT /api/users/me — update profile (username, avatar)
- GET /api/users/{id}/stats — win/loss record, Elo history

### Implementation Details

**New Files Created:**
1. src/service/user_service.rs (199 lines)
   - UserService with methods for user profile management
   - Database queries for user operations
   - Support for partial profile updates
   - User stats aggregation with win/loss records and Elo history

2. src/http/users.rs (125 lines)
   - HTTP handlers for user endpoints
   - Request/response DTOs
   - Authentication middleware integration
   - Unit tests for request validation

**Modified Files:**
1. src/service/mod.rs - Added user_service module export
2. src/http/mod.rs - Added users module
3. src/main.rs - Registered user routes under /api/users scope

### API Endpoints Implemented

#### GET /api/users/{id} - Public User Profile
- Returns public profile information for any user
- Excludes sensitive data (email, phone)
- Includes: id, username, display_name, avatar_url, is_verified, created_at, skill_score, fair_play_score

#### GET /api/users/me - Current User Profile  
- Returns full user profile for authenticated user
- Requires JWT authentication via middleware
- Returns all user fields including sensitive data

#### PUT /api/users/me - Update Profile
- Updates authenticated user's profile
- Supports partial updates (only provided fields are updated)
- Accepts: username, avatar_url, display_name, bio
- Returns updated user object
- Enhancement: Added display_name and bio beyond the basic username/avatar requirement

#### GET /api/users/{id}/stats - User Statistics
- Returns comprehensive user statistics
- Includes: current_rating, peak_rating, games_played, wins, losses, draws
- Calculates win_rate percentage
- Includes win_streak and loss_streak
- Returns recent Elo history (last 50 matches)
- Defaults to starting rating (1000) if no matches played

## Code Quality
- Follows existing codebase patterns and conventions
- Proper error handling with ApiError
- Authentication middleware integration for protected endpoints
- Database queries using sqlx with parameter binding
- Unit tests included for request validation
- Consistent JSON response format with success and data fields

## Testing Considerations
The implementation includes basic unit tests for request validation. Additional testing should include:
- Integration tests with actual database
- Authentication/authorization testing
- Edge cases (non-existent users, invalid UUIDs)
- Performance testing for stats endpoint

## Breaking Changes
None - this adds new functionality without modifying existing endpoints

## Migration Notes
No database migrations required - uses existing tables (users, user_elo, elo_history)

Generated with Devin (https://cli.devin.ai/docs)
