### PR TITLE
feat: merkle library, event registry, OTel tracing, smart compression

### DIFF
--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -1010,6 +1010,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
+name = "merkle"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -31,6 +31,7 @@ members = [
     "governance",
     "prize-distribution",
     "random-generation",
+    "merkle",
 ]
 resolver = "2"
 

--- a/contracts/arenax-events/src/events_registry.rs
+++ b/contracts/arenax-events/src/events_registry.rs
@@ -1,0 +1,68 @@
+//! Machine-readable registry of every event namespace shipped by this
+//! crate.
+//!
+//! Off-chain indexers (block scanners, replay tooling, the trace
+//! analysis dashboard from #478) call into this list to know which
+//! `(NAMESPACE, VERSION)` pairs are first-class — anything they see
+//! on chain that is *not* in this list should be flagged as either an
+//! unregistered event or a version mismatch.
+
+use crate::{
+    anti_cheat, auth_gateway, ax_token, contract_registry, dispute, escrow, governance, identity,
+    match_contract, match_lifecycle, player_reputation, prize_distribution, registry, reputation,
+    reputation_index, slashing, staking, tournament, virtual_economy,
+};
+
+/// A single entry in the namespace registry.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct NamespaceEntry {
+    pub namespace: &'static str,
+    pub version: &'static str,
+}
+
+/// Every `(NAMESPACE, VERSION)` known to this crate. Keep alphabetical
+/// by namespace so new entries land in a stable place.
+pub const NAMESPACES: &[NamespaceEntry] = &[
+    NamespaceEntry { namespace: anti_cheat::NAMESPACE, version: anti_cheat::VERSION },
+    NamespaceEntry { namespace: auth_gateway::NAMESPACE, version: auth_gateway::VERSION },
+    NamespaceEntry { namespace: ax_token::NAMESPACE, version: ax_token::VERSION },
+    NamespaceEntry { namespace: contract_registry::NAMESPACE, version: contract_registry::VERSION },
+    NamespaceEntry { namespace: dispute::NAMESPACE, version: dispute::VERSION },
+    NamespaceEntry { namespace: escrow::NAMESPACE, version: escrow::VERSION },
+    NamespaceEntry { namespace: governance::NAMESPACE, version: governance::VERSION },
+    NamespaceEntry { namespace: identity::NAMESPACE, version: identity::VERSION },
+    NamespaceEntry { namespace: match_contract::NAMESPACE, version: match_contract::VERSION },
+    NamespaceEntry { namespace: match_lifecycle::NAMESPACE, version: match_lifecycle::VERSION },
+    NamespaceEntry { namespace: player_reputation::NAMESPACE, version: player_reputation::VERSION },
+    NamespaceEntry { namespace: prize_distribution::NAMESPACE, version: prize_distribution::VERSION },
+    NamespaceEntry { namespace: registry::NAMESPACE, version: registry::VERSION },
+    NamespaceEntry { namespace: reputation::NAMESPACE, version: reputation::VERSION },
+    NamespaceEntry { namespace: reputation_index::NAMESPACE, version: reputation_index::VERSION },
+    NamespaceEntry { namespace: slashing::NAMESPACE, version: slashing::VERSION },
+    NamespaceEntry { namespace: staking::NAMESPACE, version: staking::VERSION },
+    NamespaceEntry { namespace: tournament::NAMESPACE, version: tournament::VERSION },
+    NamespaceEntry { namespace: virtual_economy::NAMESPACE, version: virtual_economy::VERSION },
+];
+
+/// Number of registered namespaces — useful for dashboards that want
+/// to surface a "domains tracked" count without iterating.
+pub const NAMESPACE_COUNT: usize = NAMESPACES.len();
+
+/// Look up a namespace by name. Returns the registered version if known.
+pub fn lookup(namespace: &str) -> Option<&'static str> {
+    let mut i = 0;
+    while i < NAMESPACES.len() {
+        if str_eq(NAMESPACES[i].namespace, namespace) {
+            return Some(NAMESPACES[i].version);
+        }
+        i += 1;
+    }
+    None
+}
+
+/// `no_std`-friendly equality for `&str` — `core::cmp::Eq` is fine but
+/// we want this callable from `const fn` callers in the future without
+/// changes.
+fn str_eq(a: &str, b: &str) -> bool {
+    a.as_bytes() == b.as_bytes()
+}

--- a/contracts/arenax-events/src/lib.rs
+++ b/contracts/arenax-events/src/lib.rs
@@ -1,3 +1,23 @@
+//! Shared, versioned event definitions for ArenaX contracts.
+//!
+//! ## Standardisation rules (issue #490)
+//!
+//! Every contract domain exposes its events from its own module here, and
+//! every module must declare the two associated constants:
+//!
+//! - `NAMESPACE: &str` — domain name (e.g. `"ArenaXMatch"`).
+//! - `VERSION: &str` — schema version (e.g. `"v1"`); bump only on a
+//!   breaking change to any event in the module.
+//!
+//! Topics use the convention `["{NAMESPACE_abbrev}_{VERSION}", "{ACTION}"]`
+//! (see existing modules). Off-chain indexers split on `_` to pick up the
+//! namespace + version without parsing the action.
+//!
+//! The [`registry`] module exposes a single machine-readable list of
+//! every `(NAMESPACE, VERSION)` shipped by this crate, and the test
+//! suite enforces uniqueness so a future PR can't accidentally collide
+//! two domains on the same namespace.
+
 #![no_std]
 
 pub mod anti_cheat;
@@ -19,4 +39,9 @@ pub mod staking;
 pub mod tournament;
 pub mod virtual_economy;
 pub mod prize_distribution;
+
+pub mod events_registry;
+
+#[cfg(test)]
+mod registry_tests;
 

--- a/contracts/arenax-events/src/registry_tests.rs
+++ b/contracts/arenax-events/src/registry_tests.rs
@@ -1,0 +1,79 @@
+//! Tests for the event namespace registry (#490).
+//!
+//! These tests guard the standard event schema — they fail if a future
+//! PR introduces an event module that:
+//!
+//! - Forgets to add itself to [`events_registry::NAMESPACES`],
+//! - Reuses an existing `NAMESPACE` string under a different module,
+//! - Drops or empties either `NAMESPACE` or `VERSION`,
+//! - Uses a `VERSION` outside the `vN` convention.
+
+extern crate alloc;
+use alloc::collections::BTreeSet;
+use alloc::string::ToString;
+
+use crate::events_registry::{lookup, NamespaceEntry, NAMESPACES, NAMESPACE_COUNT};
+
+#[test]
+fn registry_is_not_empty() {
+    assert!(NAMESPACE_COUNT > 0, "events_registry must list at least one namespace");
+    assert_eq!(NAMESPACE_COUNT, NAMESPACES.len());
+}
+
+#[test]
+fn every_namespace_has_non_empty_name_and_version() {
+    for entry in NAMESPACES {
+        assert!(!entry.namespace.is_empty(), "empty namespace: {:?}", entry);
+        assert!(!entry.version.is_empty(), "empty version for {}", entry.namespace);
+    }
+}
+
+#[test]
+fn versions_follow_vN_convention() {
+    for entry in NAMESPACES {
+        let v = entry.version;
+        assert!(
+            v.len() >= 2 && v.starts_with('v'),
+            "{} version {:?} should be vN (e.g. v1)",
+            entry.namespace,
+            v,
+        );
+        // The chars after the leading 'v' must be ascii digits.
+        for c in v.chars().skip(1) {
+            assert!(c.is_ascii_digit(), "{} version has non-digit: {:?}", entry.namespace, v);
+        }
+    }
+}
+
+#[test]
+fn namespaces_are_unique() {
+    let mut seen = BTreeSet::new();
+    for entry in NAMESPACES {
+        let inserted = seen.insert(entry.namespace.to_string());
+        assert!(inserted, "duplicate namespace: {}", entry.namespace);
+    }
+}
+
+#[test]
+fn lookup_round_trips_for_every_entry() {
+    for entry in NAMESPACES {
+        let got = lookup(entry.namespace);
+        assert_eq!(got, Some(entry.version), "lookup failed for {}", entry.namespace);
+    }
+}
+
+#[test]
+fn lookup_returns_none_for_unknown_namespace() {
+    assert_eq!(lookup("DefinitelyNotARealArenaXNamespace"), None);
+}
+
+#[test]
+fn entry_partial_eq_works() {
+    // Smoke-test the derived PartialEq so the registry is structurally
+    // comparable (used by the off-chain indexer's diff logic).
+    let a = NamespaceEntry { namespace: "X", version: "v1" };
+    let b = NamespaceEntry { namespace: "X", version: "v1" };
+    let c = NamespaceEntry { namespace: "Y", version: "v1" };
+    assert_eq!(a, b);
+    assert_ne!(a, c);
+}

--- a/contracts/merkle/Cargo.toml
+++ b/contracts/merkle/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "merkle"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Soroban Merkle-tree library for ArenaX bulk operations (airdrops, batch claims)"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk.workspace = true
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/merkle/src/lib.rs
+++ b/contracts/merkle/src/lib.rs
@@ -1,0 +1,229 @@
+//! ArenaX Merkle-tree library (#493).
+//!
+//! Provides on-chain Merkle proof verification + a thin
+//! `MerkleAirdropRegistry` contract that stores per-campaign roots and
+//! tracks which leaves have been claimed.
+//!
+//! ## Hashing convention
+//!
+//! - Leaves are `BytesN<32>` values produced *off-chain* — the caller
+//!   decides how to encode user identity + amount before hashing
+//!   (typically `sha256(account_id_xdr || amount.to_be_bytes())`).
+//! - Internal nodes use **sorted-pair hashing**:
+//!   `hash(min(a, b) || max(a, b))` — this is the OpenZeppelin /
+//!   uniswap-merkle-distributor convention, which makes proof paths
+//!   order-independent and lets clients hand back proofs without
+//!   per-position bits.
+//!
+//! ## Storage layout
+//!
+//! - `DataKey::Admin` — campaign admin (instance)
+//! - `DataKey::Root(campaign_id)` — root for a campaign (persistent)
+//! - `DataKey::Claimed(campaign_id, leaf)` — claim marker (persistent)
+
+#![no_std]
+
+use soroban_sdk::{
+    contract, contractevent, contractimpl, contracterror, contracttype, panic_with_error,
+    Address, Bytes, BytesN, Env,
+};
+
+const PERSISTENT_LIFETIME_THRESHOLD: u32 = 100_000;
+const PERSISTENT_BUMP_AMOUNT: u32 = 500_000;
+
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    Root(Bytes),                // campaign_id → root
+    Claimed(Bytes, BytesN<32>), // (campaign_id, leaf) → bool
+}
+
+#[contracterror]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u32)]
+pub enum Error {
+    AlreadyInitialized = 1,
+    NotInitialized = 2,
+    Unauthorized = 3,
+    RootNotSet = 4,
+    InvalidProof = 5,
+    AlreadyClaimed = 6,
+    RootAlreadySet = 7,
+}
+
+#[contractevent(topics = ["ArenaXMerkle_v1", "ROOT_SET"])]
+pub struct RootSet {
+    pub campaign_id: Bytes,
+    pub root: BytesN<32>,
+}
+
+#[contractevent(topics = ["ArenaXMerkle_v1", "CLAIMED"])]
+pub struct LeafClaimed {
+    pub campaign_id: Bytes,
+    pub leaf: BytesN<32>,
+    pub claimant: Address,
+}
+
+// ─── Verification primitive ────────────────────────────────────────────────
+
+/// Verify that `leaf` is a member of the tree rooted at `root`, given
+/// `proof` as the ordered list of sibling hashes from the leaf up to the
+/// root. Uses sorted-pair hashing — proof order is irrelevant.
+pub fn verify_proof(
+    env: &Env,
+    root: &BytesN<32>,
+    leaf: &BytesN<32>,
+    proof: &soroban_sdk::Vec<BytesN<32>>,
+) -> bool {
+    let mut computed: BytesN<32> = leaf.clone();
+    for i in 0..proof.len() {
+        let sibling = proof.get(i).unwrap();
+        computed = hash_pair_sorted(env, &computed, &sibling);
+    }
+    computed == *root
+}
+
+/// `hash(min(a, b) || max(a, b))` using `env.crypto().sha256(...)`.
+pub fn hash_pair_sorted(env: &Env, a: &BytesN<32>, b: &BytesN<32>) -> BytesN<32> {
+    let mut buf = soroban_sdk::Bytes::new(env);
+    let (lo, hi) = if compare_bytes32(a, b) == core::cmp::Ordering::Less {
+        (a, b)
+    } else {
+        (b, a)
+    };
+    buf.append(&Bytes::from_array(env, &lo.to_array()));
+    buf.append(&Bytes::from_array(env, &hi.to_array()));
+    env.crypto().sha256(&buf).into()
+}
+
+fn compare_bytes32(a: &BytesN<32>, b: &BytesN<32>) -> core::cmp::Ordering {
+    let ax = a.to_array();
+    let bx = b.to_array();
+    for i in 0..32 {
+        match ax[i].cmp(&bx[i]) {
+            core::cmp::Ordering::Equal => continue,
+            other => return other,
+        }
+    }
+    core::cmp::Ordering::Equal
+}
+
+// ─── Contract — MerkleAirdropRegistry ──────────────────────────────────────
+
+#[contract]
+pub struct MerkleAirdropRegistry;
+
+#[contractimpl]
+impl MerkleAirdropRegistry {
+    pub fn initialize(env: Env, admin: Address) {
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic_with_error!(&env, Error::AlreadyInitialized);
+        }
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Admin, &admin);
+    }
+
+    pub fn get_admin(env: Env) -> Address {
+        env.storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .unwrap_or_else(|| panic_with_error!(&env, Error::NotInitialized))
+    }
+
+    /// Publish (or rotate, if admin) the root for a campaign.
+    pub fn set_root(env: Env, campaign_id: Bytes, root: BytesN<32>) {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .unwrap_or_else(|| panic_with_error!(&env, Error::NotInitialized));
+        admin.require_auth();
+
+        let key = DataKey::Root(campaign_id.clone());
+        if env.storage().persistent().has(&key) {
+            // Rotation requires re-setting under the same id; emit the
+            // event so off-chain indexers can pick up the change.
+            env.storage().persistent().set(&key, &root);
+        } else {
+            env.storage().persistent().set(&key, &root);
+        }
+        env.storage().persistent().extend_ttl(
+            &key,
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+
+        RootSet { campaign_id, root }.publish(&env);
+    }
+
+    pub fn get_root(env: Env, campaign_id: Bytes) -> BytesN<32> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Root(campaign_id))
+            .unwrap_or_else(|| panic_with_error!(&env, Error::RootNotSet))
+    }
+
+    /// Verify a proof against the stored root. Read-only.
+    pub fn verify(
+        env: Env,
+        campaign_id: Bytes,
+        leaf: BytesN<32>,
+        proof: soroban_sdk::Vec<BytesN<32>>,
+    ) -> bool {
+        let root: BytesN<32> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Root(campaign_id))
+            .unwrap_or_else(|| panic_with_error!(&env, Error::RootNotSet));
+        verify_proof(&env, &root, &leaf, &proof)
+    }
+
+    /// Claim a leaf: caller must auth, the leaf must verify, and the
+    /// leaf must not have been claimed before.
+    pub fn claim(
+        env: Env,
+        campaign_id: Bytes,
+        claimant: Address,
+        leaf: BytesN<32>,
+        proof: soroban_sdk::Vec<BytesN<32>>,
+    ) {
+        claimant.require_auth();
+
+        let root: BytesN<32> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Root(campaign_id.clone()))
+            .unwrap_or_else(|| panic_with_error!(&env, Error::RootNotSet));
+
+        if !verify_proof(&env, &root, &leaf, &proof) {
+            panic_with_error!(&env, Error::InvalidProof);
+        }
+
+        let claim_key = DataKey::Claimed(campaign_id.clone(), leaf.clone());
+        if env.storage().persistent().has(&claim_key) {
+            panic_with_error!(&env, Error::AlreadyClaimed);
+        }
+        env.storage().persistent().set(&claim_key, &true);
+        env.storage().persistent().extend_ttl(
+            &claim_key,
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+
+        LeafClaimed {
+            campaign_id,
+            leaf,
+            claimant,
+        }
+        .publish(&env);
+    }
+
+    pub fn is_claimed(env: Env, campaign_id: Bytes, leaf: BytesN<32>) -> bool {
+        env.storage()
+            .persistent()
+            .has(&DataKey::Claimed(campaign_id, leaf))
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/contracts/merkle/src/tests.rs
+++ b/contracts/merkle/src/tests.rs
@@ -1,0 +1,163 @@
+use super::*;
+use soroban_sdk::{testutils::Address as _, vec, Bytes, BytesN, Env, Vec};
+
+fn h(env: &Env, bytes: &[u8]) -> BytesN<32> {
+    env.crypto().sha256(&Bytes::from_slice(env, bytes)).into()
+}
+
+#[test]
+fn verify_single_leaf_tree() {
+    let env = Env::default();
+    let leaf = h(&env, b"alice");
+    let proof: Vec<BytesN<32>> = vec![&env];
+    // A tree with a single leaf has the leaf as the root.
+    assert!(verify_proof(&env, &leaf, &leaf, &proof));
+}
+
+#[test]
+fn verify_two_leaf_tree() {
+    let env = Env::default();
+    let a = h(&env, b"alice");
+    let b = h(&env, b"bob");
+    let root = hash_pair_sorted(&env, &a, &b);
+
+    // Proof for alice = [b]
+    let proof_a: Vec<BytesN<32>> = vec![&env, b.clone()];
+    assert!(verify_proof(&env, &root, &a, &proof_a));
+
+    // Proof for bob = [a]
+    let proof_b: Vec<BytesN<32>> = vec![&env, a.clone()];
+    assert!(verify_proof(&env, &root, &b, &proof_b));
+
+    // Wrong sibling → fails.
+    let bogus = h(&env, b"mallory");
+    let proof_bogus: Vec<BytesN<32>> = vec![&env, bogus];
+    assert!(!verify_proof(&env, &root, &a, &proof_bogus));
+}
+
+#[test]
+fn verify_four_leaf_tree() {
+    let env = Env::default();
+    let a = h(&env, b"alice");
+    let b = h(&env, b"bob");
+    let c = h(&env, b"carol");
+    let d = h(&env, b"dave");
+    let ab = hash_pair_sorted(&env, &a, &b);
+    let cd = hash_pair_sorted(&env, &c, &d);
+    let root = hash_pair_sorted(&env, &ab, &cd);
+
+    // Proof for alice = [b, cd]
+    let proof_a: Vec<BytesN<32>> = vec![&env, b.clone(), cd.clone()];
+    assert!(verify_proof(&env, &root, &a, &proof_a));
+
+    // Proof for dave = [c, ab]
+    let proof_d: Vec<BytesN<32>> = vec![&env, c.clone(), ab.clone()];
+    assert!(verify_proof(&env, &root, &d, &proof_d));
+}
+
+#[test]
+fn hash_pair_is_order_independent() {
+    let env = Env::default();
+    let a = h(&env, b"a");
+    let b = h(&env, b"b");
+    assert_eq!(
+        hash_pair_sorted(&env, &a, &b),
+        hash_pair_sorted(&env, &b, &a),
+    );
+}
+
+#[test]
+fn full_claim_flow_two_leaves() {
+    let env = Env::default();
+    let contract_id = env.register(MerkleAirdropRegistry, ());
+    let client = MerkleAirdropRegistryClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin);
+
+    // Build a two-leaf tree off-chain (leaves = sha256("alice"), sha256("bob")).
+    let leaf_a = h(&env, b"alice");
+    let leaf_b = h(&env, b"bob");
+    let root = hash_pair_sorted(&env, &leaf_a, &leaf_b);
+
+    let campaign_id = Bytes::from_slice(&env, b"airdrop_1");
+    client.set_root(&campaign_id, &root);
+    assert_eq!(client.get_root(&campaign_id), root);
+
+    // Alice claims with proof [b].
+    let proof_a: Vec<BytesN<32>> = vec![&env, leaf_b.clone()];
+    assert!(client.verify(&campaign_id, &leaf_a, &proof_a));
+    client.claim(&campaign_id, &alice, &leaf_a, &proof_a);
+    assert!(client.is_claimed(&campaign_id, &leaf_a));
+
+    // Bob still can claim independently.
+    let proof_b: Vec<BytesN<32>> = vec![&env, leaf_a.clone()];
+    client.claim(&campaign_id, &bob, &leaf_b, &proof_b);
+    assert!(client.is_claimed(&campaign_id, &leaf_b));
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #6)")]
+fn double_claim_rejected() {
+    let env = Env::default();
+    let contract_id = env.register(MerkleAirdropRegistry, ());
+    let client = MerkleAirdropRegistryClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let alice = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin);
+
+    let leaf_a = h(&env, b"alice");
+    let leaf_b = h(&env, b"bob");
+    let root = hash_pair_sorted(&env, &leaf_a, &leaf_b);
+    let campaign_id = Bytes::from_slice(&env, b"airdrop_1");
+    client.set_root(&campaign_id, &root);
+
+    let proof: Vec<BytesN<32>> = vec![&env, leaf_b];
+    client.claim(&campaign_id, &alice, &leaf_a, &proof);
+    client.claim(&campaign_id, &alice, &leaf_a, &proof);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #5)")]
+fn invalid_proof_rejected() {
+    let env = Env::default();
+    let contract_id = env.register(MerkleAirdropRegistry, ());
+    let client = MerkleAirdropRegistryClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let alice = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin);
+
+    let leaf_a = h(&env, b"alice");
+    let leaf_b = h(&env, b"bob");
+    let root = hash_pair_sorted(&env, &leaf_a, &leaf_b);
+    let campaign_id = Bytes::from_slice(&env, b"airdrop_1");
+    client.set_root(&campaign_id, &root);
+
+    // Wrong sibling
+    let bogus = h(&env, b"mallory");
+    let bad_proof: Vec<BytesN<32>> = vec![&env, bogus];
+    client.claim(&campaign_id, &alice, &leaf_a, &bad_proof);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #4)")]
+fn claim_without_root_set_rejected() {
+    let env = Env::default();
+    let contract_id = env.register(MerkleAirdropRegistry, ());
+    let client = MerkleAirdropRegistryClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let alice = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin);
+
+    let leaf = h(&env, b"alice");
+    let proof: Vec<BytesN<32>> = vec![&env];
+    let campaign_id = Bytes::from_slice(&env, b"airdrop_404");
+    client.claim(&campaign_id, &alice, &leaf, &proof);
+}

--- a/docs/event-versioning.md
+++ b/docs/event-versioning.md
@@ -60,3 +60,29 @@ The namespace and version are combined in the first topic using `_v` as separato
 **v1** (versioned): Topics `["ArenaXReputation_v1", "REPUTATION_UPDATED"]`, data adds `source: u32` field.
 
 Server parser: v0 returns `source: null`, v1 returns `source` as-is. Consumer checks `event.version` to know which shape to expect.
+
+## Programmatic registry (issue #490)
+
+The shared event crate now exposes a machine-readable registry of every
+namespace it ships under `arenax_events::events_registry::NAMESPACES`. Each
+entry is a `NamespaceEntry { namespace, version }` constant, alphabetised by
+namespace. Off-chain indexers can call `events_registry::lookup(ns)` to
+resolve a topic prefix back to its current version, or iterate `NAMESPACES`
+to know which `(ns, version)` pairs to subscribe to.
+
+Test coverage in `contracts/arenax-events/src/registry_tests.rs` guards:
+
+- No empty `NAMESPACE` or `VERSION` constants.
+- `VERSION` follows the `vN` convention (ASCII digit suffix).
+- No duplicate `NAMESPACE` across modules (catches accidental collisions
+  if two domains pick the same string).
+- `lookup()` round-trips every registered entry.
+
+Adding a new event module is therefore a four-step process:
+
+1. Create `contracts/arenax-events/src/<module>.rs` with `NAMESPACE` and
+   `VERSION` constants.
+2. Add the `pub mod <module>;` line to `lib.rs`.
+3. Append a `NamespaceEntry` line to `events_registry::NAMESPACES`.
+4. Run `cargo test -p arenax-events` — the uniqueness + format tests
+   confirm the wiring.

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -8,6 +8,13 @@
             "name": "arenax-server",
             "version": "0.1.0",
             "dependencies": {
+                "@opentelemetry/api": "^1.9.0",
+                "@opentelemetry/auto-instrumentations-node": "^0.55.0",
+                "@opentelemetry/exporter-trace-otlp-http": "^0.57.0",
+                "@opentelemetry/resources": "^1.30.0",
+                "@opentelemetry/sdk-node": "^0.57.0",
+                "@opentelemetry/sdk-trace-base": "^1.30.0",
+                "@opentelemetry/semantic-conventions": "^1.30.0",
                 "@prisma/client": "^5.10.2",
                 "@sentry/node": "^9.18.0",
                 "@stellar/stellar-sdk": "^11.3.0",
@@ -87,6 +94,37 @@
                 "kuler": "^2.0.0"
             }
         },
+        "node_modules/@grpc/grpc-js": {
+            "version": "1.14.4",
+            "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+            "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@grpc/proto-loader": "^0.8.0",
+                "@js-sdsl/ordered-map": "^4.4.2"
+            },
+            "engines": {
+                "node": ">=12.10.0"
+            }
+        },
+        "node_modules/@grpc/proto-loader": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+            "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "lodash.camelcase": "^4.3.0",
+                "long": "^5.0.0",
+                "protobufjs": "^7.5.5",
+                "yargs": "^17.7.2"
+            },
+            "bin": {
+                "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/@ioredis/commands": {
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.10.0.tgz",
@@ -133,6 +171,16 @@
                 "@jridgewell/sourcemap-codec": "^1.4.10"
             }
         },
+        "node_modules/@js-sdsl/ordered-map": {
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+            "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/js-sdsl"
+            }
+        },
         "node_modules/@mapbox/node-pre-gyp": {
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
@@ -174,6 +222,112 @@
                 "node": ">=14"
             }
         },
+        "node_modules/@opentelemetry/auto-instrumentations-node": {
+            "version": "0.55.3",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/auto-instrumentations-node/-/auto-instrumentations-node-0.55.3.tgz",
+            "integrity": "sha512-tX5k3ZG8Nk6f1DHAF0K1ClP/OiW2hNuSeCVqDHNMcJ58dZSiad0XO2mwrvSipo77/DPXXUl0j9MxqmUVITdujQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/instrumentation": "^0.57.0",
+                "@opentelemetry/instrumentation-amqplib": "^0.46.0",
+                "@opentelemetry/instrumentation-aws-lambda": "^0.50.2",
+                "@opentelemetry/instrumentation-aws-sdk": "^0.49.0",
+                "@opentelemetry/instrumentation-bunyan": "^0.45.0",
+                "@opentelemetry/instrumentation-cassandra-driver": "^0.45.0",
+                "@opentelemetry/instrumentation-connect": "^0.43.0",
+                "@opentelemetry/instrumentation-cucumber": "^0.13.0",
+                "@opentelemetry/instrumentation-dataloader": "^0.16.0",
+                "@opentelemetry/instrumentation-dns": "^0.43.0",
+                "@opentelemetry/instrumentation-express": "^0.47.0",
+                "@opentelemetry/instrumentation-fastify": "^0.44.1",
+                "@opentelemetry/instrumentation-fs": "^0.19.0",
+                "@opentelemetry/instrumentation-generic-pool": "^0.43.0",
+                "@opentelemetry/instrumentation-graphql": "^0.47.0",
+                "@opentelemetry/instrumentation-grpc": "^0.57.0",
+                "@opentelemetry/instrumentation-hapi": "^0.45.1",
+                "@opentelemetry/instrumentation-http": "^0.57.0",
+                "@opentelemetry/instrumentation-ioredis": "^0.47.0",
+                "@opentelemetry/instrumentation-kafkajs": "^0.7.0",
+                "@opentelemetry/instrumentation-knex": "^0.44.0",
+                "@opentelemetry/instrumentation-koa": "^0.47.0",
+                "@opentelemetry/instrumentation-lru-memoizer": "^0.44.0",
+                "@opentelemetry/instrumentation-memcached": "^0.43.0",
+                "@opentelemetry/instrumentation-mongodb": "^0.51.0",
+                "@opentelemetry/instrumentation-mongoose": "^0.46.0",
+                "@opentelemetry/instrumentation-mysql": "^0.45.0",
+                "@opentelemetry/instrumentation-mysql2": "^0.45.0",
+                "@opentelemetry/instrumentation-nestjs-core": "^0.44.0",
+                "@opentelemetry/instrumentation-net": "^0.43.0",
+                "@opentelemetry/instrumentation-pg": "^0.50.0",
+                "@opentelemetry/instrumentation-pino": "^0.46.0",
+                "@opentelemetry/instrumentation-redis": "^0.46.0",
+                "@opentelemetry/instrumentation-redis-4": "^0.46.0",
+                "@opentelemetry/instrumentation-restify": "^0.45.0",
+                "@opentelemetry/instrumentation-router": "^0.44.0",
+                "@opentelemetry/instrumentation-socket.io": "^0.46.0",
+                "@opentelemetry/instrumentation-tedious": "^0.18.0",
+                "@opentelemetry/instrumentation-undici": "^0.10.0",
+                "@opentelemetry/instrumentation-winston": "^0.44.0",
+                "@opentelemetry/resource-detector-alibaba-cloud": "^0.30.0",
+                "@opentelemetry/resource-detector-aws": "^1.11.0",
+                "@opentelemetry/resource-detector-azure": "^0.6.0",
+                "@opentelemetry/resource-detector-container": "^0.6.0",
+                "@opentelemetry/resource-detector-gcp": "^0.33.0",
+                "@opentelemetry/resources": "^1.24.0",
+                "@opentelemetry/sdk-node": "^0.57.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.4.1"
+            }
+        },
+        "node_modules/@opentelemetry/auto-instrumentations-node/node_modules/@opentelemetry/instrumentation-mongodb": {
+            "version": "0.51.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.51.0.tgz",
+            "integrity": "sha512-cMKASxCX4aFxesoj3WK8uoQ0YUrRvnfxaO72QWI2xLu5ZtgX/QvdGBlU3Ehdond5eb74c2s1cqRQUIptBnKz1g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/instrumentation": "^0.57.0",
+                "@opentelemetry/semantic-conventions": "^1.27.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/auto-instrumentations-node/node_modules/@opentelemetry/instrumentation-pg": {
+            "version": "0.50.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.50.0.tgz",
+            "integrity": "sha512-TtLxDdYZmBhFswm8UIsrDjh/HFBeDXd4BLmE8h2MxirNHewLJ0VS9UUddKKEverb5Sm2qFVjqRjcU+8Iw4FJ3w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "^1.26.0",
+                "@opentelemetry/instrumentation": "^0.57.0",
+                "@opentelemetry/semantic-conventions": "1.27.0",
+                "@opentelemetry/sql-common": "^0.40.1",
+                "@types/pg": "8.6.1",
+                "@types/pg-pool": "2.0.6"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/auto-instrumentations-node/node_modules/@opentelemetry/semantic-conventions": {
+            "version": "1.27.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.27.0.tgz",
+            "integrity": "sha512-sAay1RrB+ONOem0OZanAR1ZI/k7yDpnOQSQmTMuGImUQb2y8EbSaCJ94FQluM74xoU03vlb2d2U90hZluL6nQg==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=14"
+            }
+        },
         "node_modules/@opentelemetry/context-async-hooks": {
             "version": "1.30.1",
             "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.1.tgz",
@@ -202,6 +356,230 @@
             }
         },
         "node_modules/@opentelemetry/core/node_modules/@opentelemetry/semantic-conventions": {
+            "version": "1.28.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+            "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-logs-otlp-grpc": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-grpc/-/exporter-logs-otlp-grpc-0.57.2.tgz",
+            "integrity": "sha512-eovEy10n3umjKJl2Ey6TLzikPE+W4cUQ4gCwgGP1RqzTGtgDra0WjIqdy29ohiUKfvmbiL3MndZww58xfIvyFw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@grpc/grpc-js": "^1.7.1",
+                "@opentelemetry/core": "1.30.1",
+                "@opentelemetry/otlp-exporter-base": "0.57.2",
+                "@opentelemetry/otlp-grpc-exporter-base": "0.57.2",
+                "@opentelemetry/otlp-transformer": "0.57.2",
+                "@opentelemetry/sdk-logs": "0.57.2"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-logs-otlp-http": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.57.2.tgz",
+            "integrity": "sha512-0rygmvLcehBRp56NQVLSleJ5ITTduq/QfU7obOkyWgPpFHulwpw2LYTqNIz5TczKZuy5YY+5D3SDnXZL1tXImg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.57.2",
+                "@opentelemetry/core": "1.30.1",
+                "@opentelemetry/otlp-exporter-base": "0.57.2",
+                "@opentelemetry/otlp-transformer": "0.57.2",
+                "@opentelemetry/sdk-logs": "0.57.2"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-logs-otlp-proto": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-proto/-/exporter-logs-otlp-proto-0.57.2.tgz",
+            "integrity": "sha512-ta0ithCin0F8lu9eOf4lEz9YAScecezCHkMMyDkvd9S7AnZNX5ikUmC5EQOQADU+oCcgo/qkQIaKcZvQ0TYKDw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.57.2",
+                "@opentelemetry/core": "1.30.1",
+                "@opentelemetry/otlp-exporter-base": "0.57.2",
+                "@opentelemetry/otlp-transformer": "0.57.2",
+                "@opentelemetry/resources": "1.30.1",
+                "@opentelemetry/sdk-logs": "0.57.2",
+                "@opentelemetry/sdk-trace-base": "1.30.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-metrics-otlp-grpc": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-grpc/-/exporter-metrics-otlp-grpc-0.57.2.tgz",
+            "integrity": "sha512-r70B8yKR41F0EC443b5CGB4rUaOMm99I5N75QQt6sHKxYDzSEc6gm48Diz1CI1biwa5tDPznpylTrywO/pT7qw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@grpc/grpc-js": "^1.7.1",
+                "@opentelemetry/core": "1.30.1",
+                "@opentelemetry/exporter-metrics-otlp-http": "0.57.2",
+                "@opentelemetry/otlp-exporter-base": "0.57.2",
+                "@opentelemetry/otlp-grpc-exporter-base": "0.57.2",
+                "@opentelemetry/otlp-transformer": "0.57.2",
+                "@opentelemetry/resources": "1.30.1",
+                "@opentelemetry/sdk-metrics": "1.30.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-metrics-otlp-http": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.57.2.tgz",
+            "integrity": "sha512-ttb9+4iKw04IMubjm3t0EZsYRNWr3kg44uUuzfo9CaccYlOh8cDooe4QObDUkvx9d5qQUrbEckhrWKfJnKhemA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "1.30.1",
+                "@opentelemetry/otlp-exporter-base": "0.57.2",
+                "@opentelemetry/otlp-transformer": "0.57.2",
+                "@opentelemetry/resources": "1.30.1",
+                "@opentelemetry/sdk-metrics": "1.30.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-metrics-otlp-proto": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.57.2.tgz",
+            "integrity": "sha512-HX068Q2eNs38uf7RIkNN9Hl4Ynl+3lP0++KELkXMCpsCbFO03+0XNNZ1SkwxPlP9jrhQahsMPMkzNXpq3fKsnw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "1.30.1",
+                "@opentelemetry/exporter-metrics-otlp-http": "0.57.2",
+                "@opentelemetry/otlp-exporter-base": "0.57.2",
+                "@opentelemetry/otlp-transformer": "0.57.2",
+                "@opentelemetry/resources": "1.30.1",
+                "@opentelemetry/sdk-metrics": "1.30.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-prometheus": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.57.2.tgz",
+            "integrity": "sha512-VqIqXnuxWMWE/1NatAGtB1PvsQipwxDcdG4RwA/umdBcW3/iOHp0uejvFHTRN2O78ZPged87ErJajyUBPUhlDQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "1.30.1",
+                "@opentelemetry/resources": "1.30.1",
+                "@opentelemetry/sdk-metrics": "1.30.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.57.2.tgz",
+            "integrity": "sha512-gHU1vA3JnHbNxEXg5iysqCWxN9j83d7/epTYBZflqQnTyCC4N7yZXn/dMM+bEmyhQPGjhCkNZLx4vZuChH1PYw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@grpc/grpc-js": "^1.7.1",
+                "@opentelemetry/core": "1.30.1",
+                "@opentelemetry/otlp-exporter-base": "0.57.2",
+                "@opentelemetry/otlp-grpc-exporter-base": "0.57.2",
+                "@opentelemetry/otlp-transformer": "0.57.2",
+                "@opentelemetry/resources": "1.30.1",
+                "@opentelemetry/sdk-trace-base": "1.30.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-trace-otlp-http": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.57.2.tgz",
+            "integrity": "sha512-sB/gkSYFu+0w2dVQ0PWY9fAMl172PKMZ/JrHkkW8dmjCL0CYkmXeE+ssqIL/yBUTPOvpLIpenX5T9RwXRBW/3g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "1.30.1",
+                "@opentelemetry/otlp-exporter-base": "0.57.2",
+                "@opentelemetry/otlp-transformer": "0.57.2",
+                "@opentelemetry/resources": "1.30.1",
+                "@opentelemetry/sdk-trace-base": "1.30.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-trace-otlp-proto": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.57.2.tgz",
+            "integrity": "sha512-awDdNRMIwDvUtoRYxRhja5QYH6+McBLtoz1q9BeEsskhZcrGmH/V1fWpGx8n+Rc+542e8pJA6y+aullbIzQmlw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "1.30.1",
+                "@opentelemetry/otlp-exporter-base": "0.57.2",
+                "@opentelemetry/otlp-transformer": "0.57.2",
+                "@opentelemetry/resources": "1.30.1",
+                "@opentelemetry/sdk-trace-base": "1.30.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-zipkin": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.30.1.tgz",
+            "integrity": "sha512-6S2QIMJahIquvFaaxmcwpvQQRD/YFaMTNoIxrfPIPOeITN+a8lfEcPDxNxn8JDAaxkg+4EnXhz8upVDYenoQjA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "1.30.1",
+                "@opentelemetry/resources": "1.30.1",
+                "@opentelemetry/sdk-trace-base": "1.30.1",
+                "@opentelemetry/semantic-conventions": "1.28.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.0.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-zipkin/node_modules/@opentelemetry/semantic-conventions": {
             "version": "1.28.0",
             "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
             "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
@@ -247,6 +625,74 @@
                 "@opentelemetry/api": "^1.3.0"
             }
         },
+        "node_modules/@opentelemetry/instrumentation-aws-lambda": {
+            "version": "0.50.3",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-lambda/-/instrumentation-aws-lambda-0.50.3.tgz",
+            "integrity": "sha512-kotm/mRvSWUauudxcylc5YCDei+G/r+jnOH6q5S99aPLQ/Ms8D2yonMIxEJUILIPlthEmwLYxkw3ualWzMjm/A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/instrumentation": "^0.57.1",
+                "@opentelemetry/semantic-conventions": "^1.27.0",
+                "@types/aws-lambda": "8.10.147"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-aws-sdk": {
+            "version": "0.49.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-sdk/-/instrumentation-aws-sdk-0.49.1.tgz",
+            "integrity": "sha512-Vbj4BYeV/1K4Pbbfk+gQ8gwYL0w+tBeUwG88cOxnF7CLPO1XnskGV8Q3Gzut2Ah/6Dg17dBtlzEqL3UiFP2Z6A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "^1.8.0",
+                "@opentelemetry/instrumentation": "^0.57.1",
+                "@opentelemetry/propagation-utils": "^0.30.16",
+                "@opentelemetry/semantic-conventions": "^1.27.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-bunyan": {
+            "version": "0.45.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-bunyan/-/instrumentation-bunyan-0.45.1.tgz",
+            "integrity": "sha512-T9POV9ccS41UjpsjLrJ4i0m8LfplBiN3dMeH9XZ2btiDrjoaWtDrst6tNb1avetBjkeshOuBp1EWKP22EVSr0g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "^0.57.1",
+                "@opentelemetry/instrumentation": "^0.57.1",
+                "@types/bunyan": "1.8.11"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-cassandra-driver": {
+            "version": "0.45.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-cassandra-driver/-/instrumentation-cassandra-driver-0.45.1.tgz",
+            "integrity": "sha512-RqnP0rK2hcKK1AKcmYvedLiL6G5TvFGiSUt2vI9wN0cCBdTt9Y9+wxxY19KoGxq7e9T/aHow6P5SUhCVI1sHvQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/instrumentation": "^0.57.1",
+                "@opentelemetry/semantic-conventions": "^1.27.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
         "node_modules/@opentelemetry/instrumentation-connect": {
             "version": "0.43.1",
             "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.43.1.tgz",
@@ -265,6 +711,22 @@
                 "@opentelemetry/api": "^1.3.0"
             }
         },
+        "node_modules/@opentelemetry/instrumentation-cucumber": {
+            "version": "0.13.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-cucumber/-/instrumentation-cucumber-0.13.0.tgz",
+            "integrity": "sha512-ZBswBKONU2g7mhjEKF4vkTXxezq16QdvGaD5W4o01/t5KzvCZGQ6hYPsB34miJIj/hh6UrFLRDAjqb7nur5I3Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/instrumentation": "^0.57.0",
+                "@opentelemetry/semantic-conventions": "^1.27.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.0.0"
+            }
+        },
         "node_modules/@opentelemetry/instrumentation-dataloader": {
             "version": "0.16.1",
             "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.16.1.tgz",
@@ -280,10 +742,42 @@
                 "@opentelemetry/api": "^1.3.0"
             }
         },
+        "node_modules/@opentelemetry/instrumentation-dns": {
+            "version": "0.43.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dns/-/instrumentation-dns-0.43.1.tgz",
+            "integrity": "sha512-e/tMZYU1nc+k+J3259CQtqVZIPsPRSLNoAQbGEmSKrjLEY/KJSbpBZ17lu4dFVBzqoF1cZYIZxn9WPQxy4V9ng==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/instrumentation": "^0.57.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
         "node_modules/@opentelemetry/instrumentation-express": {
             "version": "0.47.1",
             "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.47.1.tgz",
             "integrity": "sha512-QNXPTWteDclR2B4pDFpz0TNghgB33UMjUt14B+BZPmtH1MwUFAfLHBaP5If0Z5NZC+jaH8oF2glgYjrmhZWmSw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "^1.8.0",
+                "@opentelemetry/instrumentation": "^0.57.1",
+                "@opentelemetry/semantic-conventions": "^1.27.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-fastify": {
+            "version": "0.44.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.44.2.tgz",
+            "integrity": "sha512-arSp97Y4D2NWogoXRb8CzFK3W2ooVdvqRRtQDljFt9uC3zI6OuShgey6CVFC0JxT1iGjkAr1r4PDz23mWrFULQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@opentelemetry/core": "^1.8.0",
@@ -341,6 +835,31 @@
             },
             "peerDependencies": {
                 "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-grpc": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.57.2.tgz",
+            "integrity": "sha512-TR6YQA67cLSZzdxbf2SrbADJy2Y8eBW1+9mF15P0VK2MYcpdoUSmQTF1oMkBwa3B9NwqDFA2fq7wYTTutFQqaQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/instrumentation": "0.57.2",
+                "@opentelemetry/semantic-conventions": "1.28.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-grpc/node_modules/@opentelemetry/semantic-conventions": {
+            "version": "1.28.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+            "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=14"
             }
         },
         "node_modules/@opentelemetry/instrumentation-hapi": {
@@ -469,6 +988,23 @@
                 "@opentelemetry/api": "^1.3.0"
             }
         },
+        "node_modules/@opentelemetry/instrumentation-memcached": {
+            "version": "0.43.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-memcached/-/instrumentation-memcached-0.43.1.tgz",
+            "integrity": "sha512-rK5YWC22gmsLp2aEbaPk5F+9r6BFFZuc9GTnW/ErrWpz2XNHUgeFInoPDg4t+Trs8OttIfn8XwkfFkSKqhxanw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/instrumentation": "^0.57.1",
+                "@opentelemetry/semantic-conventions": "^1.27.0",
+                "@types/memcached": "^2.2.6"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
         "node_modules/@opentelemetry/instrumentation-mongodb": {
             "version": "0.52.0",
             "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.52.0.tgz",
@@ -536,6 +1072,38 @@
                 "@opentelemetry/api": "^1.3.0"
             }
         },
+        "node_modules/@opentelemetry/instrumentation-nestjs-core": {
+            "version": "0.44.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-nestjs-core/-/instrumentation-nestjs-core-0.44.1.tgz",
+            "integrity": "sha512-4TXaqJK27QXoMqrt4+hcQ6rKFd8B6V4JfrTJKnqBmWR1cbaqd/uwyl9yxhNH1JEkyo8GaBfdpBC4ZE4FuUhPmg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/instrumentation": "^0.57.1",
+                "@opentelemetry/semantic-conventions": "^1.27.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-net": {
+            "version": "0.43.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-net/-/instrumentation-net-0.43.1.tgz",
+            "integrity": "sha512-TaMqP6tVx9/SxlY81dHlSyP5bWJIKq+K7vKfk4naB/LX4LBePPY3++1s0edpzH+RfwN+tEGVW9zTb9ci0up/lQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/instrumentation": "^0.57.1",
+                "@opentelemetry/semantic-conventions": "^1.27.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
         "node_modules/@opentelemetry/instrumentation-pg": {
             "version": "0.51.1",
             "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.51.1.tgz",
@@ -556,6 +1124,40 @@
                 "@opentelemetry/api": "^1.3.0"
             }
         },
+        "node_modules/@opentelemetry/instrumentation-pino": {
+            "version": "0.46.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pino/-/instrumentation-pino-0.46.1.tgz",
+            "integrity": "sha512-HB8gD/9CNAKlTV+mdZehnFC4tLUtQ7e+729oGq88e4WipxzZxmMYuRwZ2vzOA9/APtq+MRkERJ9PcoDqSIjZ+g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "^0.57.1",
+                "@opentelemetry/core": "^1.25.0",
+                "@opentelemetry/instrumentation": "^0.57.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-redis": {
+            "version": "0.46.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.46.1.tgz",
+            "integrity": "sha512-AN7OvlGlXmlvsgbLHs6dS1bggp6Fcki+GxgYZdSrb/DB692TyfjR7sVILaCe0crnP66aJuXsg9cge3hptHs9UA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/instrumentation": "^0.57.1",
+                "@opentelemetry/redis-common": "^0.36.2",
+                "@opentelemetry/semantic-conventions": "^1.27.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
         "node_modules/@opentelemetry/instrumentation-redis-4": {
             "version": "0.46.1",
             "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.46.1.tgz",
@@ -564,6 +1166,55 @@
             "dependencies": {
                 "@opentelemetry/instrumentation": "^0.57.1",
                 "@opentelemetry/redis-common": "^0.36.2",
+                "@opentelemetry/semantic-conventions": "^1.27.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-restify": {
+            "version": "0.45.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-restify/-/instrumentation-restify-0.45.1.tgz",
+            "integrity": "sha512-Zd6Go9iEa+0zcoA2vDka9r/plYKaT3BhD3ESIy4JNIzFWXeQBGbH3zZxQIsz0jbNTMEtonlymU7eTLeaGWiApA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "^1.8.0",
+                "@opentelemetry/instrumentation": "^0.57.1",
+                "@opentelemetry/semantic-conventions": "^1.27.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-router": {
+            "version": "0.44.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-router/-/instrumentation-router-0.44.1.tgz",
+            "integrity": "sha512-l4T/S7ByjpY5TCUPeDe1GPns02/5BpR0jroSMexyH3ZnXJt9PtYqx1IKAlOjaFEGEOQF2tGDsMi4PY5l+fSniQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/instrumentation": "^0.57.1",
+                "@opentelemetry/semantic-conventions": "^1.27.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-socket.io": {
+            "version": "0.46.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-socket.io/-/instrumentation-socket.io-0.46.1.tgz",
+            "integrity": "sha512-9AsCVUAHOqvfe2RM/2I0DsDnx2ihw1d5jIN4+Bly1YPFTJIbk4+bXjAkr9+X6PUfhiV5urQHZkiYYPU1Q4yzPA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/instrumentation": "^0.57.1",
                 "@opentelemetry/semantic-conventions": "^1.27.0"
             },
             "engines": {
@@ -606,6 +1257,119 @@
                 "@opentelemetry/api": "^1.7.0"
             }
         },
+        "node_modules/@opentelemetry/instrumentation-winston": {
+            "version": "0.44.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-winston/-/instrumentation-winston-0.44.1.tgz",
+            "integrity": "sha512-iexblTsT3fP0hHUz/M1mWr+Ylg3bsYN2En/jvKXZtboW3Qkvt17HrQJYTF9leVIkXAfN97QxAcTE99YGbQW7vQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "^0.57.1",
+                "@opentelemetry/instrumentation": "^0.57.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/otlp-exporter-base": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.57.2.tgz",
+            "integrity": "sha512-XdxEzL23Urhidyebg5E6jZoaiW5ygP/mRjxLHixogbqwDy2Faduzb5N0o/Oi+XTIJu+iyxXdVORjXax+Qgfxag==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "1.30.1",
+                "@opentelemetry/otlp-transformer": "0.57.2"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/otlp-grpc-exporter-base": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.57.2.tgz",
+            "integrity": "sha512-USn173KTWy0saqqRB5yU9xUZ2xdgb1Rdu5IosJnm9aV4hMTuFFRTUsQxbgc24QxpCHeoKzzCSnS/JzdV0oM2iQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@grpc/grpc-js": "^1.7.1",
+                "@opentelemetry/core": "1.30.1",
+                "@opentelemetry/otlp-exporter-base": "0.57.2",
+                "@opentelemetry/otlp-transformer": "0.57.2"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/otlp-transformer": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.57.2.tgz",
+            "integrity": "sha512-48IIRj49gbQVK52jYsw70+Jv+JbahT8BqT2Th7C4H7RCM9d0gZ5sgNPoMpWldmfjvIsSgiGJtjfk9MeZvjhoig==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.57.2",
+                "@opentelemetry/core": "1.30.1",
+                "@opentelemetry/resources": "1.30.1",
+                "@opentelemetry/sdk-logs": "0.57.2",
+                "@opentelemetry/sdk-metrics": "1.30.1",
+                "@opentelemetry/sdk-trace-base": "1.30.1",
+                "protobufjs": "^7.3.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/propagation-utils": {
+            "version": "0.30.16",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/propagation-utils/-/propagation-utils-0.30.16.tgz",
+            "integrity": "sha512-ZVQ3Z/PQ+2GQlrBfbMMMT0U7MzvYZLCPP800+ooyaBqm4hMvuQHfP028gB9/db0mwkmyEAMad9houukUVxhwcw==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.0.0"
+            }
+        },
+        "node_modules/@opentelemetry/propagator-b3": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.30.1.tgz",
+            "integrity": "sha512-oATwWWDIJzybAZ4pO76ATN5N6FFbOA1otibAVlS8v90B4S1wClnhRUk7K+2CHAwN1JKYuj4jh/lpCEG5BAqFuQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "1.30.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/propagator-jaeger": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.30.1.tgz",
+            "integrity": "sha512-Pj/BfnYEKIOImirH76M4hDaBSx6HyZ2CXUqk+Kj02m6BB80c/yo4BdWkn/1gDFfU+YPY+bPR2U0DKBfdxCKwmg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "1.30.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
         "node_modules/@opentelemetry/redis-common": {
             "version": "0.36.2",
             "resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.36.2.tgz",
@@ -613,6 +1377,92 @@
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=14"
+            }
+        },
+        "node_modules/@opentelemetry/resource-detector-alibaba-cloud": {
+            "version": "0.30.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-alibaba-cloud/-/resource-detector-alibaba-cloud-0.30.1.tgz",
+            "integrity": "sha512-9l0FVP3F4+Z6ax27vMzkmhZdNtxAbDqEfy7rduzya3xFLaRiJSvOpw6cru6Edl5LwO+WvgNui+VzHa9ViE8wCg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "^1.26.0",
+                "@opentelemetry/resources": "^1.10.0",
+                "@opentelemetry/semantic-conventions": "^1.27.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.0.0"
+            }
+        },
+        "node_modules/@opentelemetry/resource-detector-aws": {
+            "version": "1.12.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-aws/-/resource-detector-aws-1.12.0.tgz",
+            "integrity": "sha512-Cvi7ckOqiiuWlHBdA1IjS0ufr3sltex2Uws2RK6loVp4gzIJyOijsddAI6IZ5kiO8h/LgCWe8gxPmwkTKImd+Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "^1.0.0",
+                "@opentelemetry/resources": "^1.10.0",
+                "@opentelemetry/semantic-conventions": "^1.27.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.0.0"
+            }
+        },
+        "node_modules/@opentelemetry/resource-detector-azure": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-azure/-/resource-detector-azure-0.6.1.tgz",
+            "integrity": "sha512-Djr31QCExVfWViaf9cGJnH+bUInD72p0GEfgDGgjCAztyvyji6WJvKjs6qmkpPN+Ig6KLk0ho2VgzT5Kdl4L2Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "^1.25.1",
+                "@opentelemetry/resources": "^1.10.1",
+                "@opentelemetry/semantic-conventions": "^1.27.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.0.0"
+            }
+        },
+        "node_modules/@opentelemetry/resource-detector-container": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-container/-/resource-detector-container-0.6.1.tgz",
+            "integrity": "sha512-o4sLzx149DQXDmVa8pgjBDEEKOj9SuQnkSLbjUVOpQNnn10v0WNR6wLwh30mFsK26xOJ6SpqZBGKZiT7i5MjlA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "^1.26.0",
+                "@opentelemetry/resources": "^1.10.0",
+                "@opentelemetry/semantic-conventions": "^1.27.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.0.0"
+            }
+        },
+        "node_modules/@opentelemetry/resource-detector-gcp": {
+            "version": "0.33.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-gcp/-/resource-detector-gcp-0.33.1.tgz",
+            "integrity": "sha512-/aZJXI1rU6Eus04ih2vU0hxXAibXXMzH1WlDZ8bXcTJmhwmTY8cP392+6l7cWeMnTQOibBUz8UKV3nhcCBAefw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "^1.0.0",
+                "@opentelemetry/resources": "^1.10.0",
+                "@opentelemetry/semantic-conventions": "^1.27.0",
+                "gcp-metadata": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.0.0"
             }
         },
         "node_modules/@opentelemetry/resources": {
@@ -632,6 +1482,82 @@
             }
         },
         "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/semantic-conventions": {
+            "version": "1.28.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+            "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-logs": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.57.2.tgz",
+            "integrity": "sha512-TXFHJ5c+BKggWbdEQ/inpgIzEmS2BGQowLE9UhsMd7YYlUfBQJ4uax0VF/B5NYigdM/75OoJGhAV3upEhK+3gg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.57.2",
+                "@opentelemetry/core": "1.30.1",
+                "@opentelemetry/resources": "1.30.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.4.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-metrics": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.30.1.tgz",
+            "integrity": "sha512-q9zcZ0Okl8jRgmy7eNW3Ku1XSgg3sDLa5evHZpCwjspw7E8Is4K/haRPDJrBcX3YSn/Y7gUvFnByNYEKQNbNog==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "1.30.1",
+                "@opentelemetry/resources": "1.30.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-node": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.57.2.tgz",
+            "integrity": "sha512-8BaeqZyN5sTuPBtAoY+UtKwXBdqyuRKmekN5bFzAO40CgbGzAxfTpiL3PBerT7rhZ7p2nBdq7FaMv/tBQgHE4A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.57.2",
+                "@opentelemetry/core": "1.30.1",
+                "@opentelemetry/exporter-logs-otlp-grpc": "0.57.2",
+                "@opentelemetry/exporter-logs-otlp-http": "0.57.2",
+                "@opentelemetry/exporter-logs-otlp-proto": "0.57.2",
+                "@opentelemetry/exporter-metrics-otlp-grpc": "0.57.2",
+                "@opentelemetry/exporter-metrics-otlp-http": "0.57.2",
+                "@opentelemetry/exporter-metrics-otlp-proto": "0.57.2",
+                "@opentelemetry/exporter-prometheus": "0.57.2",
+                "@opentelemetry/exporter-trace-otlp-grpc": "0.57.2",
+                "@opentelemetry/exporter-trace-otlp-http": "0.57.2",
+                "@opentelemetry/exporter-trace-otlp-proto": "0.57.2",
+                "@opentelemetry/exporter-zipkin": "1.30.1",
+                "@opentelemetry/instrumentation": "0.57.2",
+                "@opentelemetry/resources": "1.30.1",
+                "@opentelemetry/sdk-logs": "0.57.2",
+                "@opentelemetry/sdk-metrics": "1.30.1",
+                "@opentelemetry/sdk-trace-base": "1.30.1",
+                "@opentelemetry/sdk-trace-node": "1.30.1",
+                "@opentelemetry/semantic-conventions": "1.28.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/semantic-conventions": {
             "version": "1.28.0",
             "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
             "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
@@ -664,6 +1590,26 @@
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=14"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-trace-node": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.30.1.tgz",
+            "integrity": "sha512-cBjYOINt1JxXdpw1e5MlHmFRc5fgj4GW/86vsKFxJCJ8AL4PdVtYH41gWwl4qd4uQjqEL1oJVrXkSy5cnduAnQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/context-async-hooks": "1.30.1",
+                "@opentelemetry/core": "1.30.1",
+                "@opentelemetry/propagator-b3": "1.30.1",
+                "@opentelemetry/propagator-jaeger": "1.30.1",
+                "@opentelemetry/sdk-trace-base": "1.30.1",
+                "semver": "^7.5.2"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
             }
         },
         "node_modules/@opentelemetry/semantic-conventions": {
@@ -769,6 +1715,63 @@
             "peerDependencies": {
                 "@opentelemetry/api": "^1.8"
             }
+        },
+        "node_modules/@protobufjs/aspromise": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+            "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@protobufjs/base64": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+            "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@protobufjs/codegen": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+            "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@protobufjs/eventemitter": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+            "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@protobufjs/fetch": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+            "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@protobufjs/aspromise": "^1.1.1"
+            }
+        },
+        "node_modules/@protobufjs/float": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+            "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@protobufjs/path": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+            "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@protobufjs/pool": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+            "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@protobufjs/utf8": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+            "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+            "license": "BSD-3-Clause"
         },
         "node_modules/@sentry/core": {
             "version": "9.47.1",
@@ -985,6 +1988,12 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@types/aws-lambda": {
+            "version": "8.10.147",
+            "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.147.tgz",
+            "integrity": "sha512-nD0Z9fNIZcxYX5Mai2CTmFD7wX7UldCkW2ezCF8D1T5hdiLsnTWDGRpfRYntU6VjTdLQjOvyszru7I1c1oCQew==",
+            "license": "MIT"
+        },
         "node_modules/@types/bcrypt": {
             "version": "5.0.2",
             "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-5.0.2.tgz",
@@ -1002,6 +2011,15 @@
             "license": "MIT",
             "dependencies": {
                 "@types/connect": "*",
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/bunyan": {
+            "version": "1.8.11",
+            "resolved": "https://registry.npmjs.org/@types/bunyan/-/bunyan-1.8.11.tgz",
+            "integrity": "sha512-758fRH7umIMk5qt5ELmRMff4mLDlN+xyYzC+dkPTdKwbSkJFvz6xwyScrytPU0QIBbRRwbiE8/BIg8bpajerNQ==",
+            "license": "MIT",
+            "dependencies": {
                 "@types/node": "*"
             }
         },
@@ -1072,6 +2090,15 @@
             "license": "MIT",
             "dependencies": {
                 "@types/ms": "*",
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/memcached": {
+            "version": "2.2.10",
+            "resolved": "https://registry.npmjs.org/@types/memcached/-/memcached-2.2.10.tgz",
+            "integrity": "sha512-AM9smvZN55Gzs2wRrqeMHVP7KE8KWgCJO/XL5yCly2xF6EKa4YlbpK+cLSAH4NG/Ah64HrlegmGqW8kYws7Vxg==",
+            "license": "MIT",
+            "dependencies": {
                 "@types/node": "*"
             }
         },
@@ -1407,6 +2434,39 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/ansi-styles/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "license": "MIT",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/ansi-styles/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "license": "MIT"
         },
         "node_modules/anymatch": {
             "version": "3.1.3",
@@ -1811,6 +2871,20 @@
             "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
             "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
             "license": "MIT"
+        },
+        "node_modules/cliui": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+            "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.1",
+                "wrap-ansi": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/cluster-key-slot": {
             "version": "1.1.2",
@@ -2296,6 +3370,15 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/escalade": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+            "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/escape-html": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -2380,6 +3463,12 @@
             "peerDependencies": {
                 "express": ">= 4.11"
             }
+        },
+        "node_modules/extend": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+            "license": "MIT"
         },
         "node_modules/fecha": {
             "version": "4.2.3",
@@ -2559,6 +3648,90 @@
                 "node": ">=10"
             }
         },
+        "node_modules/gaxios": {
+            "version": "6.7.1",
+            "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+            "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "extend": "^3.0.2",
+                "https-proxy-agent": "^7.0.1",
+                "is-stream": "^2.0.0",
+                "node-fetch": "^2.6.9",
+                "uuid": "^9.0.1"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/gaxios/node_modules/agent-base": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/gaxios/node_modules/debug": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/gaxios/node_modules/https-proxy-agent": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.2",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/gaxios/node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "license": "MIT"
+        },
+        "node_modules/gcp-metadata": {
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+            "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "gaxios": "^6.1.1",
+                "google-logging-utils": "^0.0.2",
+                "json-bigint": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/get-caller-file": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+            "license": "ISC",
+            "engines": {
+                "node": "6.* || 8.* || >= 10.*"
+            }
+        },
         "node_modules/get-intrinsic": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -2628,6 +3801,15 @@
             },
             "engines": {
                 "node": ">= 6"
+            }
+        },
+        "node_modules/google-logging-utils": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+            "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=14"
             }
         },
         "node_modules/gopd": {
@@ -2996,6 +4178,15 @@
             "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
             "license": "MIT"
         },
+        "node_modules/json-bigint": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+            "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+            "license": "MIT",
+            "dependencies": {
+                "bignumber.js": "^9.0.0"
+            }
+        },
         "node_modules/jsonwebtoken": {
             "version": "9.0.3",
             "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
@@ -3049,6 +4240,12 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
             "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+            "license": "MIT"
+        },
+        "node_modules/lodash.camelcase": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+            "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
             "license": "MIT"
         },
         "node_modules/lodash.defaults": {
@@ -3127,6 +4324,12 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "license": "MIT"
+        },
+        "node_modules/long": {
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+            "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+            "license": "Apache-2.0"
         },
         "node_modules/make-dir": {
             "version": "3.1.0",
@@ -3718,6 +4921,29 @@
                 "node": "^16 || ^18 || >=20"
             }
         },
+        "node_modules/protobufjs": {
+            "version": "7.6.4",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+            "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+            "hasInstallScript": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@protobufjs/aspromise": "^1.1.2",
+                "@protobufjs/base64": "^1.1.2",
+                "@protobufjs/codegen": "^2.0.5",
+                "@protobufjs/eventemitter": "^1.1.1",
+                "@protobufjs/fetch": "^1.1.1",
+                "@protobufjs/float": "^1.0.2",
+                "@protobufjs/path": "^1.1.2",
+                "@protobufjs/pool": "^1.1.0",
+                "@protobufjs/utf8": "^1.1.1",
+                "@types/node": ">=13.7.0",
+                "long": "^5.3.2"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
         "node_modules/proxy-addr": {
             "version": "2.0.7",
             "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -3844,6 +5070,15 @@
             },
             "engines": {
                 "bare": ">=1.10.0"
+            }
+        },
+        "node_modules/require-directory": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/require-in-the-middle": {
@@ -4839,6 +6074,23 @@
                 "node": ">= 12.0.0"
             }
         },
+        "node_modules/wrap-ansi": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
         "node_modules/wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -4884,6 +6136,15 @@
                 "node": ">=0.4"
             }
         },
+        "node_modules/y18n": {
+            "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+            "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/yallist": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
@@ -4891,6 +6152,33 @@
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": ">=18"
+            }
+        },
+        "node_modules/yargs": {
+            "version": "17.7.3",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+            "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+            "license": "MIT",
+            "dependencies": {
+                "cliui": "^8.0.1",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.3",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^21.1.1"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/yargs-parser": {
+            "version": "21.1.1",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+            "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/yn": {

--- a/server/package.json
+++ b/server/package.json
@@ -16,6 +16,13 @@
         "lint": "tsc --noEmit"
     },
     "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/auto-instrumentations-node": "^0.55.0",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.57.0",
+        "@opentelemetry/resources": "^1.30.0",
+        "@opentelemetry/sdk-node": "^0.57.0",
+        "@opentelemetry/sdk-trace-base": "^1.30.0",
+        "@opentelemetry/semantic-conventions": "^1.30.0",
         "@prisma/client": "^5.10.2",
         "@sentry/node": "^9.18.0",
         "@stellar/stellar-sdk": "^11.3.0",

--- a/server/src/middleware/compression.middleware.ts
+++ b/server/src/middleware/compression.middleware.ts
@@ -1,0 +1,177 @@
+/**
+ * compression.middleware.ts
+ *
+ * Configurable response-compression middleware for the ArenaX HTTP API.
+ *
+ * Why a wrapper around `compression`?
+ *
+ * The bare `app.use(compression())` call we used to ship is gzip-only,
+ * has no metrics, and doesn't expose its tunables. This wrapper:
+ *
+ *   1. Honours per-deploy config (env-driven) for `level`, `threshold`,
+ *      and an `excludedContentTypes` blocklist for content that is
+ *      already compressed (images, videos, archives, fonts).
+ *   2. Records prom-client metrics for compression ratio + total
+ *      uncompressed and compressed bytes so dashboards can show the
+ *      bandwidth reduction.
+ *   3. Honours the existing `compression` package's `filter` API and
+ *      `req.headers['x-no-compression']` escape hatch.
+ *
+ * ## Brotli
+ *
+ * The `compression` package is gzip-only by design. Production-grade
+ * brotli for Express either needs `shrink-ray-current` (which compiles
+ * native deps, breaks on Alpine) or a custom transform stream. We do
+ * not add it here to keep the install surface tight; clients will
+ * negotiate gzip via Accept-Encoding, which is supported by every
+ * browser shipped in the last decade. If brotli becomes a hard
+ * requirement, this is the place to add it — bump
+ * `EXPECTED_ENCODINGS` and plug an iltorb-backed branch in.
+ *
+ * See ADR 005 in docs/adr/ for the full rationale.
+ */
+
+import type { Request, Response, NextFunction, RequestHandler } from 'express';
+import compression from 'compression';
+import { metricsService } from '../services/metrics.service';
+import { logger } from '../services/logger.service';
+
+const EXCLUDED_DEFAULT_PREFIXES = [
+  'image/',
+  'video/',
+  'audio/',
+  'font/',
+  'application/zip',
+  'application/gzip',
+  'application/x-gzip',
+  'application/x-tar',
+  'application/x-bzip2',
+  'application/x-xz',
+  'application/octet-stream',
+  'application/pdf',
+];
+
+export interface CompressionConfig {
+  /**
+   * zlib compression level (1 = fastest / least compression, 9 = best /
+   * slowest). Defaults to 6, matching `compression` upstream.
+   */
+  level: number;
+  /**
+   * Minimum response size (in bytes) before compression kicks in.
+   * Below this, gzip's per-message overhead is worse than the savings.
+   */
+  threshold: number;
+  /**
+   * Content-Type prefixes that should bypass compression entirely.
+   * Already-compressed payloads (images, video, archives) waste CPU
+   * for no bandwidth win.
+   */
+  excludedContentTypes: string[];
+}
+
+export const DEFAULT_COMPRESSION_CONFIG: CompressionConfig = {
+  level: 6,
+  threshold: 1024,
+  excludedContentTypes: EXCLUDED_DEFAULT_PREFIXES,
+};
+
+export const resolveCompressionConfigFromEnv = (
+  env: NodeJS.ProcessEnv = process.env,
+): CompressionConfig => {
+  const level = clampInt(env.COMPRESSION_LEVEL, 1, 9, DEFAULT_COMPRESSION_CONFIG.level);
+  const threshold = clampInt(
+    env.COMPRESSION_THRESHOLD_BYTES,
+    0,
+    1024 * 1024,
+    DEFAULT_COMPRESSION_CONFIG.threshold,
+  );
+  const exclusions = env.COMPRESSION_EXCLUDED_TYPES
+    ? env.COMPRESSION_EXCLUDED_TYPES.split(',').map((s) => s.trim()).filter(Boolean)
+    : DEFAULT_COMPRESSION_CONFIG.excludedContentTypes;
+  return { level, threshold, excludedContentTypes: exclusions };
+};
+
+const clampInt = (raw: string | undefined, min: number, max: number, fallback: number): number => {
+  if (!raw) return fallback;
+  const n = parseInt(raw, 10);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.max(min, Math.min(max, n));
+};
+
+/** Returns true if the response Content-Type is in the bypass list. */
+export const shouldBypass = (contentType: string | undefined, excluded: string[]): boolean => {
+  if (!contentType) return false;
+  const lower = contentType.toLowerCase();
+  return excluded.some((prefix) => lower.startsWith(prefix));
+};
+
+/**
+ * Build the compression middleware stack. Returns a single
+ * `RequestHandler` that records metrics + delegates to the underlying
+ * `compression` package.
+ */
+export const createCompressionMiddleware = (
+  config: CompressionConfig = DEFAULT_COMPRESSION_CONFIG,
+): RequestHandler => {
+  const inner = compression({
+    level: config.level,
+    threshold: config.threshold,
+    filter: (req, res) => {
+      // Explicit opt-out: clients can disable compression with a header
+      // (useful for SSE / streaming endpoints).
+      if (req.headers['x-no-compression']) return false;
+      const contentType = res.getHeader('Content-Type');
+      if (typeof contentType === 'string' && shouldBypass(contentType, config.excludedContentTypes)) {
+        return false;
+      }
+      return compression.filter(req, res);
+    },
+  });
+
+  return (req: Request, res: Response, next: NextFunction) => {
+    let uncompressedBytes = 0;
+    const write = res.write.bind(res);
+    const end = res.end.bind(res);
+
+    // Patch write/end so we can count the bytes the application would
+    // have sent without compression. The `compression` package wraps
+    // res internally; both gzipped and raw paths go through the same
+    // res.write hook below the wrapper, so this counter is accurate
+    // for the un-compressed payload.
+    (res as Response).write = function patchedWrite(chunk: any, ...args: any[]): boolean {
+      if (chunk) uncompressedBytes += Buffer.byteLength(chunk);
+      return write(chunk, ...args);
+    } as Response['write'];
+
+    (res as Response).end = function patchedEnd(chunk?: any, ...args: any[]): Response {
+      if (chunk) uncompressedBytes += Buffer.byteLength(chunk);
+      return end(chunk, ...args);
+    } as Response['end'];
+
+    res.on('finish', () => {
+      try {
+        const contentLengthHeader = res.getHeader('Content-Length');
+        const compressedBytes =
+          typeof contentLengthHeader === 'string' || typeof contentLengthHeader === 'number'
+            ? parseInt(String(contentLengthHeader), 10)
+            : uncompressedBytes;
+        if (!Number.isFinite(compressedBytes) || compressedBytes <= 0 || uncompressedBytes <= 0) {
+          return;
+        }
+        const encoding = res.getHeader('Content-Encoding');
+        const wasCompressed = encoding === 'gzip' || encoding === 'br' || encoding === 'deflate';
+        const ratio = wasCompressed ? compressedBytes / uncompressedBytes : 1;
+        metricsService.recordCompression?.(wasCompressed ? String(encoding) : 'identity', {
+          uncompressedBytes,
+          compressedBytes,
+          ratio,
+        });
+      } catch (err) {
+        logger.error('Failed to record compression metrics', { error: err });
+      }
+    });
+
+    return inner(req, res, next);
+  };
+};

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -2,12 +2,20 @@ import dotenv from 'dotenv';
 import path from 'node:path';
 import os from 'node:os';
 import express, { Express, Request, Response } from 'express';
-import compression from 'compression';
+import {
+  createCompressionMiddleware,
+  resolveCompressionConfigFromEnv,
+} from './middleware/compression.middleware';
 import { createApp } from './app';
 import { logger } from './services/logger.service';
 import { createAdminService, getAdminService } from './services/admin.service';
 import { initEnv } from './config/env';
 import { initializeTelemetry } from './services/telemetry.service';
+import {
+  initTracing,
+  shutdownTracing,
+  traceparentResponseMiddleware,
+} from './services/tracing.service';
 import { registerAchievementIntegration } from './services/achievement.service';
 import { startHealthMonitor } from './services/health.service';
 import { Server as SocketIOServer } from 'socket.io';
@@ -25,6 +33,10 @@ dotenv.config({ path: path.join(root, `.env.${nodeEnv}`) });
 dotenv.config({ path: path.join(root, `.env.${nodeEnv}.local`) });
 
 const env = initEnv();
+// Tracing must initialise *before* createApp() so the OTel SDK can
+// wrap the imported express/http modules before any routes are
+// registered.
+initTracing();
 initializeTelemetry();
 registerAchievementIntegration();
 
@@ -65,7 +77,8 @@ app.get('/health', async (_req: Request, res: Response) => {
     }
 });
 
-app.use(compression());
+app.use(createCompressionMiddleware(resolveCompressionConfigFromEnv()));
+app.use(traceparentResponseMiddleware());
 
 let memoryWarningInterval: ReturnType<typeof setInterval> | null = null;
 
@@ -93,6 +106,8 @@ const gracefulShutdown = (signal: string) => {
 
     stopMemoryMonitor();
     eventMonitoringService.stop();
+    // Best-effort: flush in-flight spans before we exit.
+    shutdownTracing().catch(() => {});
 
     if (!server) {
         logger.info('No server running, exiting');

--- a/server/src/services/metrics.service.ts
+++ b/server/src/services/metrics.service.ts
@@ -89,6 +89,26 @@ const cacheMissesTotal = getOrCreateCounter({
   labelNames: ['namespace'],
 });
 
+// Compression metrics (issue #477)
+const compressionUncompressedBytes = getOrCreateCounter({
+  name: 'http_response_uncompressed_bytes_total',
+  help: 'Total number of uncompressed response bytes (what the app would have sent)',
+  labelNames: ['encoding'],
+});
+
+const compressionCompressedBytes = getOrCreateCounter({
+  name: 'http_response_compressed_bytes_total',
+  help: 'Total number of compressed (wire) response bytes',
+  labelNames: ['encoding'],
+});
+
+const compressionRatio = getOrCreateHistogram({
+  name: 'http_response_compression_ratio',
+  help: 'Distribution of per-response compression ratios (compressed/uncompressed)',
+  labelNames: ['encoding'],
+  buckets: [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0],
+});
+
 export class MetricsService {
   private static instance: MetricsService;
 
@@ -131,6 +151,16 @@ export class MetricsService {
 
   recordCacheMiss(namespace: string) {
     cacheMissesTotal.inc({ namespace });
+  }
+
+  // Compression metrics (issue #477)
+  recordCompression(
+    encoding: string,
+    payload: { uncompressedBytes: number; compressedBytes: number; ratio: number },
+  ) {
+    compressionUncompressedBytes.inc({ encoding }, payload.uncompressedBytes);
+    compressionCompressedBytes.inc({ encoding }, payload.compressedBytes);
+    compressionRatio.observe({ encoding }, payload.ratio);
   }
 
   // Connection metrics

--- a/server/src/services/tracing.service.ts
+++ b/server/src/services/tracing.service.ts
@@ -1,0 +1,193 @@
+/**
+ * tracing.service.ts
+ *
+ * OpenTelemetry distributed tracing bootstrap for the ArenaX HTTP API
+ * (#478).
+ *
+ * Design:
+ * - Tracing is *opt-in* via `OTEL_EXPORTER_OTLP_ENDPOINT`. With the env
+ *   var unset, `initTracing()` is a no-op so non-prod / CI runs aren't
+ *   penalised by trace overhead.
+ * - The exporter uses OTLP-over-HTTP (the standard wire protocol). The
+ *   destination can be Jaeger (local), Tempo (staging), Grafana Cloud,
+ *   or any other OTLP collector — no code change required.
+ * - Auto-instrumentations cover Express, http, ioredis, and Prisma
+ *   query latency out of the box. Manual spans for blockchain calls and
+ *   queue workers can be added with `withSpan(name, attrs, fn)`.
+ * - W3C `traceparent` propagation is set up via the SDK's default
+ *   propagator stack; `traceparentResponseMiddleware()` echoes the
+ *   active context back on every response so the frontend can link a
+ *   Sentry event to its server-side trace.
+ *
+ * Imports use `require()` inside `initTracing()` so the OTel SDK is
+ * only loaded when tracing is enabled — this keeps the cold-start
+ * surface small for test runs and disabled deployments.
+ */
+
+import type { Request, Response, NextFunction, RequestHandler } from 'express';
+import { logger } from './logger.service';
+
+let started = false;
+
+export const isTracingEnabled = (env: NodeJS.ProcessEnv = process.env): boolean =>
+  Boolean(env.OTEL_EXPORTER_OTLP_ENDPOINT);
+
+export interface TracingHandle {
+  shutdown(): Promise<void>;
+}
+
+let activeHandle: TracingHandle | null = null;
+
+/**
+ * Initialise the OTel NodeSDK with HTTP + Express + ioredis
+ * auto-instrumentation. Returns a handle for `shutdown()` (called
+ * during graceful shutdown). Safe to call multiple times — subsequent
+ * calls return the existing handle.
+ */
+export const initTracing = (env: NodeJS.ProcessEnv = process.env): TracingHandle | null => {
+  if (started) return activeHandle;
+  if (!isTracingEnabled(env)) {
+    logger.info('Tracing disabled: OTEL_EXPORTER_OTLP_ENDPOINT is not configured');
+    return null;
+  }
+
+  try {
+    // Lazy-require so consumers without OTel installed can still boot.
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { NodeSDK } = require('@opentelemetry/sdk-node');
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { getNodeAutoInstrumentations } = require('@opentelemetry/auto-instrumentations-node');
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { OTLPTraceExporter } = require('@opentelemetry/exporter-trace-otlp-http');
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { Resource } = require('@opentelemetry/resources');
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { SemanticResourceAttributes } = require('@opentelemetry/semantic-conventions');
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { TraceIdRatioBasedSampler } = require('@opentelemetry/sdk-trace-base');
+
+    const serviceName = env.OTEL_SERVICE_NAME ?? 'arenax-server';
+    const sampleRatio = clampFloat(env.OTEL_TRACES_SAMPLER_ARG, 0, 1, 1);
+
+    const sdk = new NodeSDK({
+      resource: new Resource({
+        [SemanticResourceAttributes.SERVICE_NAME]: serviceName,
+        [SemanticResourceAttributes.SERVICE_VERSION]:
+          env.APP_VERSION ?? process.env.npm_package_version ?? '0.1.0',
+        [SemanticResourceAttributes.DEPLOYMENT_ENVIRONMENT]:
+          env.NODE_ENV ?? 'development',
+      }),
+      traceExporter: new OTLPTraceExporter({
+        url: `${env.OTEL_EXPORTER_OTLP_ENDPOINT}/v1/traces`,
+      }),
+      sampler: new TraceIdRatioBasedSampler(sampleRatio),
+      instrumentations: [
+        getNodeAutoInstrumentations({
+          '@opentelemetry/instrumentation-fs': { enabled: false },
+        }),
+      ],
+    });
+
+    sdk.start();
+    started = true;
+    logger.info('Tracing initialized', {
+      provider: 'opentelemetry',
+      endpoint: env.OTEL_EXPORTER_OTLP_ENDPOINT,
+      serviceName,
+      sampleRatio,
+    });
+
+    activeHandle = {
+      async shutdown() {
+        try {
+          await sdk.shutdown();
+        } catch (err) {
+          logger.error('Tracing shutdown failed', { error: err });
+        }
+      },
+    };
+    return activeHandle;
+  } catch (err) {
+    logger.error('Failed to initialise tracing', { error: err });
+    return null;
+  }
+};
+
+const clampFloat = (raw: string | undefined, min: number, max: number, fallback: number): number => {
+  if (!raw) return fallback;
+  const n = parseFloat(raw);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.max(min, Math.min(max, n));
+};
+
+/**
+ * Run `fn` inside a named span with `attrs` set as span attributes.
+ * If tracing is disabled, executes `fn` directly with no overhead.
+ */
+export const withSpan = async <T>(
+  name: string,
+  attrs: Record<string, string | number | boolean>,
+  fn: () => Promise<T> | T,
+): Promise<T> => {
+  if (!started) return await fn();
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { trace } = require('@opentelemetry/api');
+    const tracer = trace.getTracer('arenax-server');
+    return await tracer.startActiveSpan(name, async (span: any) => {
+      try {
+        for (const [k, v] of Object.entries(attrs)) span.setAttribute(k, v);
+        const result = await fn();
+        span.setStatus({ code: 1 }); // OK
+        return result;
+      } catch (err) {
+        span.recordException(err as Error);
+        span.setStatus({ code: 2, message: (err as Error).message }); // ERROR
+        throw err;
+      } finally {
+        span.end();
+      }
+    });
+  } catch {
+    return await fn();
+  }
+};
+
+/**
+ * Express middleware that, when tracing is on, propagates the current
+ * `traceparent` (W3C TraceContext) back on the HTTP response so the
+ * frontend can link a Sentry event to its server-side trace.
+ */
+export const traceparentResponseMiddleware = (): RequestHandler => {
+  return (req: Request, res: Response, next: NextFunction) => {
+    if (!started) return next();
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { propagation, context } = require('@opentelemetry/api');
+      const carrier: Record<string, string> = {};
+      propagation.inject(context.active(), carrier);
+      if (carrier.traceparent) {
+        res.setHeader('traceparent', carrier.traceparent);
+        // CORS exposed-headers — the frontend needs to read this one.
+        const existing = res.getHeader('Access-Control-Expose-Headers');
+        const value = existing ? `${existing}, traceparent` : 'traceparent';
+        res.setHeader('Access-Control-Expose-Headers', value);
+      }
+    } catch {
+      /* propagation is best-effort */
+    }
+    next();
+  };
+};
+
+/**
+ * Used in graceful shutdown to flush in-flight spans before the
+ * process exits. Safe to call when tracing is disabled.
+ */
+export const shutdownTracing = async (): Promise<void> => {
+  if (activeHandle) {
+    await activeHandle.shutdown();
+    activeHandle = null;
+    started = false;
+  }
+};

--- a/server/test/compression.middleware.test.js
+++ b/server/test/compression.middleware.test.js
@@ -1,0 +1,69 @@
+import test from 'node:test'
+import assert from 'node:assert'
+
+test('resolveCompressionConfigFromEnv falls back to defaults when no env vars are set', async () => {
+  const { resolveCompressionConfigFromEnv, DEFAULT_COMPRESSION_CONFIG } =
+    await import('../dist/middleware/compression.middleware.js')
+  const cfg = resolveCompressionConfigFromEnv({})
+  assert.strictEqual(cfg.level, DEFAULT_COMPRESSION_CONFIG.level)
+  assert.strictEqual(cfg.threshold, DEFAULT_COMPRESSION_CONFIG.threshold)
+  assert.deepStrictEqual(cfg.excludedContentTypes, DEFAULT_COMPRESSION_CONFIG.excludedContentTypes)
+})
+
+test('resolveCompressionConfigFromEnv parses and clamps env values', async () => {
+  const { resolveCompressionConfigFromEnv } =
+    await import('../dist/middleware/compression.middleware.js')
+
+  // Valid in-range values
+  let cfg = resolveCompressionConfigFromEnv({
+    COMPRESSION_LEVEL: '3',
+    COMPRESSION_THRESHOLD_BYTES: '500',
+    COMPRESSION_EXCLUDED_TYPES: 'image/png, text/csv',
+  })
+  assert.strictEqual(cfg.level, 3)
+  assert.strictEqual(cfg.threshold, 500)
+  assert.deepStrictEqual(cfg.excludedContentTypes, ['image/png', 'text/csv'])
+
+  // Out-of-range level clamps
+  cfg = resolveCompressionConfigFromEnv({ COMPRESSION_LEVEL: '99' })
+  assert.strictEqual(cfg.level, 9)
+  cfg = resolveCompressionConfigFromEnv({ COMPRESSION_LEVEL: '0' })
+  assert.strictEqual(cfg.level, 1)
+
+  // Non-numeric falls back
+  cfg = resolveCompressionConfigFromEnv({ COMPRESSION_LEVEL: 'gzip-please' })
+  assert.strictEqual(cfg.level, 6)
+})
+
+test('shouldBypass matches by content-type prefix and is case-insensitive', async () => {
+  const { shouldBypass } = await import('../dist/middleware/compression.middleware.js')
+  const excluded = ['image/', 'video/', 'application/zip']
+  assert.strictEqual(shouldBypass('image/png', excluded), true)
+  assert.strictEqual(shouldBypass('IMAGE/PNG', excluded), true)
+  assert.strictEqual(shouldBypass('application/zip', excluded), true)
+  assert.strictEqual(shouldBypass('application/json', excluded), false)
+  assert.strictEqual(shouldBypass(undefined, excluded), false)
+})
+
+test('createCompressionMiddleware returns a 3-arg express middleware', async () => {
+  const { createCompressionMiddleware } =
+    await import('../dist/middleware/compression.middleware.js')
+  const mw = createCompressionMiddleware()
+  assert.strictEqual(typeof mw, 'function')
+  assert.strictEqual(mw.length, 3)
+})
+
+test('createCompressionMiddleware exposes a no-arg form with safe defaults', async () => {
+  const { createCompressionMiddleware, DEFAULT_COMPRESSION_CONFIG } =
+    await import('../dist/middleware/compression.middleware.js')
+  // No throws, valid handler.
+  const mw = createCompressionMiddleware()
+  assert.strictEqual(typeof mw, 'function')
+  assert.strictEqual(mw.length, 3)
+  // The default config object the middleware was built around is still
+  // shaped as expected (guards against accidental schema drift).
+  assert.strictEqual(typeof DEFAULT_COMPRESSION_CONFIG.level, 'number')
+  assert.strictEqual(typeof DEFAULT_COMPRESSION_CONFIG.threshold, 'number')
+  assert.ok(Array.isArray(DEFAULT_COMPRESSION_CONFIG.excludedContentTypes))
+  assert.ok(DEFAULT_COMPRESSION_CONFIG.excludedContentTypes.includes('image/'))
+})

--- a/server/test/tracing.service.test.js
+++ b/server/test/tracing.service.test.js
@@ -1,0 +1,64 @@
+import test from 'node:test'
+import assert from 'node:assert'
+
+test('isTracingEnabled returns false when OTEL_EXPORTER_OTLP_ENDPOINT is unset', async () => {
+  const { isTracingEnabled } = await import('../dist/services/tracing.service.js')
+  assert.strictEqual(isTracingEnabled({}), false)
+  assert.strictEqual(isTracingEnabled({ OTEL_EXPORTER_OTLP_ENDPOINT: '' }), false)
+})
+
+test('isTracingEnabled returns true when OTEL_EXPORTER_OTLP_ENDPOINT is configured', async () => {
+  const { isTracingEnabled } = await import('../dist/services/tracing.service.js')
+  assert.strictEqual(
+    isTracingEnabled({ OTEL_EXPORTER_OTLP_ENDPOINT: 'http://otel:4318' }),
+    true,
+  )
+})
+
+test('initTracing is a no-op when disabled (returns null)', async () => {
+  const { initTracing } = await import('../dist/services/tracing.service.js')
+  const handle = initTracing({}) // no env
+  assert.strictEqual(handle, null)
+})
+
+test('withSpan runs fn directly when tracing has not been started', async () => {
+  const { withSpan } = await import('../dist/services/tracing.service.js')
+  let ran = false
+  const out = await withSpan('test-span', { foo: 'bar' }, async () => {
+    ran = true
+    return 42
+  })
+  assert.strictEqual(ran, true)
+  assert.strictEqual(out, 42)
+})
+
+test('withSpan re-throws errors thrown by fn (tracing disabled path)', async () => {
+  const { withSpan } = await import('../dist/services/tracing.service.js')
+  await assert.rejects(
+    withSpan('failing-span', {}, async () => {
+      throw new Error('boom')
+    }),
+    /boom/,
+  )
+})
+
+test('traceparentResponseMiddleware is a no-op when tracing is disabled', async () => {
+  const { traceparentResponseMiddleware } =
+    await import('../dist/services/tracing.service.js')
+  const mw = traceparentResponseMiddleware()
+  let nextCalled = false
+  let traceparentHeaderSet = false
+  const req = {}
+  const res = {
+    setHeader(name) { if (name === 'traceparent') traceparentHeaderSet = true },
+    getHeader() { return undefined },
+  }
+  mw(req, res, () => { nextCalled = true })
+  assert.strictEqual(nextCalled, true)
+  assert.strictEqual(traceparentHeaderSet, false)
+})
+
+test('shutdownTracing is safe to call when tracing was never started', async () => {
+  const { shutdownTracing } = await import('../dist/services/tracing.service.js')
+  await assert.doesNotReject(shutdownTracing())
+})


### PR DESCRIPTION
## Summary

Four related platform improvements in one PR:

- **#493 — Merkle tree for bulk operations**: new \`contracts/merkle/\`
  crate providing on-chain proof verification + a
  \`MerkleAirdropRegistry\` contract that stores per-campaign roots and
  tracks claimed leaves.
- **#490 — Event standardization + indexing**: new
  \`arenax_events::events_registry\` module exposing every event
  namespace shipped by the shared crate as a single machine-readable
  list, plus uniqueness / format tests that lock the convention in.
- **#478 — Distributed tracing with OpenTelemetry**: new
  \`server/src/services/tracing.service.ts\` that initialises the
  OpenTelemetry NodeSDK with HTTP + Express + ioredis auto-
  instrumentation, OTLP/HTTP export, env-driven sampling, and W3C
  \`traceparent\` propagation on every response.
- **#477 — Smart compression middleware**: replaces the bare
  \`app.use(compression())\` call with a configurable middleware that
  reads \`COMPRESSION_LEVEL\` / \`COMPRESSION_THRESHOLD_BYTES\` /
  \`COMPRESSION_EXCLUDED_TYPES\` env vars, bypasses already-compressed
  content types (images, video, archives), and emits prom-client
  metrics for bytes-in / bytes-out / ratio.

## Implementation notes

### #493 Merkle (\`contracts/merkle/\`)

- **\`verify_proof(env, root, leaf, proof)\`**: pure verifier using
  \`env.crypto().sha256()\` and sorted-pair hashing
  (\`hash(min(a, b) || max(a, b))\`) so proof order is irrelevant — same
  convention as OpenZeppelin and the Uniswap merkle distributor.
- **\`MerkleAirdropRegistry\` contract** with \`initialize\`, \`set_root\`,
  \`get_root\`, \`verify\`, \`claim\`, \`is_claimed\`. Admin-gated root
  publication; claimants must auth and present a valid proof; double-
  claim is rejected via a persistent marker keyed by
  \`(campaign_id, leaf)\`.
- 8 tests: single-leaf identity, two-leaf, four-leaf, order-independence,
  full claim flow, double-claim panic, invalid-proof panic, claim-
  without-root panic. All passing under \`cargo test -p merkle\`.

### #490 Event registry

- \`arenax-events\` now ships an \`events_registry\` module with a
  \`NamespaceEntry { namespace, version }\` table covering all 19
  domains in the crate. Off-chain indexers (the trace analysis
  dashboard from #478, the existing \`event-monitoring.service\`) can
  iterate \`NAMESPACES\` instead of grepping module sources.
- 7 new tests in \`registry_tests.rs\` enforce the standard: every entry
  has non-empty \`NAMESPACE\` + \`VERSION\`; \`VERSION\` matches \`vN\` shape;
  no duplicate namespaces; \`lookup()\` round-trips; \`lookup()\` returns
  \`None\` for unknown names; smoke-test on derived equality.
- \`docs/event-versioning.md\` extended with the "Programmatic registry"
  section describing the four-step process to register a new event
  module.

### #478 OpenTelemetry

- Adds 7 \`@opentelemetry/*\` dependencies. The SDK loads via lazy
  \`require()\` inside \`initTracing()\` so test runs / disabled
  deployments don't pay the import cost.
- Tracing is opt-in via \`OTEL_EXPORTER_OTLP_ENDPOINT\`. Sampling rate
  configurable via \`OTEL_TRACES_SAMPLER_ARG\` (default 1.0). Auto-
  instrumentations cover http, express, ioredis, and Prisma.
- \`withSpan(name, attrs, fn)\` helper for manual span creation around
  blockchain calls / queue workers — no-op when tracing is disabled.
- \`traceparentResponseMiddleware()\` echoes the active W3C
  \`traceparent\` on every response and adds it to
  \`Access-Control-Expose-Headers\` so the frontend can link a Sentry
  event to its server-side trace.
- \`shutdownTracing()\` hooked into \`gracefulShutdown\` to flush
  in-flight spans on SIGTERM / SIGINT.
- 7 tests for the no-tracing path: env detection, init returns null
  when disabled, \`withSpan\` runs fn directly + propagates errors,
  middleware is a no-op, shutdown is safe to call.

### #477 Compression

- \`createCompressionMiddleware(config)\` wraps the existing
  \`compression\` package + adds:
  - Bypass for image/video/audio/zip/gzip/tar/octet-stream/pdf
    content-type prefixes (configurable via env).
  - Per-deploy \`level\` (1-9, clamped) and \`threshold\` (0-1MB,
    clamped) via env.
  - \`x-no-compression\` request-header escape hatch for SSE /
    streaming endpoints.
  - Prom-client metrics (\`http_response_uncompressed_bytes_total\`,
    \`http_response_compressed_bytes_total\`,
    \`http_response_compression_ratio\` histogram) so dashboards
    surface the actual bandwidth reduction.
- Brotli is deliberately *not* added — production-grade brotli on
  Express needs native deps (\`shrink-ray-current\`, \`iltorb\`) that
  break on Alpine images. Documented inline; flag for a follow-up if
  the requirement firms up.
- 5 tests for env parsing, clamping, content-type bypass logic, and
  middleware shape.

## Verification

- \`cargo test -p merkle\`: 8/8 passed
- \`cargo test -p arenax-events\`: 11/11 passed (7 new + 4 pre-existing)
- \`node --test test/compression.middleware.test.js test/tracing.service.test.js\`:
  12/12 passed (5 compression + 7 tracing)
- \`npx tsc\` emits the new files cleanly. \`server.ts\` shows a
  **pre-existing** TS1005 brace-mismatch (line 193-194) that
  reproduces on unmodified \`main\` — disclosed here, not introduced
  by this PR.

closes #493
closes #490
closes #478
closes #477