### PR TITLE
feat(server): secrets, readiness probes, api versioning foundations (#484 #483 #476)

### DIFF
--- a/server/src/middleware/api-version.middleware.ts
+++ b/server/src/middleware/api-version.middleware.ts
@@ -1,0 +1,161 @@
+import type { Request, Response, NextFunction, RequestHandler } from 'express'
+
+/**
+ * Foundation for the API versioning + deprecation strategy tracked in #476.
+ *
+ * Strategy: URL-segment versioning (`/api/v1/...`, `/api/v2/...`) with
+ * `Accept` header overrides for clients that want to pin an older
+ * version without changing URLs. URL was chosen over header-only
+ * versioning because every existing log line, CDN rule, and metric
+ * already keys on the URL; preserving that gives migration teams a
+ * cheap analytics signal.
+ *
+ * What this file owns:
+ *   - The shape of the version registry: which versions are live,
+ *     which are deprecated, when the sunset date is.
+ *   - The middleware that resolves a request's version from URL or
+ *     header, stashes it on `res.locals.apiVersion`, and adds the
+ *     `Deprecation` / `Sunset` response headers from RFC 8594 when
+ *     applicable.
+ *   - A small helper for routers that want to mount per-version
+ *     controllers without repeating the `/api/vN` prefix everywhere.
+ *
+ * Controller migration: existing routes stay on whichever path they
+ * have today. As they move under `/api/vN/…` they pick up the
+ * deprecation headers automatically — no per-controller changes.
+ */
+
+export type ApiVersionStatus = 'live' | 'deprecated' | 'sunset'
+
+export interface ApiVersionDescriptor {
+    name: string // "v1", "v2026-06"
+    status: ApiVersionStatus
+    /** ISO timestamp the version started accepting traffic. */
+    introducedAt: string
+    /** Set when status is `deprecated`. */
+    deprecatedAt?: string
+    /** Set when status is `deprecated`. RFC 8594 Sunset header. */
+    sunsetAt?: string
+    /** Optional URL to the migration guide. RFC 8594 Link header. */
+    migrationGuide?: string
+}
+
+export interface ApiVersionRegistry {
+    list(): ApiVersionDescriptor[]
+    /** Look up the version by name (case-insensitive). */
+    resolve(name: string): ApiVersionDescriptor | null
+    /** Default version when the URL doesn't include one. */
+    getDefault(): ApiVersionDescriptor
+}
+
+export class InMemoryApiVersionRegistry implements ApiVersionRegistry {
+    private readonly versions = new Map<string, ApiVersionDescriptor>()
+    private defaultVersion: ApiVersionDescriptor | null = null
+
+    register(version: ApiVersionDescriptor, options: { default?: boolean } = {}): void {
+        if (version.status === 'deprecated' && (!version.deprecatedAt || !version.sunsetAt)) {
+            throw new Error(
+                `api-version: "${version.name}" is deprecated but missing deprecatedAt/sunsetAt`,
+            )
+        }
+        this.versions.set(version.name.toLowerCase(), version)
+        if (options.default) {
+            this.defaultVersion = version
+        }
+    }
+
+    list(): ApiVersionDescriptor[] {
+        return Array.from(this.versions.values())
+    }
+
+    resolve(name: string): ApiVersionDescriptor | null {
+        return this.versions.get(name.toLowerCase()) ?? null
+    }
+
+    getDefault(): ApiVersionDescriptor {
+        if (!this.defaultVersion) {
+            throw new Error('api-version: no default version registered')
+        }
+        return this.defaultVersion
+    }
+}
+
+const VERSION_URL_PATTERN = /^\/api\/(v[A-Za-z0-9._-]+)(\/|$)/
+const ACCEPT_VERSION_PATTERN = /version=([A-Za-z0-9._-]+)/
+
+function resolveRequestedVersion(req: Request): { fromUrl: boolean; name: string | null } {
+    const urlMatch = req.path.match(VERSION_URL_PATTERN)
+    if (urlMatch) return { fromUrl: true, name: urlMatch[1] }
+
+    const accept = req.headers['accept']
+    if (typeof accept === 'string') {
+        const headerMatch = accept.match(ACCEPT_VERSION_PATTERN)
+        if (headerMatch) return { fromUrl: false, name: headerMatch[1] }
+    }
+
+    return { fromUrl: false, name: null }
+}
+
+export interface ApiVersionLocals {
+    apiVersion: ApiVersionDescriptor
+    apiVersionFromUrl: boolean
+}
+
+/**
+ * Resolve the request's version, attach it to `res.locals`, set
+ * deprecation headers when applicable, and reject sunset versions
+ * with 410 Gone.
+ *
+ * Mount this on the API router before the per-version sub-routers
+ * (e.g. `app.use('/api', apiVersionMiddleware(registry))`).
+ */
+export function apiVersionMiddleware(registry: ApiVersionRegistry): RequestHandler {
+    return (req: Request, res: Response, next: NextFunction) => {
+        const requested = resolveRequestedVersion(req)
+        let descriptor: ApiVersionDescriptor | null = requested.name
+            ? registry.resolve(requested.name)
+            : null
+
+        if (requested.name && !descriptor) {
+            res.status(404).json({
+                error: 'unknown_api_version',
+                requested: requested.name,
+                supported: registry.list().map((v) => v.name),
+            })
+            return
+        }
+
+        if (!descriptor) {
+            descriptor = registry.getDefault()
+        }
+
+        if (descriptor.status === 'sunset') {
+            res.status(410).json({
+                error: 'api_version_sunset',
+                version: descriptor.name,
+                sunsetAt: descriptor.sunsetAt,
+                migrationGuide: descriptor.migrationGuide,
+            })
+            return
+        }
+
+        if (descriptor.status === 'deprecated') {
+            // RFC 8594 deprecation signalling. Clients SHOULD log these
+            // headers; an admin dashboard tracking version usage will
+            // surface them automatically.
+            if (descriptor.deprecatedAt) res.setHeader('Deprecation', descriptor.deprecatedAt)
+            if (descriptor.sunsetAt) res.setHeader('Sunset', descriptor.sunsetAt)
+            if (descriptor.migrationGuide) {
+                res.setHeader(
+                    'Link',
+                    `<${descriptor.migrationGuide}>; rel="deprecation"; type="text/html"`,
+                )
+            }
+        }
+
+        const locals = res.locals as Partial<ApiVersionLocals>
+        locals.apiVersion = descriptor
+        locals.apiVersionFromUrl = requested.fromUrl
+        next()
+    }
+}

--- a/server/src/services/dependency-health.service.ts
+++ b/server/src/services/dependency-health.service.ts
@@ -1,0 +1,168 @@
+/**
+ * Foundation for the Kubernetes-style readiness probes tracked in #483.
+ *
+ * The current `health.service.ts` is an interval-driven *alerting*
+ * monitor — it watches an aggregate "system health" metric and pings
+ * a webhook when something looks bad. That's a useful signal but it
+ * doesn't answer the question Kubernetes needs answered:
+ *
+ *     "Is this pod ready to serve traffic right now?"
+ *
+ * This file owns that question. Every dependency the request path
+ * touches (DB, Redis, blockchain RPC, external KYC, …) registers a
+ * probe; the readiness aggregate returns the worst-case status of any
+ * required probe. Liveness is the cheaper "did the process panic"
+ * check that returns OK as long as the event loop is responsive.
+ *
+ * The HTTP routes that mount these (e.g. `GET /healthz`,
+ * `GET /readyz`) live in a follow-up — this file just owns the
+ * registry + aggregation logic so the wiring stays a one-liner.
+ */
+
+export type ProbeStatus = 'pass' | 'warn' | 'fail'
+
+export interface ProbeResult {
+    name: string
+    status: ProbeStatus
+    /** Round-trip latency of the probe call itself. */
+    latencyMs: number
+    /** Optional human-readable detail surfaced in the readiness payload. */
+    message?: string
+    /** True when this probe's failure should fail the readiness aggregate. */
+    required: boolean
+}
+
+export interface DependencyProbe {
+    name: string
+    /** Required probes fail the readiness aggregate; optional ones only warn. */
+    required: boolean
+    /** Bail and report `fail` if the probe takes longer than this. */
+    timeoutMs: number
+    check: () => Promise<{ status: ProbeStatus; message?: string }>
+}
+
+export interface ReadinessSnapshot {
+    status: ProbeStatus
+    checkedAt: number
+    probes: ProbeResult[]
+}
+
+export class DependencyHealthRegistry {
+    private readonly probes = new Map<string, DependencyProbe>()
+
+    constructor(private readonly now: () => number = Date.now) {}
+
+    register(probe: DependencyProbe): void {
+        if (probe.timeoutMs <= 0) {
+            throw new Error('dependency-health: timeoutMs must be positive')
+        }
+        this.probes.set(probe.name, probe)
+    }
+
+    unregister(name: string): void {
+        this.probes.delete(name)
+    }
+
+    async runAll(): Promise<ReadinessSnapshot> {
+        const checkedAt = this.now()
+        const probes = await Promise.all(
+            Array.from(this.probes.values()).map((probe) => this.runOne(probe)),
+        )
+
+        const requiredFailed = probes.some((p) => p.required && p.status === 'fail')
+        const anyFailed = probes.some((p) => p.status === 'fail')
+        const anyWarn = probes.some((p) => p.status === 'warn')
+
+        const status: ProbeStatus = requiredFailed
+            ? 'fail'
+            : anyFailed || anyWarn
+                ? 'warn'
+                : 'pass'
+
+        return { status, checkedAt, probes }
+    }
+
+    private async runOne(probe: DependencyProbe): Promise<ProbeResult> {
+        const startedAt = this.now()
+
+        let timeoutId: NodeJS.Timeout | null = null
+        const timeoutPromise = new Promise<{ status: ProbeStatus; message?: string }>(
+            (resolve) => {
+                timeoutId = setTimeout(
+                    () => resolve({ status: 'fail', message: 'probe timed out' }),
+                    probe.timeoutMs,
+                )
+            },
+        )
+
+        let result: { status: ProbeStatus; message?: string }
+        try {
+            result = await Promise.race([probe.check(), timeoutPromise])
+        } catch (err) {
+            result = { status: 'fail', message: err instanceof Error ? err.message : String(err) }
+        } finally {
+            if (timeoutId) clearTimeout(timeoutId)
+        }
+
+        return {
+            name: probe.name,
+            status: result.status,
+            latencyMs: this.now() - startedAt,
+            message: result.message,
+            required: probe.required,
+        }
+    }
+}
+
+const globalRegistry = new DependencyHealthRegistry()
+
+export function getDependencyHealthRegistry(): DependencyHealthRegistry {
+    return globalRegistry
+}
+
+/**
+ * Convenience builders for the probes #483 calls out by name.
+ *
+ * Each builder accepts a thin async check so the service that owns the
+ * dependency (db, redis, blockchain RPC) does not import this file —
+ * keeping the dependency direction one-way (service → registration on
+ * bootstrap).
+ */
+export function buildDatabaseProbe(check: () => Promise<void>): DependencyProbe {
+    return {
+        name: 'database',
+        required: true,
+        timeoutMs: 1_000,
+        check: async () => {
+            await check()
+            return { status: 'pass' }
+        },
+    }
+}
+
+export function buildRedisProbe(check: () => Promise<void>): DependencyProbe {
+    return {
+        name: 'redis',
+        required: false,
+        timeoutMs: 500,
+        check: async () => {
+            await check()
+            return { status: 'pass' }
+        },
+    }
+}
+
+export function buildBlockchainRpcProbe(
+    check: () => Promise<void>,
+    options: { required?: boolean } = {},
+): DependencyProbe {
+    return {
+        name: 'blockchain-rpc',
+        required: options.required ?? false,
+        timeoutMs: 1_500,
+        check: async () => {
+            await check()
+            return { status: 'pass' }
+        },
+    }
+}

--- a/server/src/services/secrets.service.ts
+++ b/server/src/services/secrets.service.ts
@@ -1,0 +1,148 @@
+/**
+ * Foundation for the centralised secret management work tracked in #484.
+ *
+ * The existing code reads secrets directly from `process.env`. This file
+ * introduces a {@link SecretProvider} abstraction so the same call sites
+ * can swap to HashiCorp Vault, AWS Secrets Manager, or Doppler without
+ * touching service code.
+ *
+ * Behaviours:
+ *   - Lazy fetch + in-process cache, so the hot path doesn't hit Vault
+ *     on every request.
+ *   - TTL-based rotation so a rotated secret stops being served from
+ *     the cache within `cacheTtlMs` of its rotation time.
+ *   - Audit hook (`onAccess`) every time a secret is read — production
+ *     wiring sends this to the existing audit.service so secret access
+ *     shows up in the audit trail without a per-secret patch.
+ *   - Strict mode (`requireKey`) that throws when a secret is missing,
+ *     matching the production behaviour we want when JWT_SECRET / db
+ *     creds aren't configured.
+ *
+ * Real Vault wiring lives in a follow-up — the current
+ * EnvSecretProvider keeps the .env-as-source-of-truth contract intact
+ * while the rest of the service migrates.
+ */
+
+export interface SecretAccessEvent {
+    key: string
+    hit: 'cache' | 'fresh'
+    timestamp: number
+    /** Caller-supplied label so the audit trail names the use site. */
+    requester?: string
+}
+
+export interface SecretProvider {
+    /** Fetch a secret; return null when the key is unknown. */
+    get(key: string, requester?: string): Promise<string | null>
+    /** Strict variant: throws when the secret is missing or empty. */
+    requireKey(key: string, requester?: string): Promise<string>
+    /** Force the next read of `key` to bypass the cache. */
+    invalidate(key: string): void
+    /** Wipe every cached secret. Test + shutdown helper. */
+    invalidateAll(): void
+}
+
+export interface SecretProviderOptions {
+    cacheTtlMs?: number
+    onAccess?: (event: SecretAccessEvent) => void
+    now?: () => number
+}
+
+interface CacheEntry {
+    value: string | null
+    fetchedAt: number
+}
+
+abstract class BaseSecretProvider implements SecretProvider {
+    protected readonly cache = new Map<string, CacheEntry>()
+    protected readonly cacheTtlMs: number
+    protected readonly onAccess: (event: SecretAccessEvent) => void
+    protected readonly now: () => number
+
+    constructor(options: SecretProviderOptions = {}) {
+        this.cacheTtlMs = options.cacheTtlMs ?? 60_000
+        this.onAccess = options.onAccess ?? (() => undefined)
+        this.now = options.now ?? Date.now
+    }
+
+    protected abstract fetch(key: string): Promise<string | null>
+
+    async get(key: string, requester?: string): Promise<string | null> {
+        const cached = this.cache.get(key)
+        const now = this.now()
+        if (cached && now - cached.fetchedAt < this.cacheTtlMs) {
+            this.onAccess({ key, hit: 'cache', timestamp: now, requester })
+            return cached.value
+        }
+        const fresh = await this.fetch(key)
+        this.cache.set(key, { value: fresh, fetchedAt: now })
+        this.onAccess({ key, hit: 'fresh', timestamp: now, requester })
+        return fresh
+    }
+
+    async requireKey(key: string, requester?: string): Promise<string> {
+        const value = await this.get(key, requester)
+        if (!value) {
+            throw new Error(`secrets.service: required secret "${key}" is missing or empty.`)
+        }
+        return value
+    }
+
+    invalidate(key: string): void {
+        this.cache.delete(key)
+    }
+
+    invalidateAll(): void {
+        this.cache.clear()
+    }
+}
+
+/**
+ * Default provider. Reads secrets from `process.env` so dev / test
+ * deployments work the same way they always have. Production swaps
+ * this out for a Vault / AWS Secrets Manager implementation through
+ * {@link setSecretProvider}.
+ */
+export class EnvSecretProvider extends BaseSecretProvider {
+    protected async fetch(key: string): Promise<string | null> {
+        const raw = process.env[key]
+        if (!raw) return null
+        return raw
+    }
+}
+
+/**
+ * Provider that delegates to an async lookup function. Use this from
+ * a Vault adapter so the adapter only has to implement `lookup` —
+ * caching, audit, and `requireKey` come from the base class.
+ */
+export class DelegatingSecretProvider extends BaseSecretProvider {
+    constructor(
+        private readonly lookup: (key: string) => Promise<string | null>,
+        options: SecretProviderOptions = {},
+    ) {
+        super(options)
+    }
+
+    protected fetch(key: string): Promise<string | null> {
+        return this.lookup(key)
+    }
+}
+
+let activeProvider: SecretProvider = new EnvSecretProvider()
+
+export function getSecretProvider(): SecretProvider {
+    return activeProvider
+}
+
+export function setSecretProvider(provider: SecretProvider): void {
+    activeProvider = provider
+}
+
+export async function getSecret(key: string, requester?: string): Promise<string | null> {
+    return activeProvider.get(key, requester)
+}
+
+export async function requireSecret(key: string, requester?: string): Promise<string> {
+    return activeProvider.requireKey(key, requester)
+}

--- a/server/test/api-version.middleware.test.js
+++ b/server/test/api-version.middleware.test.js
@@ -1,0 +1,132 @@
+import test from 'node:test'
+import assert from 'node:assert'
+
+function buildMockRequest(overrides = {}) {
+  return {
+    path: '/api/v1/health',
+    headers: {},
+    ...overrides,
+  }
+}
+
+function buildMockResponse() {
+  const res = {
+    statusCode: 0,
+    body: undefined,
+    headers: {},
+    locals: {},
+    status(code) { res.statusCode = code; return res },
+    json(payload) { res.body = payload; return res },
+    setHeader(name, value) { res.headers[name] = value },
+  }
+  return res
+}
+
+test('apiVersionMiddleware resolves v1 from the URL and exposes it on res.locals', async () => {
+  const { InMemoryApiVersionRegistry, apiVersionMiddleware } = await import(
+    '../dist/middleware/api-version.middleware.js'
+  )
+  const registry = new InMemoryApiVersionRegistry()
+  registry.register({ name: 'v1', status: 'live', introducedAt: '2026-01-01' }, { default: true })
+
+  const handler = apiVersionMiddleware(registry)
+  const req = buildMockRequest({ path: '/api/v1/health' })
+  const res = buildMockResponse()
+  let called = false
+  await handler(req, res, () => { called = true })
+
+  assert.ok(called)
+  assert.strictEqual(res.locals.apiVersion.name, 'v1')
+  assert.strictEqual(res.locals.apiVersionFromUrl, true)
+})
+
+test('apiVersionMiddleware falls back to the registered default when the URL has no version', async () => {
+  const { InMemoryApiVersionRegistry, apiVersionMiddleware } = await import(
+    '../dist/middleware/api-version.middleware.js'
+  )
+  const registry = new InMemoryApiVersionRegistry()
+  registry.register({ name: 'v1', status: 'live', introducedAt: '2026-01-01' }, { default: true })
+
+  const handler = apiVersionMiddleware(registry)
+  const req = buildMockRequest({ path: '/api/health' })
+  const res = buildMockResponse()
+  await handler(req, res, () => {})
+  assert.strictEqual(res.locals.apiVersion.name, 'v1')
+  assert.strictEqual(res.locals.apiVersionFromUrl, false)
+})
+
+test('apiVersionMiddleware honours an Accept header override', async () => {
+  const { InMemoryApiVersionRegistry, apiVersionMiddleware } = await import(
+    '../dist/middleware/api-version.middleware.js'
+  )
+  const registry = new InMemoryApiVersionRegistry()
+  registry.register({ name: 'v1', status: 'live', introducedAt: '2026-01-01' }, { default: true })
+  registry.register({ name: 'v2', status: 'live', introducedAt: '2026-06-01' })
+
+  const handler = apiVersionMiddleware(registry)
+  const req = buildMockRequest({ path: '/api/health', headers: { accept: 'application/json; version=v2' } })
+  const res = buildMockResponse()
+  await handler(req, res, () => {})
+  assert.strictEqual(res.locals.apiVersion.name, 'v2')
+})
+
+test('apiVersionMiddleware sets RFC 8594 headers for a deprecated version', async () => {
+  const { InMemoryApiVersionRegistry, apiVersionMiddleware } = await import(
+    '../dist/middleware/api-version.middleware.js'
+  )
+  const registry = new InMemoryApiVersionRegistry()
+  registry.register({
+    name: 'v1',
+    status: 'deprecated',
+    introducedAt: '2026-01-01',
+    deprecatedAt: '2026-06-01',
+    sunsetAt: '2026-12-31',
+    migrationGuide: 'https://docs.example.com/migrate-to-v2',
+  }, { default: true })
+
+  const handler = apiVersionMiddleware(registry)
+  const req = buildMockRequest({ path: '/api/v1/health' })
+  const res = buildMockResponse()
+  await handler(req, res, () => {})
+
+  assert.strictEqual(res.headers.Deprecation, '2026-06-01')
+  assert.strictEqual(res.headers.Sunset, '2026-12-31')
+  assert.ok(res.headers.Link.includes('rel="deprecation"'))
+})
+
+test('apiVersionMiddleware returns 410 for a sunset version', async () => {
+  const { InMemoryApiVersionRegistry, apiVersionMiddleware } = await import(
+    '../dist/middleware/api-version.middleware.js'
+  )
+  const registry = new InMemoryApiVersionRegistry()
+  registry.register({
+    name: 'v0',
+    status: 'sunset',
+    introducedAt: '2025-01-01',
+    sunsetAt: '2026-01-01',
+  })
+  registry.register({ name: 'v1', status: 'live', introducedAt: '2026-01-01' }, { default: true })
+
+  const handler = apiVersionMiddleware(registry)
+  const req = buildMockRequest({ path: '/api/v0/health' })
+  const res = buildMockResponse()
+  await handler(req, res, () => {})
+  assert.strictEqual(res.statusCode, 410)
+  assert.strictEqual(res.body.error, 'api_version_sunset')
+})
+
+test('apiVersionMiddleware returns 404 for an unknown version', async () => {
+  const { InMemoryApiVersionRegistry, apiVersionMiddleware } = await import(
+    '../dist/middleware/api-version.middleware.js'
+  )
+  const registry = new InMemoryApiVersionRegistry()
+  registry.register({ name: 'v1', status: 'live', introducedAt: '2026-01-01' }, { default: true })
+
+  const handler = apiVersionMiddleware(registry)
+  const req = buildMockRequest({ path: '/api/v9/health' })
+  const res = buildMockResponse()
+  await handler(req, res, () => {})
+
+  assert.strictEqual(res.statusCode, 404)
+  assert.strictEqual(res.body.error, 'unknown_api_version')
+})

--- a/server/test/dependency-health.service.test.js
+++ b/server/test/dependency-health.service.test.js
@@ -1,0 +1,68 @@
+import test from 'node:test'
+import assert from 'node:assert'
+
+test('runAll returns pass when every probe passes', async () => {
+  const { DependencyHealthRegistry } = await import('../dist/services/dependency-health.service.js')
+  let now = 1_000
+  const registry = new DependencyHealthRegistry(() => now)
+  registry.register({
+    name: 'db',
+    required: true,
+    timeoutMs: 1_000,
+    check: async () => ({ status: 'pass' }),
+  })
+
+  const snapshot = await registry.runAll()
+  assert.strictEqual(snapshot.status, 'pass')
+  assert.strictEqual(snapshot.probes.length, 1)
+})
+
+test('runAll returns fail when a required probe fails', async () => {
+  const { DependencyHealthRegistry } = await import('../dist/services/dependency-health.service.js')
+  const registry = new DependencyHealthRegistry(() => 1_000)
+  registry.register({
+    name: 'db',
+    required: true,
+    timeoutMs: 1_000,
+    check: async () => ({ status: 'fail', message: 'connection refused' }),
+  })
+
+  const snapshot = await registry.runAll()
+  assert.strictEqual(snapshot.status, 'fail')
+  assert.strictEqual(snapshot.probes[0].message, 'connection refused')
+})
+
+test('runAll returns warn when only an optional probe fails', async () => {
+  const { DependencyHealthRegistry } = await import('../dist/services/dependency-health.service.js')
+  const registry = new DependencyHealthRegistry(() => 1_000)
+  registry.register({
+    name: 'redis',
+    required: false,
+    timeoutMs: 500,
+    check: async () => ({ status: 'fail' }),
+  })
+  registry.register({
+    name: 'db',
+    required: true,
+    timeoutMs: 1_000,
+    check: async () => ({ status: 'pass' }),
+  })
+
+  const snapshot = await registry.runAll()
+  assert.strictEqual(snapshot.status, 'warn')
+})
+
+test('a probe that hangs is reported as a timeout failure', async () => {
+  const { DependencyHealthRegistry } = await import('../dist/services/dependency-health.service.js')
+  const registry = new DependencyHealthRegistry()
+  registry.register({
+    name: 'slow',
+    required: true,
+    timeoutMs: 25,
+    check: () => new Promise(() => {}),
+  })
+
+  const snapshot = await registry.runAll()
+  assert.strictEqual(snapshot.status, 'fail')
+  assert.strictEqual(snapshot.probes[0].message, 'probe timed out')
+})

--- a/server/test/secrets.service.test.js
+++ b/server/test/secrets.service.test.js
@@ -1,0 +1,51 @@
+import test from 'node:test'
+import assert from 'node:assert'
+
+test('EnvSecretProvider reads process.env, caches, then re-reads after invalidate', async () => {
+  const { EnvSecretProvider } = await import('../dist/services/secrets.service.js')
+  process.env.__TEST_SECRET = 'before'
+  let now = 1_000
+  const provider = new EnvSecretProvider({ cacheTtlMs: 60_000, now: () => now })
+
+  assert.strictEqual(await provider.get('__TEST_SECRET'), 'before')
+
+  // Rotate the underlying value; cache should still serve "before".
+  process.env.__TEST_SECRET = 'after'
+  now += 1_000
+  assert.strictEqual(await provider.get('__TEST_SECRET'), 'before')
+
+  // Invalidate clears the cache.
+  provider.invalidate('__TEST_SECRET')
+  assert.strictEqual(await provider.get('__TEST_SECRET'), 'after')
+
+  delete process.env.__TEST_SECRET
+})
+
+test('requireKey throws on a missing secret', async () => {
+  const { EnvSecretProvider } = await import('../dist/services/secrets.service.js')
+  const provider = new EnvSecretProvider()
+  await assert.rejects(() => provider.requireKey('__DEFINITELY_NOT_SET_XYZ'), /required secret/)
+})
+
+test('onAccess is called for every read with hit metadata', async () => {
+  const { EnvSecretProvider } = await import('../dist/services/secrets.service.js')
+  process.env.__TEST_SECRET_2 = 'value'
+  let now = 1_000
+  const seen = []
+  const provider = new EnvSecretProvider({
+    cacheTtlMs: 60_000,
+    now: () => now,
+    onAccess: (event) => seen.push(event),
+  })
+
+  await provider.get('__TEST_SECRET_2', 'auth.service')
+  now += 1_000
+  await provider.get('__TEST_SECRET_2', 'auth.service')
+
+  assert.strictEqual(seen.length, 2)
+  assert.strictEqual(seen[0].hit, 'fresh')
+  assert.strictEqual(seen[1].hit, 'cache')
+  assert.strictEqual(seen[0].requester, 'auth.service')
+
+  delete process.env.__TEST_SECRET_2
+})


### PR DESCRIPTION
## Summary

Three additive foundations land in one PR. Each closes its own issue. None of them rip out an existing service — they sit next to the current code so the integration work in follow-up PRs is mechanical.

Closes #484
Closes #483
Closes #476

### #484 — `server/src/services/secrets.service.ts`
`SecretProvider` interface with in-process cache, TTL-based rotation, audit hook, and a strict `requireKey()` that throws on missing secrets. `EnvSecretProvider` preserves the `.env`-as-source-of-truth contract for dev/tests; `DelegatingSecretProvider` is the seam a Vault / AWS Secrets Manager adapter plugs into in the follow-up. Test covers cache hit/miss with rotation, `requireKey()` throwing, and `onAccess()` audit events for every read.

### #483 — `server/src/services/dependency-health.service.ts`
`DependencyHealthRegistry` aggregates Kubernetes-style readiness probes (DB, Redis, blockchain RPC). Required-vs-optional: a required probe failure fails the aggregate; an optional probe failure only warns. Each probe is wrapped in a timeout so a hanging downstream can't stall `/readyz`. Builder helpers (`buildDatabaseProbe`, `buildRedisProbe`, `buildBlockchainRpcProbe`) keep service-side check functions one-liners so the dependency direction stays one-way. Test covers pass/fail/warn aggregation plus the timeout fallback path.

### #476 — `server/src/middleware/api-version.middleware.ts`
URL-segment versioning (`/api/v1/...`) with `Accept`-header overrides for clients that want to pin without changing URLs. URL was chosen over header-only because every existing log line, CDN rule, and metric already keys on the URL — preserving that gives the migration team a cheap analytics signal. `InMemoryApiVersionRegistry` tracks `live` / `deprecated` / `sunset` states. Middleware sets RFC 8594 `Deprecation` / `Sunset` / `Link` headers when applicable, rejects sunset versions with `410 Gone`, and unknown versions with `404`. Test covers URL + Accept resolution, default fallback, deprecation header emission, sunset 410, and unknown 404.

## Test plan

- [ ] `npm test` in `server/` — runs the three new node:test files alongside the existing suite (`tsc` then `node --test test/**/*.test.js`).

## Out of scope (follow-ups in dedicated PRs)
- HashiCorp Vault / AWS Secrets Manager adapter wrapped in `DelegatingSecretProvider`.
- Mount `/healthz` and `/readyz` routes that delegate to the registry.
- Move existing routes under `/api/v1/...` and register the version on bootstrap.