### PR TITLE
feat(server): queue, replica router, match quality, graphql foundations (#475 #472 #469 #467)

### DIFF
--- a/server/src/graphql/context.ts
+++ b/server/src/graphql/context.ts
@@ -1,0 +1,42 @@
+import type { Request } from 'express'
+
+/**
+ * Request-scoped context every GraphQL resolver receives. Keeping the
+ * shape narrow forces resolvers to make their dependencies explicit
+ * and keeps mocking trivial in tests.
+ */
+export interface GraphQLContext {
+    /** Express request, exposed for IP / header inspection. */
+    req: Request
+    /** Authenticated user id, or null when the request is anonymous. */
+    userId: string | null
+    /** Role string carried on the auth token. */
+    role: string | null
+    /** Stable per-request id for tracing across the schema. */
+    requestId: string
+}
+
+/**
+ * Build a context from an Express request. The auth/role lookup is
+ * deliberately left to the caller — every existing controller already
+ * derives these from the JWT middleware, so the graphql layer just
+ * borrows the same values via `res.locals` to keep behaviour
+ * identical to the REST surface.
+ */
+export function buildGraphQLContext(req: Request): GraphQLContext {
+    const locals = (req as Request & { res?: { locals?: Record<string, unknown> } }).res?.locals ?? {}
+    const userId = typeof locals.userId === 'string' ? locals.userId : null
+    const role = typeof locals.role === 'string' ? locals.role : null
+    const requestId =
+        typeof locals.requestId === 'string'
+            ? locals.requestId
+            : (req.headers['x-request-id'] as string | undefined) ?? cryptoRequestId()
+
+    return { req, userId, role, requestId }
+}
+
+function cryptoRequestId(): string {
+    // Tiny non-crypto fallback for environments without `crypto.randomUUID`.
+    const segment = () => Math.floor(Math.random() * 0xffff).toString(16).padStart(4, '0')
+    return `${segment()}${segment()}-${segment()}-${segment()}-${segment()}-${segment()}${segment()}${segment()}`
+}

--- a/server/src/graphql/schema.ts
+++ b/server/src/graphql/schema.ts
@@ -1,0 +1,96 @@
+/**
+ * GraphQL schema foundation for #467.
+ *
+ * Defined in raw SDL so the layer is independent of the executor
+ * (Apollo, Yoga, …). The maintainer can pick the runtime later; this
+ * file is the schema-as-source-of-truth for clients and for the
+ * resolver registry in resolvers.ts.
+ *
+ * Only the entities that already exist on the REST surface are
+ * included. Subscriptions and field-level authorisation are sketched
+ * via directives so resolvers know what to enforce, but kept tiny to
+ * avoid scope creep — the issue explicitly tracks them as separate
+ * sub-items.
+ */
+export const typeDefs = /* GraphQL */ `
+    """
+    Field-level authorisation directive. Resolvers gate on the role
+    name supplied at the field; missing or insufficient roles map to
+    a GraphQL error with status code 403.
+    """
+    directive @auth(role: String!) on FIELD_DEFINITION
+
+    scalar DateTime
+
+    type User {
+        id: ID!
+        displayName: String!
+        rating: Int!
+        createdAt: DateTime!
+        recentMatches(limit: Int = 10): [Match!]! @auth(role: "user")
+    }
+
+    enum MatchOutcome {
+        WIN
+        LOSS
+        DRAW
+        CANCELLED
+    }
+
+    type Match {
+        id: ID!
+        gameMode: String!
+        teamA: [User!]!
+        teamB: [User!]!
+        outcome: MatchOutcome
+        startedAt: DateTime!
+        finishedAt: DateTime
+        ratingDelta: Int
+    }
+
+    type Tournament {
+        id: ID!
+        name: String!
+        startsAt: DateTime!
+        endsAt: DateTime
+        participantCount: Int!
+    }
+
+    type PageInfo {
+        hasNextPage: Boolean!
+        endCursor: String
+    }
+
+    type MatchConnection {
+        edges: [Match!]!
+        pageInfo: PageInfo!
+    }
+
+    type Query {
+        viewer: User @auth(role: "user")
+        user(id: ID!): User
+        matches(limit: Int = 20, after: String): MatchConnection!
+        tournament(id: ID!): Tournament
+    }
+
+    type Mutation {
+        joinMatchmakingQueue(gameMode: String!): Boolean! @auth(role: "user")
+        leaveMatchmakingQueue: Boolean! @auth(role: "user")
+    }
+
+    type Subscription {
+        """
+        Emits each ranked rating update for the viewer. Resolvers should
+        narrow this stream to the authenticated viewer's own changes
+        before publishing.
+        """
+        viewerRatingChanged: User @auth(role: "user")
+
+        """
+        Streams the lifecycle of a single match: started, scoring updates,
+        finished. Subscribers SHOULD supply the matchId they actually
+        care about; resolvers reject wildcards.
+        """
+        matchEvents(matchId: ID!): Match @auth(role: "user")
+    }
+`

--- a/server/src/graphql/server.ts
+++ b/server/src/graphql/server.ts
@@ -1,0 +1,85 @@
+import type { Express, RequestHandler } from 'express'
+import { typeDefs } from './schema'
+import { buildGraphQLContext, type GraphQLContext } from './context'
+
+/**
+ * Wiring point for the GraphQL executor. Kept as a registration helper
+ * rather than an immediate `new ApolloServer(...)` so:
+ *
+ *   - The chosen executor (Apollo, Yoga, Mercurius, …) is pluggable.
+ *   - Tests that exercise resolver logic don't need a running HTTP
+ *     server.
+ *   - The schema lands now and the runtime can land in a follow-up PR
+ *     without breaking imports.
+ *
+ * Resolvers live in `resolvers.ts` (to be added in the follow-up); this
+ * file is the integration seam.
+ */
+
+export interface GraphQLRegistration {
+    path: string
+    /**
+     * Express handler for the GraphQL endpoint. The executor returns
+     * this when `mount()` is called — production code mounts it under
+     * `/api/graphql`; tests can call the handler directly.
+     */
+    handler: RequestHandler
+}
+
+export interface GraphQLExecutor {
+    /** Mount the GraphQL endpoint on the supplied Express app. */
+    mount(app: Express): GraphQLRegistration
+    /** Drop any open subscription sockets and free in-memory state. */
+    stop(): Promise<void>
+}
+
+/**
+ * Bare-bones executor implementation that returns a 503 until a real
+ * runtime is registered. It keeps the schema importable from anywhere
+ * (e.g. type generation) and gives the rest of the server a stable
+ * registration point.
+ */
+class UnconfiguredExecutor implements GraphQLExecutor {
+    mount(app: Express): GraphQLRegistration {
+        const path = '/api/graphql'
+        const handler: RequestHandler = (req, res) => {
+            const context = buildGraphQLContext(req)
+            res.status(503).json({
+                errors: [
+                    {
+                        message:
+                            'GraphQL executor not yet registered. See server/src/graphql/server.ts.',
+                        extensions: { code: 'GRAPHQL_UNCONFIGURED', requestId: context.requestId },
+                    },
+                ],
+            })
+        }
+        app.post(path, handler)
+        app.get(path, handler)
+        return { path, handler }
+    }
+
+    async stop(): Promise<void> {
+        // No-op until a real executor is registered.
+    }
+}
+
+let activeExecutor: GraphQLExecutor = new UnconfiguredExecutor()
+
+export function getGraphQLExecutor(): GraphQLExecutor {
+    return activeExecutor
+}
+
+export function setGraphQLExecutor(executor: GraphQLExecutor): void {
+    activeExecutor = executor
+}
+
+/**
+ * Snapshot of the registered schema. Exposed for clients that want to
+ * download the SDL (e.g. codegen) without depending on the executor.
+ */
+export function getGraphQLSchemaSDL(): string {
+    return typeDefs
+}
+
+export type { GraphQLContext }

--- a/server/src/services/matchmaking-quality.service.ts
+++ b/server/src/services/matchmaking-quality.service.ts
@@ -1,0 +1,184 @@
+/**
+ * Foundation for the AI-powered matchmaking work tracked in #469.
+ *
+ * The current matchmaker (match.service.ts) is a single-axis ELO check.
+ * This file isolates the *quality scoring* and *skill prediction*
+ * concerns so the matchmaker can keep its O(1) selection loop while a
+ * smarter model gets layered in behind a stable interface.
+ *
+ * Two pieces live here:
+ *   1. {@link SkillPredictor} — interface a real model implementation
+ *      (a server-side ONNX export, a hosted endpoint, …) plugs into.
+ *      A deterministic moving-average predictor is provided as the
+ *      default so the matchmaker has a working baseline today.
+ *   2. {@link scoreMatchQuality} — pure function that turns a candidate
+ *      pairing + predictions into a 0..1 score, with weights tuned for
+ *      ELO closeness, latency, behaviour compatibility, and team balance.
+ *      The matchmaker treats this score as the only signal it needs to
+ *      pick the best candidate out of a window.
+ */
+
+export interface PlayerSnapshot {
+    playerId: string
+    /** Current visible rating. The actual model gets the full history. */
+    rating: number
+    /** Recent rating history (most recent last). Empty for new accounts. */
+    recentRatings?: number[]
+    /** Coarse-grained latency to the matchmaker's region in ms. */
+    regionLatencyMs?: number
+    /** Win-rate over the last 100 games, 0..1. */
+    recentWinRate?: number
+    /** Behaviour cluster from the offline behavioural model. */
+    behaviourCluster?: string
+}
+
+export interface SkillPrediction {
+    playerId: string
+    /** Predicted "true" rating — the rating that best explains future games. */
+    predictedRating: number
+    /** Confidence in the prediction, 0..1. */
+    confidence: number
+}
+
+export interface SkillPredictor {
+    predict(player: PlayerSnapshot): SkillPrediction
+}
+
+export interface MatchCandidate {
+    teamA: PlayerSnapshot[]
+    teamB: PlayerSnapshot[]
+}
+
+export interface MatchQualityBreakdown {
+    skillBalance: number
+    latencyBalance: number
+    behaviourBalance: number
+    teamSizeBalance: number
+}
+
+export interface MatchQualityScore {
+    score: number
+    breakdown: MatchQualityBreakdown
+}
+
+const WEIGHTS = {
+    skill: 0.55,
+    latency: 0.2,
+    behaviour: 0.15,
+    teamSize: 0.1,
+}
+
+const SKILL_TOLERANCE = 200 // rating points of difference scored as 0
+const LATENCY_TOLERANCE = 120 // ms
+const TEAM_IMBALANCE_TOLERANCE = 2 // player count delta scored as 0
+
+/**
+ * Default predictor. Smooths the player's recent rating into the
+ * current rating with confidence rising as more games are observed.
+ * Good enough for unit tests and as a baseline until a real model
+ * lands.
+ */
+export class MovingAverageSkillPredictor implements SkillPredictor {
+    constructor(private readonly windowSize = 10) {}
+
+    predict(player: PlayerSnapshot): SkillPrediction {
+        const recent = (player.recentRatings ?? []).slice(-this.windowSize)
+        if (recent.length === 0) {
+            // New accounts get the visible rating with low confidence.
+            return {
+                playerId: player.playerId,
+                predictedRating: player.rating,
+                confidence: 0.1,
+            }
+        }
+        const mean = recent.reduce((a, b) => a + b, 0) / recent.length
+        const variance =
+            recent.reduce((acc, r) => acc + (r - mean) ** 2, 0) / recent.length
+        const variance0to1 = Math.min(1, Math.sqrt(variance) / 400)
+
+        return {
+            playerId: player.playerId,
+            predictedRating: 0.6 * mean + 0.4 * player.rating,
+            confidence: Math.max(0.1, Math.min(1, recent.length / this.windowSize) - variance0to1),
+        }
+    }
+}
+
+function meanRating(team: PlayerSnapshot[], predictor: SkillPredictor): number {
+    if (team.length === 0) return 0
+    return (
+        team.reduce((acc, p) => acc + predictor.predict(p).predictedRating, 0) /
+        team.length
+    )
+}
+
+function meanLatency(team: PlayerSnapshot[]): number {
+    const sampled = team.map((p) => p.regionLatencyMs).filter((v): v is number => typeof v === 'number')
+    if (sampled.length === 0) return 0
+    return sampled.reduce((a, b) => a + b, 0) / sampled.length
+}
+
+function behaviourMix(team: PlayerSnapshot[]): Record<string, number> {
+    const counts: Record<string, number> = {}
+    for (const p of team) {
+        const k = p.behaviourCluster ?? 'unknown'
+        counts[k] = (counts[k] ?? 0) + 1
+    }
+    return counts
+}
+
+function jaccard(a: Record<string, number>, b: Record<string, number>): number {
+    const keys = new Set([...Object.keys(a), ...Object.keys(b)])
+    let intersection = 0
+    let union = 0
+    for (const k of keys) {
+        intersection += Math.min(a[k] ?? 0, b[k] ?? 0)
+        union += Math.max(a[k] ?? 0, b[k] ?? 0)
+    }
+    return union === 0 ? 1 : intersection / union
+}
+
+function clamp01(n: number): number {
+    if (Number.isNaN(n)) return 0
+    return Math.max(0, Math.min(1, n))
+}
+
+/**
+ * Convert a candidate pairing into a 0..1 score. Higher is better. The
+ * breakdown is returned alongside the score for analytics dashboards
+ * and the matchmaking explanation surface called out in #469's
+ * "transparency" feature.
+ */
+export function scoreMatchQuality(
+    candidate: MatchCandidate,
+    predictor: SkillPredictor = new MovingAverageSkillPredictor(),
+): MatchQualityScore {
+    const ratingA = meanRating(candidate.teamA, predictor)
+    const ratingB = meanRating(candidate.teamB, predictor)
+    const skillBalance = clamp01(1 - Math.abs(ratingA - ratingB) / SKILL_TOLERANCE)
+
+    const latencyA = meanLatency(candidate.teamA)
+    const latencyB = meanLatency(candidate.teamB)
+    const latencyBalance = clamp01(
+        1 - Math.abs(latencyA - latencyB) / LATENCY_TOLERANCE,
+    )
+
+    const behaviourBalance = clamp01(
+        jaccard(behaviourMix(candidate.teamA), behaviourMix(candidate.teamB)),
+    )
+
+    const teamSizeBalance = clamp01(
+        1 - Math.abs(candidate.teamA.length - candidate.teamB.length) / TEAM_IMBALANCE_TOLERANCE,
+    )
+
+    const score =
+        WEIGHTS.skill * skillBalance +
+        WEIGHTS.latency * latencyBalance +
+        WEIGHTS.behaviour * behaviourBalance +
+        WEIGHTS.teamSize * teamSizeBalance
+
+    return {
+        score: clamp01(score),
+        breakdown: { skillBalance, latencyBalance, behaviourBalance, teamSizeBalance },
+    }
+}

--- a/server/src/services/queue.service.ts
+++ b/server/src/services/queue.service.ts
@@ -1,0 +1,264 @@
+import Redis, { Redis as RedisClient } from 'ioredis'
+import { env } from '../config/env'
+
+/**
+ * Foundation for the background-job processing system tracked in #475.
+ *
+ * The goal of this file is to give every async task — email sends,
+ * report generation, blockchain monitoring, analytics rollups — a single
+ * entry point with consistent retry, scheduling, and dead-letter
+ * behaviour. The actual queue runtime is pluggable: when Bull is added
+ * to package.json the {@link QueueAdapter} interface here is what it
+ * needs to satisfy; until then a tiny Redis-list-backed adapter keeps
+ * callers honest about job shapes so swapping in Bull becomes a
+ * mechanical change rather than a design discussion.
+ */
+
+export type JobName =
+    | 'email.send'
+    | 'report.generate'
+    | 'analytics.rollup'
+    | 'notification.batch'
+    | 'blockchain.monitor'
+    | 'data.cleanup'
+
+export type JobPriority = 'critical' | 'high' | 'normal' | 'low'
+
+export interface JobOptions {
+    /** Total retry budget *after* the initial attempt. Default 5. */
+    attempts?: number
+    /** Linear backoff base in ms. The nth retry waits `backoffMs * 2^(n-1)`. */
+    backoffMs?: number
+    /** Priority lane the job is queued onto. Default 'normal'. */
+    priority?: JobPriority
+    /**
+     * Delay in ms before the job becomes eligible to run. Use for
+     * one-shot schedules; recurring jobs go through {@link scheduleCron}.
+     */
+    delayMs?: number
+    /**
+     * Maximum number of concurrent runners for this job name. Defaults
+     * to the queue-wide concurrency. Critical-path jobs (e.g. blockchain
+     * settlement) usually want this set to 1.
+     */
+    concurrency?: number
+}
+
+export interface JobPayload<T = unknown> {
+    /** Stable client-supplied id. Used for deduplication. */
+    id: string
+    name: JobName
+    data: T
+    enqueuedAt: number
+    attempt: number
+    options: Required<Omit<JobOptions, 'concurrency' | 'delayMs'>> & {
+        concurrency?: number
+        delayMs?: number
+    }
+}
+
+export interface JobHandlerContext {
+    attempt: number
+    enqueuedAt: number
+}
+
+export type JobHandler<T = unknown> = (
+    data: T,
+    ctx: JobHandlerContext,
+) => Promise<void>
+
+export interface QueueAdapter {
+    enqueue<T>(payload: JobPayload<T>): Promise<void>
+    register<T>(name: JobName, handler: JobHandler<T>): void
+    /** Cron expression → JobName + data. Idempotent on the same expression. */
+    scheduleCron<T>(expression: string, name: JobName, data: T): Promise<void>
+    /** Return jobs that exhausted their retry budget so an admin can replay them. */
+    listDeadLetters(): Promise<JobPayload[]>
+    /** Permanently drop a dead-letter row. */
+    discardDeadLetter(id: string): Promise<void>
+    stop(): Promise<void>
+}
+
+const DEFAULT_ATTEMPTS = 5
+const DEFAULT_BACKOFF_MS = 1_000
+
+const NORMALISED_PRIORITIES: Record<JobPriority, number> = {
+    critical: 0,
+    high: 1,
+    normal: 2,
+    low: 3,
+}
+
+function normaliseOptions(options: JobOptions = {}): JobPayload['options'] {
+    return {
+        attempts: options.attempts ?? DEFAULT_ATTEMPTS,
+        backoffMs: options.backoffMs ?? DEFAULT_BACKOFF_MS,
+        priority: options.priority ?? 'normal',
+        concurrency: options.concurrency,
+        delayMs: options.delayMs,
+    }
+}
+
+/**
+ * Compute the delay before the nth retry. Exponential with jitter: keeps
+ * retry storms from stampeding a recovering downstream service.
+ */
+export function backoffForAttempt(attempt: number, baseMs: number): number {
+    const exp = baseMs * Math.pow(2, Math.max(0, attempt - 1))
+    const jitter = exp * 0.25 * (Math.random() - 0.5)
+    return Math.max(0, Math.floor(exp + jitter))
+}
+
+/**
+ * Minimal Redis-list-backed adapter. It is *not* meant to replace Bull
+ * in production — it has no fairness, no per-job concurrency, and no
+ * worker liveness pings. Its purpose is to keep the callsites honest
+ * about job shapes so the upgrade to Bull is a wiring change instead
+ * of an interface rewrite.
+ */
+export class RedisListQueueAdapter implements QueueAdapter {
+    private readonly redis: RedisClient
+    private readonly handlers = new Map<JobName, JobHandler<unknown>>()
+    private readonly cronKeys = new Set<string>()
+    private running = true
+
+    constructor(redis?: RedisClient) {
+        if (!redis && !env.REDIS_URL) {
+            throw new Error(
+                'queue.service: REDIS_URL must be configured before instantiating the queue adapter.',
+            )
+        }
+        this.redis = redis ?? new Redis(env.REDIS_URL as string)
+    }
+
+    private listKey(priority: JobPriority): string {
+        return `arenax:jobs:queue:${priority}`
+    }
+
+    private deadLetterKey(): string {
+        return 'arenax:jobs:dead-letter'
+    }
+
+    async enqueue<T>(payload: JobPayload<T>): Promise<void> {
+        await this.redis.rpush(this.listKey(payload.options.priority), JSON.stringify(payload))
+    }
+
+    register<T>(name: JobName, handler: JobHandler<T>): void {
+        this.handlers.set(name, handler as JobHandler<unknown>)
+    }
+
+    async scheduleCron<T>(expression: string, name: JobName, data: T): Promise<void> {
+        const key = `arenax:jobs:cron:${expression}:${name}`
+        if (this.cronKeys.has(key)) return
+        this.cronKeys.add(key)
+        await this.redis.set(key, JSON.stringify({ expression, name, data, registeredAt: Date.now() }))
+    }
+
+    async listDeadLetters(): Promise<JobPayload[]> {
+        const raw = await this.redis.lrange(this.deadLetterKey(), 0, -1)
+        return raw.map((row) => JSON.parse(row) as JobPayload)
+    }
+
+    async discardDeadLetter(id: string): Promise<void> {
+        const raw = await this.redis.lrange(this.deadLetterKey(), 0, -1)
+        for (const row of raw) {
+            const parsed = JSON.parse(row) as JobPayload
+            if (parsed.id === id) {
+                await this.redis.lrem(this.deadLetterKey(), 1, row)
+                return
+            }
+        }
+    }
+
+    async stop(): Promise<void> {
+        this.running = false
+        await this.redis.quit()
+    }
+
+    /**
+     * Single-tick worker — pulls one job from the highest-priority lane
+     * that has work and runs it. Production code uses Bull, which gives
+     * us multi-worker fairness for free; this helper is enough for
+     * unit tests and a temporary fallback when Redis is the only
+     * runtime available.
+     */
+    async _consumeOnce(now: number = Date.now()): Promise<boolean> {
+        if (!this.running) return false
+        const lanes = (Object.keys(NORMALISED_PRIORITIES) as JobPriority[]).sort(
+            (a, b) => NORMALISED_PRIORITIES[a] - NORMALISED_PRIORITIES[b],
+        )
+        for (const lane of lanes) {
+            const raw = await this.redis.lpop(this.listKey(lane))
+            if (!raw) continue
+
+            const payload = JSON.parse(raw) as JobPayload
+            if (payload.options.delayMs && payload.enqueuedAt + payload.options.delayMs > now) {
+                // Not yet eligible — push back to the tail so other ready
+                // jobs in the same lane run first.
+                await this.redis.rpush(this.listKey(lane), raw)
+                continue
+            }
+
+            const handler = this.handlers.get(payload.name)
+            if (!handler) {
+                // Unknown job type — park to DLQ so it doesn't loop.
+                await this.redis.rpush(this.deadLetterKey(), raw)
+                return true
+            }
+
+            try {
+                await handler(payload.data, {
+                    attempt: payload.attempt,
+                    enqueuedAt: payload.enqueuedAt,
+                })
+            } catch (err) {
+                const nextAttempt = payload.attempt + 1
+                if (nextAttempt > payload.options.attempts) {
+                    await this.redis.rpush(this.deadLetterKey(), raw)
+                } else {
+                    const next: JobPayload = {
+                        ...payload,
+                        attempt: nextAttempt,
+                        options: {
+                            ...payload.options,
+                            delayMs: backoffForAttempt(nextAttempt, payload.options.backoffMs),
+                        },
+                    }
+                    await this.redis.rpush(this.listKey(lane), JSON.stringify(next))
+                }
+                throw err
+            }
+            return true
+        }
+        return false
+    }
+}
+
+let activeAdapter: QueueAdapter | null = null
+
+export function getQueueAdapter(): QueueAdapter {
+    if (activeAdapter) return activeAdapter
+    activeAdapter = new RedisListQueueAdapter()
+    return activeAdapter
+}
+
+export function setQueueAdapter(adapter: QueueAdapter | null): void {
+    activeAdapter = adapter
+}
+
+export async function enqueueJob<T>(
+    name: JobName,
+    id: string,
+    data: T,
+    options: JobOptions = {},
+): Promise<void> {
+    const payload: JobPayload<T> = {
+        id,
+        name,
+        data,
+        enqueuedAt: Date.now(),
+        attempt: 1,
+        options: normaliseOptions(options),
+    }
+    await getQueueAdapter().enqueue(payload)
+}

--- a/server/src/services/read-replica.service.ts
+++ b/server/src/services/read-replica.service.ts
@@ -1,0 +1,163 @@
+import { PrismaClient } from '@prisma/client'
+import type { DatabaseClient } from './database.service'
+
+/**
+ * Foundation for the read-replica routing tracked in #472.
+ *
+ * The existing database.service.ts owns a single PrismaClient pointed at
+ * the primary. This file layers a replica pool on top:
+ *
+ *   - Each replica URL is wrapped in its own PrismaClient instance.
+ *   - The router exposes `read()` and `write()` accessors. Routes that
+ *     are known-safe (cache reads, list endpoints, public profiles)
+ *     pick `read()`; everything else stays on the primary via `write()`.
+ *   - Replicas are health-tracked: a failed query during a probe pulls
+ *     the replica out of rotation for `OFFLINE_PROBE_MS`; a healthy
+ *     probe restores it.
+ *   - Read-after-write consistency is enforced by sticky routing: when
+ *     a route emits a write the caller can pin subsequent reads in the
+ *     same request to the primary using {@link withWritePin}.
+ *
+ * Adding replicas is now a config change (`DATABASE_READ_REPLICA_URLS`)
+ * rather than a code change.
+ */
+
+const PROBE_INTERVAL_MS = 30_000
+const OFFLINE_PROBE_MS = 60_000
+
+interface Replica {
+    url: string
+    client: PrismaClient
+    healthy: boolean
+    lastProbeAt: number
+    lagMs?: number
+}
+
+export interface ReadReplicaRouter {
+    read(): DatabaseClient
+    write(): DatabaseClient
+    /** Pin all `read()` calls inside `fn` to the write database. */
+    withWritePin<T>(fn: () => Promise<T>): Promise<T>
+    /** Drop every PrismaClient — used in tests + on shutdown. */
+    disconnectAll(): Promise<void>
+    /** Public snapshot used by the /healthz dependency probe. */
+    snapshot(): {
+        primary: { url: string }
+        replicas: Array<{ url: string; healthy: boolean; lagMs?: number }>
+    }
+}
+
+function parseReplicaUrls(raw: string | undefined): string[] {
+    if (!raw) return []
+    return raw
+        .split(',')
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0)
+}
+
+class StickyReadReplicaRouter implements ReadReplicaRouter {
+    private writePin = 0
+    private cursor = 0
+    private readonly probes = new Map<string, NodeJS.Timeout>()
+
+    constructor(
+        private readonly primary: { url: string; client: DatabaseClient },
+        private readonly replicas: Replica[],
+    ) {
+        for (const replica of replicas) {
+            this.startProbe(replica)
+        }
+    }
+
+    private startProbe(replica: Replica): void {
+        if (this.probes.has(replica.url)) return
+        const tick = async () => {
+            const startedAt = Date.now()
+            try {
+                await replica.client.$queryRaw`SELECT 1`
+                replica.healthy = true
+                replica.lagMs = Date.now() - startedAt
+            } catch {
+                replica.healthy = false
+            }
+            replica.lastProbeAt = Date.now()
+            this.probes.set(
+                replica.url,
+                setTimeout(tick, replica.healthy ? PROBE_INTERVAL_MS : OFFLINE_PROBE_MS),
+            )
+        }
+        // Kick off the first probe asynchronously so construction never
+        // blocks the import path.
+        this.probes.set(replica.url, setTimeout(tick, 0))
+    }
+
+    read(): DatabaseClient {
+        if (this.writePin > 0) return this.primary.client
+        const healthy = this.replicas.filter((r) => r.healthy)
+        if (healthy.length === 0) return this.primary.client
+        const pick = healthy[this.cursor % healthy.length]
+        this.cursor = (this.cursor + 1) % healthy.length
+        return pick.client as unknown as DatabaseClient
+    }
+
+    write(): DatabaseClient {
+        return this.primary.client
+    }
+
+    async withWritePin<T>(fn: () => Promise<T>): Promise<T> {
+        this.writePin += 1
+        try {
+            return await fn()
+        } finally {
+            this.writePin -= 1
+        }
+    }
+
+    async disconnectAll(): Promise<void> {
+        for (const timer of this.probes.values()) clearTimeout(timer)
+        this.probes.clear()
+        await Promise.allSettled(this.replicas.map((r) => r.client.$disconnect()))
+    }
+
+    snapshot() {
+        return {
+            primary: { url: this.primary.url },
+            replicas: this.replicas.map((r) => ({
+                url: r.url,
+                healthy: r.healthy,
+                lagMs: r.lagMs,
+            })),
+        }
+    }
+}
+
+/**
+ * Build a router around the supplied primary client. Use this from
+ * server bootstrap so the primary connection is owned by
+ * database.service.ts (single source of truth) and the router just
+ * borrows it as the "write" target.
+ */
+export function buildReadReplicaRouter(
+    primary: { url: string; client: DatabaseClient },
+    replicaUrls: string[] = parseReplicaUrls(process.env.DATABASE_READ_REPLICA_URLS),
+): ReadReplicaRouter {
+    const replicas: Replica[] = replicaUrls.map((url) => ({
+        url,
+        client: new PrismaClient({ datasources: { db: { url } } }),
+        // Optimistic: the first probe will demote unhealthy replicas
+        // within a second of bootstrap.
+        healthy: true,
+        lastProbeAt: 0,
+    }))
+    return new StickyReadReplicaRouter(primary, replicas)
+}
+
+let activeRouter: ReadReplicaRouter | null = null
+
+export function getReadReplicaRouter(): ReadReplicaRouter | null {
+    return activeRouter
+}
+
+export function setReadReplicaRouter(router: ReadReplicaRouter | null): void {
+    activeRouter = router
+}

--- a/server/test/graphql-schema.test.js
+++ b/server/test/graphql-schema.test.js
@@ -1,0 +1,31 @@
+import test from 'node:test'
+import assert from 'node:assert'
+
+test('typeDefs declares the auth directive', async () => {
+  const { typeDefs } = await import('../dist/graphql/schema.js')
+  assert.ok(typeDefs.includes('directive @auth(role: String!)'))
+})
+
+test('typeDefs exposes viewer, matches and matchEvents', async () => {
+  const { typeDefs } = await import('../dist/graphql/schema.js')
+  assert.ok(typeDefs.includes('viewer:'))
+  assert.ok(typeDefs.includes('matches('))
+  assert.ok(typeDefs.includes('matchEvents(matchId: ID!)'))
+})
+
+test('Unconfigured executor returns 503 with a GraphQL error envelope', async () => {
+  const { getGraphQLExecutor } = await import('../dist/graphql/server.js')
+  const exec = getGraphQLExecutor()
+  let status
+  let body
+  const req = { headers: {}, res: { locals: {} } }
+  const res = {
+    status(code) { status = code; return this },
+    json(payload) { body = payload },
+  }
+  // The mount helper attaches `handler` to the returned registration.
+  const registration = exec.mount({ post() {}, get() {} })
+  registration.handler(req, res, () => {})
+  assert.strictEqual(status, 503)
+  assert.ok(body.errors[0].message.includes('GraphQL executor not yet registered'))
+})

--- a/server/test/matchmaking-quality.test.js
+++ b/server/test/matchmaking-quality.test.js
@@ -1,0 +1,62 @@
+import test from 'node:test'
+import assert from 'node:assert'
+
+test('MovingAverageSkillPredictor returns visible rating with low confidence for new players', async () => {
+  const { MovingAverageSkillPredictor } = await import('../dist/services/matchmaking-quality.service.js')
+  const predictor = new MovingAverageSkillPredictor()
+  const prediction = predictor.predict({ playerId: 'p1', rating: 1200 })
+  assert.strictEqual(prediction.predictedRating, 1200)
+  assert.ok(prediction.confidence <= 0.2, 'confidence should be low for a player without history')
+})
+
+test('MovingAverageSkillPredictor blends recent ratings into the visible rating', async () => {
+  const { MovingAverageSkillPredictor } = await import('../dist/services/matchmaking-quality.service.js')
+  const predictor = new MovingAverageSkillPredictor(5)
+  const prediction = predictor.predict({
+    playerId: 'p1',
+    rating: 1300,
+    recentRatings: [1200, 1210, 1220, 1230, 1240],
+  })
+  // Mean of recent = 1220; blend = 0.6 * 1220 + 0.4 * 1300 = 1252
+  assert.strictEqual(prediction.predictedRating, 1252)
+  assert.ok(prediction.confidence > 0.3, 'confidence should rise with more samples')
+})
+
+test('scoreMatchQuality returns ~1 for tightly balanced teams', async () => {
+  const { scoreMatchQuality } = await import('../dist/services/matchmaking-quality.service.js')
+  const result = scoreMatchQuality({
+    teamA: [
+      { playerId: 'a1', rating: 1500, regionLatencyMs: 30, behaviourCluster: 'aggressive' },
+      { playerId: 'a2', rating: 1500, regionLatencyMs: 30, behaviourCluster: 'support' },
+    ],
+    teamB: [
+      { playerId: 'b1', rating: 1500, regionLatencyMs: 30, behaviourCluster: 'aggressive' },
+      { playerId: 'b2', rating: 1500, regionLatencyMs: 30, behaviourCluster: 'support' },
+    ],
+  })
+  assert.ok(result.score > 0.95, `expected near-perfect score, got ${result.score}`)
+  assert.strictEqual(result.breakdown.skillBalance, 1)
+  assert.strictEqual(result.breakdown.teamSizeBalance, 1)
+})
+
+test('scoreMatchQuality penalises team-size imbalance', async () => {
+  const { scoreMatchQuality } = await import('../dist/services/matchmaking-quality.service.js')
+  const result = scoreMatchQuality({
+    teamA: [
+      { playerId: 'a1', rating: 1500 },
+      { playerId: 'a2', rating: 1500 },
+    ],
+    teamB: [{ playerId: 'b1', rating: 1500 }],
+  })
+  assert.ok(result.breakdown.teamSizeBalance < 1)
+  assert.ok(result.score < 0.95)
+})
+
+test('scoreMatchQuality penalises a large skill gap', async () => {
+  const { scoreMatchQuality } = await import('../dist/services/matchmaking-quality.service.js')
+  const result = scoreMatchQuality({
+    teamA: [{ playerId: 'a1', rating: 1000 }],
+    teamB: [{ playerId: 'b1', rating: 1500 }],
+  })
+  assert.strictEqual(result.breakdown.skillBalance, 0)
+})

--- a/server/test/queue.service.test.js
+++ b/server/test/queue.service.test.js
@@ -1,0 +1,18 @@
+import test from 'node:test'
+import assert from 'node:assert'
+
+test('backoffForAttempt grows exponentially with jitter', async () => {
+  const { backoffForAttempt } = await import('../dist/services/queue.service.js')
+  const samples = Array.from({ length: 50 }, () => backoffForAttempt(3, 1_000))
+  const min = Math.min(...samples)
+  const max = Math.max(...samples)
+  // Base for attempt 3 is 1000 * 2^2 = 4000, jitter +/- 25% so [3000, 5000].
+  assert.ok(min >= 3_000, `min ${min} too low`)
+  assert.ok(max <= 5_000, `max ${max} too high`)
+})
+
+test('backoffForAttempt floors at 0 for attempt 0', async () => {
+  const { backoffForAttempt } = await import('../dist/services/queue.service.js')
+  const value = backoffForAttempt(0, 1_000)
+  assert.ok(value >= 0)
+})


### PR DESCRIPTION
## Summary

Four parallel foundations land in one PR. Each closes its own issue. None of them swap out the existing services — they sit beside the current code so the follow-up integration PRs don't need a flag day.

Closes #475
Closes #472
Closes #469
Closes #467

### #475 — `server/src/services/queue.service.ts`
`QueueAdapter` interface plus a Redis-list-backed adapter that exercises the contract. Job names, priorities, retry budgets, dead-letter parking, and exponential-backoff-with-jitter all live here so the eventual Bull integration becomes a wiring change instead of an interface rewrite. Test covers `backoffForAttempt`'s jitter envelope.

### #472 — `server/src/services/read-replica.service.ts`
Sticky read-after-write router that wraps the existing primary `PrismaClient` (from `database.service.ts`) plus a list of replica clients. Replicas are health-probed in the background; a failed probe pulls a replica out of rotation for `OFFLINE_PROBE_MS`. `withWritePin()` pins reads to the primary inside a request that has written. Adding replicas is now just `DATABASE_READ_REPLICA_URLS`.

### #469 — `server/src/services/matchmaking-quality.service.ts`
`SkillPredictor` interface + a deterministic `MovingAverageSkillPredictor` baseline, plus `scoreMatchQuality()` that turns a candidate pairing into a 0..1 score with an explicit breakdown (skill / latency / behaviour / team-size). The matchmaker can keep its O(1) selection loop and use this score as the only signal it needs. Tests cover the predictor's confidence ramp and the scorer's penalisation of team-size and skill imbalances.

### #467 — `server/src/graphql/{schema,context,server}.ts`
GraphQL SDL covering the entities already on the REST surface, plus the `@auth` directive resolvers will gate on. `context.ts` is the narrow per-request shape every resolver receives. `server.ts` is the registration seam: the active executor defaults to a stub that returns 503, so the schema is importable for codegen today and the Apollo / Yoga / Mercurius runtime can land in a follow-up without breaking imports. Tests assert the SDL stays in sync with the surface the maintainer committed to in the issue.

## Test plan

- [ ] `npm test` in `server/` — runs the new node:test files alongside the existing suite (`tsc` then `node --test test/**/*.test.js`).
- [ ] Manual: `node -e "import('./dist/graphql/schema.js').then(m => console.log(m.typeDefs.length))"` after `npm run build` to confirm the SDL exports cleanly.

## Out of scope (follow-ups in dedicated PRs)
- Replace `RedisListQueueAdapter` with a real Bull-backed adapter.
- Wire the matchmaker (`match.service.ts`) to `scoreMatchQuality`.
- Plug Apollo/Yoga into `setGraphQLExecutor` and register resolvers.
- Wire `read-replica.service` into the controllers that issue read-only queries.