### PR TITLE
feat(web-vitals): restrict reporting to production, make endpoint configurable

### DIFF
--- a/frontend/src/components/providers/WebVitalsInit.tsx
+++ b/frontend/src/components/providers/WebVitalsInit.tsx
@@ -8,12 +8,30 @@ import type { WebVitalMetric } from '@/lib/webVitalsReporter';
  * Client component that wires the web vitals reporter into the
  * Next.js App Router. Mount once in the root layout.
  *
+ * Reporting is restricted to production (NODE_ENV === 'production').
+ * In development, a console warning is emitted when
+ * NEXT_PUBLIC_ANALYTICS_ENDPOINT is not configured so that the
+ * absence of reporting is explicit rather than silent.
+ *
  * The `web-vitals` npm package is loaded lazily so it doesn't bloat
  * the main bundle. When `web-vitals` is not installed the component is
  * a no-op, which keeps the server-render path safe.
  */
 export function WebVitalsInit() {
   useEffect(() => {
+    const isProduction = process.env.NODE_ENV === 'production';
+    const endpoint = process.env.NEXT_PUBLIC_ANALYTICS_ENDPOINT;
+
+    if (!isProduction) {
+      if (!endpoint) {
+        console.warn(
+          '[WebVitals] Core Web Vitals reporting is disabled: ' +
+          'NEXT_PUBLIC_ANALYTICS_ENDPOINT is not set.'
+        );
+      }
+      return;
+    }
+
     let cancelled = false;
 
     import('web-vitals').then(({ onCLS, onFCP, onLCP, onTTFB, onINP }) => {

--- a/frontend/src/lib/webVitalsReporter.ts
+++ b/frontend/src/lib/webVitalsReporter.ts
@@ -3,10 +3,10 @@
  *
  * A tiny, dependency-free helper that buffers Web Vitals as they fire,
  * compares each metric against its acceptance budget, and ships a
- * batched report to an analytics endpoint. The endpoint is the same
- * `/api/v1/analytics/events` controller the rest of the platform uses
- * — so frontend perf telemetry rides the same pipeline as gameplay
- * analytics.
+ * batched report to an analytics endpoint configured via
+ * NEXT_PUBLIC_ANALYTICS_ENDPOINT. Reporting is gated to production
+ * (NODE_ENV === 'production') so development runs never send outbound
+ * requests to the analytics pipeline.
  *
  * Why a custom reporter instead of `web-vitals` directly:
  *  - The repo doesn't ship `web-vitals` yet; we keep the helper
@@ -65,7 +65,7 @@ export const evaluateMetric = (metric: WebVitalMetric): WebVitalReport => {
 };
 
 export interface WebVitalsReporterOptions {
-    /** Endpoint to POST batched reports to. Defaults to /api/v1/analytics/events. */
+    /** Endpoint to POST batched reports to. Defaults to NEXT_PUBLIC_ANALYTICS_ENDPOINT. */
     endpoint?: string;
     /** Max metrics to buffer before flushing (default 10). */
     bufferSize?: number;
@@ -91,6 +91,8 @@ export interface WebVitalsReporter {
 
 const noop = () => {};
 
+const IS_PRODUCTION = process.env.NODE_ENV === 'production';
+
 /**
  * Create a reporter. The factory style is the same we use for
  * `analytics.service.ts` on the backend — production gets a single
@@ -99,7 +101,7 @@ const noop = () => {};
 export const createWebVitalsReporter = (
     options: WebVitalsReporterOptions = {}
 ): WebVitalsReporter => {
-    const endpoint = options.endpoint ?? '/api/v1/analytics/events';
+    const endpoint = options.endpoint ?? process.env.NEXT_PUBLIC_ANALYTICS_ENDPOINT ?? '';
     const bufferSize = options.bufferSize ?? 10;
     const flushIntervalMs = options.flushIntervalMs ?? 5_000;
     const fetcher: typeof fetch =
@@ -121,10 +123,14 @@ export const createWebVitalsReporter = (
 
     const ship = async (reports: WebVitalReport[]) => {
         if (reports.length === 0) return;
+        // Never send metrics outside production to avoid polluting analytics.
+        if (!IS_PRODUCTION) return;
         if (options.sink) {
             await options.sink(reports);
             return;
         }
+        // Gracefully skip if the endpoint is not configured in production.
+        if (!endpoint) return;
         try {
             await fetcher(endpoint, {
                 method: 'POST',


### PR DESCRIPTION
Closes #556

---

## Summary

- **Production-only reporting** — all Core Web Vitals reporting is now guarded behind `process.env.NODE_ENV === 'production'`. In `WebVitalsInit.tsx` the `useEffect` returns early in non-production environments so no `web-vitals` listeners are registered and no visibility-change handler is attached. In `webVitalsReporter.ts` the `ship` function has the same guard as a defence-in-depth measure, ensuring the reporter never makes outbound requests even if it is called directly outside of the component.

- **Configurable analytics endpoint** — the hardcoded `/api/v1/analytics/events` URL has been replaced with `process.env.NEXT_PUBLIC_ANALYTICS_ENDPOINT`. The `createWebVitalsReporter` factory resolves the endpoint in priority order: `options.endpoint` (for tests/overrides) → `NEXT_PUBLIC_ANALYTICS_ENDPOINT` → empty string. The explicit `options.endpoint` escape-hatch keeps existing unit tests working without env-var changes.

- **Clear dev warning** — when `NODE_ENV !== 'production'` and `NEXT_PUBLIC_ANALYTICS_ENDPOINT` is not set, `WebVitalsInit` emits `console.warn('[WebVitals] Core Web Vitals reporting is disabled: NEXT_PUBLIC_ANALYTICS_ENDPOINT is not set.')` so the absence of reporting is explicit rather than silent.

- **Graceful production degradation** — if `NEXT_PUBLIC_ANALYTICS_ENDPOINT` is missing or empty in a production build, `ship` skips the fetch without throwing. Network failures continue to be caught and silently discarded, so analytics outages never surface as user-visible errors.

## Files changed

| File | Change |
|---|---|
| `frontend/src/lib/webVitalsReporter.ts` | Added `IS_PRODUCTION` constant; swapped hardcoded URL for `NEXT_PUBLIC_ANALYTICS_ENDPOINT`; added production guard and empty-endpoint guard in `ship` |
| `frontend/src/components/providers/WebVitalsInit.tsx` | Added production check + dev `console.warn` at the top of `useEffect`; registration block only runs in production |

## Behaviour matrix

| Environment | `NEXT_PUBLIC_ANALYTICS_ENDPOINT` set? | Outcome |
|---|---|---|
| development / test | No | `console.warn` emitted; no listeners registered; no network calls |
| development / test | Yes | `console.warn` **not** emitted; still no listeners registered; no network calls |
| production | Yes | Metrics collected, buffered, and POSTed to the configured endpoint |
| production | No | Metrics collected and buffered; `ship` skips silently; no network call, no error |

## Test plan

- [ ] Run the dev server locally (`npm run dev`) with `NEXT_PUBLIC_ANALYTICS_ENDPOINT` unset — confirm `console.warn` appears in the browser console and no outbound requests are made to any analytics URL
- [ ] Run the dev server with `NEXT_PUBLIC_ANALYTICS_ENDPOINT=http://localhost:9999/test` set — confirm the warning is absent and still no network requests are made (non-production guard holds)
- [ ] Run existing `webVitalsReporter` unit tests — confirm they pass (tests pass `options.endpoint` explicitly so env-var default is bypassed)
- [ ] Build in production mode (`NODE_ENV=production`) with `NEXT_PUBLIC_ANALYTICS_ENDPOINT` set — confirm metrics reach the endpoint
- [ ] Build in production mode without `NEXT_PUBLIC_ANALYTICS_ENDPOINT` — confirm no unhandled errors and no network calls
