### PR TITLE
feat(wallet): add Copy address button to QRCode component

### DIFF
--- a/frontend/src/components/wallet/QRCode.tsx
+++ b/frontend/src/components/wallet/QRCode.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState, useCallback } from "react";
 import QRCodeLib from "qrcode";
 
 interface QRCodeProps {
@@ -10,6 +10,8 @@ interface QRCodeProps {
 
 export function QRCode({ value, size = 180 }: QRCodeProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [copied, setCopied] = useState(false);
 
   useEffect(() => {
     if (!canvasRef.current || !value) return;
@@ -21,13 +23,58 @@ export function QRCode({ value, size = 180 }: QRCodeProps) {
     }).catch(() => undefined);
   }, [value, size]);
 
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  const handleCopy = useCallback(() => {
+    const showCopied = () => {
+      setCopied(true);
+      timerRef.current = setTimeout(() => setCopied(false), 2000);
+    };
+
+    if (navigator.clipboard?.writeText) {
+      navigator.clipboard.writeText(value).then(showCopied).catch(() => {
+        fallbackCopy(value, showCopied);
+      });
+    } else {
+      fallbackCopy(value, showCopied);
+    }
+  }, [value]);
+
   return (
-    <canvas
-      ref={canvasRef}
-      width={size}
-      height={size}
-      aria-label={`QR code for ${value}`}
-      className="rounded-md"
-    />
+    <div className="flex flex-col items-center gap-2">
+      <canvas
+        ref={canvasRef}
+        width={size}
+        height={size}
+        aria-label={`QR code for ${value}`}
+        className="rounded-md"
+      />
+      <button
+        type="button"
+        onClick={handleCopy}
+        className="text-sm px-3 py-1 rounded border border-gray-300 hover:bg-gray-100 transition-colors"
+      >
+        {copied ? "Copied!" : "Copy address"}
+      </button>
+    </div>
   );
+}
+
+function fallbackCopy(text: string, onSuccess: () => void) {
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.style.cssText = "position:fixed;top:0;left:0;opacity:0;";
+  document.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+  try {
+    document.execCommand("copy");
+    onSuccess();
+  } finally {
+    document.body.removeChild(textarea);
+  }
 }


### PR DESCRIPTION
Closes #561

---

## Summary
- Adds a **"Copy address"** button beneath the QR code canvas
- Uses `navigator.clipboard.writeText` when available; falls back to `execCommand('copy')` via a temporary `<textarea>` for unsupported browsers
- Button label temporarily changes to **"Copied!"** for 2 seconds then reverts, with timer cleanup on unmount to prevent memory leaks

## Test plan
- [ ] Open the wallet QR code modal and confirm the "Copy address" button renders below the QR image
- [ ] Click the button in a modern browser — verify the wallet address is in the clipboard and the label changes to "Copied!" then reverts after 2 seconds
- [ ] Test in a browser with `navigator.clipboard` disabled/unavailable — verify the fallback selects the address and the copy still succeeds
- [ ] Rapidly click the button multiple times — confirm no timer stacking or duplicate "Copied!" states
- [ ] Unmount the component while the "Copied!" label is showing — confirm no console warnings about state updates on unmounted components