### PR TITLE
feat: real-time bio character counter, client-side validation, and shared MAX_BIO_LENGTH constant

### DIFF
--- a/frontend/src/__tests__/profile-bio.test.tsx
+++ b/frontend/src/__tests__/profile-bio.test.tsx
@@ -1,0 +1,189 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ProfileBio } from '@/components/profile/ProfileBio';
+import { MAX_BIO_LENGTH, profileBioSchema } from '@/lib/validations/profile';
+import type { User } from '@/types/user';
+
+const baseUser: User = {
+  id: 'user-1',
+  username: 'TestPlayer',
+  email: 'test@example.com',
+  isVerified: true,
+  elo: 1500,
+  createdAt: '2024-01-01T00:00:00Z',
+  bio: '',
+  socialLinks: {},
+};
+
+function renderBio(user: Partial<User> = {}) {
+  const onSave = jest.fn();
+  render(<ProfileBio user={{ ...baseUser, ...user }} onSave={onSave} />);
+
+  // Enter edit mode
+  fireEvent.click(screen.getByRole('button', { name: /edit profile/i }));
+
+  return { onSave };
+}
+
+describe('ProfileBio — character counter', () => {
+  it('shows 0 / MAX_BIO_LENGTH initially when bio is empty', () => {
+    renderBio();
+    expect(screen.getByText(`0 / ${MAX_BIO_LENGTH}`)).toBeInTheDocument();
+  });
+
+  it('updates counter immediately as the user types', () => {
+    renderBio();
+    const textarea = screen.getByRole('textbox', { name: /bio/i });
+
+    fireEvent.change(textarea, { target: { value: 'Hello!' } });
+    expect(screen.getByText(`6 / ${MAX_BIO_LENGTH}`)).toBeInTheDocument();
+
+    fireEvent.change(textarea, { target: { value: 'Hello, world!' } });
+    expect(screen.getByText(`13 / ${MAX_BIO_LENGTH}`)).toBeInTheDocument();
+  });
+
+  it('reflects the existing bio length on first render', () => {
+    const existingBio = 'A'.repeat(50);
+    renderBio({ bio: existingBio });
+    expect(screen.getByText(`50 / ${MAX_BIO_LENGTH}`)).toBeInTheDocument();
+  });
+});
+
+describe('ProfileBio — warning state at 90% capacity', () => {
+  const warningThreshold = Math.floor(MAX_BIO_LENGTH * 0.9);
+
+  it('counter has no warning style below 90%', () => {
+    renderBio();
+    const textarea = screen.getByRole('textbox', { name: /bio/i });
+
+    fireEvent.change(textarea, { target: { value: 'A'.repeat(warningThreshold - 1) } });
+
+    const counter = screen.getByText(`${warningThreshold - 1} / ${MAX_BIO_LENGTH}`);
+    expect(counter).not.toHaveClass('text-destructive');
+  });
+
+  it('counter switches to warning style at exactly 90% of MAX_BIO_LENGTH', () => {
+    renderBio();
+    const textarea = screen.getByRole('textbox', { name: /bio/i });
+
+    fireEvent.change(textarea, { target: { value: 'A'.repeat(warningThreshold) } });
+
+    const counter = screen.getByText(`${warningThreshold} / ${MAX_BIO_LENGTH}`);
+    expect(counter).toHaveClass('text-destructive');
+  });
+
+  it('counter keeps warning style when bio exceeds the limit', () => {
+    renderBio();
+    const textarea = screen.getByRole('textbox', { name: /bio/i });
+
+    fireEvent.change(textarea, { target: { value: 'A'.repeat(MAX_BIO_LENGTH + 1) } });
+
+    const counter = screen.getByText(`${MAX_BIO_LENGTH + 1} / ${MAX_BIO_LENGTH}`);
+    expect(counter).toHaveClass('text-destructive');
+  });
+});
+
+describe('ProfileBio — submission blocking', () => {
+  it('Save button is enabled within the limit', () => {
+    renderBio();
+    const textarea = screen.getByRole('textbox', { name: /bio/i });
+
+    fireEvent.change(textarea, { target: { value: 'A'.repeat(MAX_BIO_LENGTH) } });
+
+    expect(screen.getByRole('button', { name: /save changes/i })).not.toBeDisabled();
+  });
+
+  it('Save button is disabled when bio exceeds MAX_BIO_LENGTH', () => {
+    renderBio();
+    const textarea = screen.getByRole('textbox', { name: /bio/i });
+
+    fireEvent.change(textarea, { target: { value: 'A'.repeat(MAX_BIO_LENGTH + 1) } });
+
+    expect(screen.getByRole('button', { name: /save changes/i })).toBeDisabled();
+  });
+
+  it('shows inline error message when bio exceeds MAX_BIO_LENGTH', () => {
+    renderBio();
+    const textarea = screen.getByRole('textbox', { name: /bio/i });
+
+    fireEvent.change(textarea, { target: { value: 'A'.repeat(MAX_BIO_LENGTH + 1) } });
+
+    expect(
+      screen.getByText(`Bio must be ${MAX_BIO_LENGTH} characters or less`)
+    ).toBeInTheDocument();
+  });
+
+  it('clears the error once bio is back within the limit', () => {
+    renderBio();
+    const textarea = screen.getByRole('textbox', { name: /bio/i });
+
+    fireEvent.change(textarea, { target: { value: 'A'.repeat(MAX_BIO_LENGTH + 1) } });
+    expect(
+      screen.getByText(`Bio must be ${MAX_BIO_LENGTH} characters or less`)
+    ).toBeInTheDocument();
+
+    fireEvent.change(textarea, { target: { value: 'A'.repeat(MAX_BIO_LENGTH) } });
+    expect(
+      screen.queryByText(`Bio must be ${MAX_BIO_LENGTH} characters or less`)
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not call onSave when bio exceeds the limit', () => {
+    const { onSave } = renderBio();
+    const textarea = screen.getByRole('textbox', { name: /bio/i });
+
+    fireEvent.change(textarea, { target: { value: 'A'.repeat(MAX_BIO_LENGTH + 1) } });
+    fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+    expect(onSave).not.toHaveBeenCalled();
+  });
+});
+
+describe('ProfileBio — successful submission', () => {
+  it('calls onSave with the correct bio when within the limit', () => {
+    const { onSave } = renderBio();
+    const textarea = screen.getByRole('textbox', { name: /bio/i });
+    const validBio = 'Hello, I am a gamer!';
+
+    fireEvent.change(textarea, { target: { value: validBio } });
+    fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({ bio: validBio })
+    );
+  });
+
+  it('exits edit mode after a successful save', () => {
+    renderBio();
+    const textarea = screen.getByRole('textbox', { name: /bio/i });
+
+    fireEvent.change(textarea, { target: { value: 'Short bio' } });
+    fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+    expect(screen.queryByRole('textbox', { name: /bio/i })).not.toBeInTheDocument();
+  });
+});
+
+describe('ProfileBio — constant / schema consistency', () => {
+  it('profileBioSchema rejects bio longer than MAX_BIO_LENGTH', () => {
+    const result = profileBioSchema.safeParse({ bio: 'A'.repeat(MAX_BIO_LENGTH + 1) });
+    expect(result.success).toBe(false);
+  });
+
+  it('profileBioSchema accepts bio exactly at MAX_BIO_LENGTH', () => {
+    const result = profileBioSchema.safeParse({ bio: 'A'.repeat(MAX_BIO_LENGTH) });
+    expect(result.success).toBe(true);
+  });
+
+  it('profileBioSchema accepts an undefined bio', () => {
+    const result = profileBioSchema.safeParse({ bio: undefined });
+    expect(result.success).toBe(true);
+  });
+
+  it('MAX_BIO_LENGTH matches the schema max constraint', () => {
+    const tooLong = profileBioSchema.safeParse({ bio: 'A'.repeat(MAX_BIO_LENGTH + 1) });
+    const exactLimit = profileBioSchema.safeParse({ bio: 'A'.repeat(MAX_BIO_LENGTH) });
+    expect(tooLong.success).toBe(false);
+    expect(exactLimit.success).toBe(true);
+  });
+});

--- a/frontend/src/__tests__/profile-edit.test.tsx
+++ b/frontend/src/__tests__/profile-edit.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
-import ProfileEditPage from '@/app/profile/edit/page';
+import ProfileEditPage from '@/app/[locale]/profile/edit/page';
+import { MAX_BIO_LENGTH } from '@/lib/validations/profile';
 
 jest.mock('@/hooks/useAuth', () => ({
   useAuth: () => ({ user: { id: 'u1', username: 'TestUser', email: 'test@test.com' } }),
@@ -8,6 +9,7 @@ jest.mock('@/hooks/useAuth', () => ({
 
 jest.mock('next/navigation', () => ({
   useRouter: () => ({ push: jest.fn(), back: jest.fn() }),
+  useSearchParams: () => new URLSearchParams(),
 }));
 
 // CustomizationOptions uses lucide-react icons; mock to keep tests simple
@@ -16,15 +18,17 @@ jest.mock('@/components/profile/CustomizationOptions', () => ({
 }));
 
 describe('ProfileEditPage', () => {
-  it('disables submit button and shows error when bio exceeds 500 characters', () => {
+  it('disables submit button and shows error when bio exceeds MAX_BIO_LENGTH', () => {
     render(<ProfileEditPage />);
 
     const textarea = screen.getByRole('textbox', { name: /bio/i });
-    const longBio = 'a'.repeat(501);
+    const longBio = 'a'.repeat(MAX_BIO_LENGTH + 1);
 
     fireEvent.change(textarea, { target: { value: longBio } });
 
-    expect(screen.getByText('Bio must be 500 characters or less')).toBeInTheDocument();
+    expect(
+      screen.getByText(`Bio must be ${MAX_BIO_LENGTH} characters or less`)
+    ).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /save/i })).toBeDisabled();
   });
 

--- a/frontend/src/app/[locale]/profile/edit/page.tsx
+++ b/frontend/src/app/[locale]/profile/edit/page.tsx
@@ -13,8 +13,8 @@ import { X, Camera, Upload, CheckCircle, AlertTriangle, Twitter, Github, Twitch 
 import { cn } from '@/lib/utils';
 import type { ProfileCustomization } from '@/types/profile';
 import type { UserProfileUpdate } from '@/types/user';
+import { MAX_BIO_LENGTH } from '@/lib/validations/profile';
 
-const MAX_BIO_LENGTH = 500;
 const USERNAME_MIN_LENGTH = 3;
 const USERNAME_MAX_LENGTH = 20;
 
@@ -141,7 +141,7 @@ function ProfileEditContent() {
     const value = e.target.value;
     setBio(value);
     if (value.length > MAX_BIO_LENGTH) {
-      setBioError('Bio must be 500 characters or less');
+      setBioError(`Bio must be ${MAX_BIO_LENGTH} characters or less`);
     } else {
       setBioError(null);
     }
@@ -353,7 +353,10 @@ function ProfileEditContent() {
           <CardTitle>Bio</CardTitle>
         </CardHeader>
         <CardContent className="space-y-2">
+          <label htmlFor="profile-bio" className="sr-only">Bio</label>
           <textarea
+            id="profile-bio"
+            aria-label="Bio"
             value={bio}
             onChange={handleBioChange}
             rows={4}

--- a/frontend/src/components/profile/ProfileBio.tsx
+++ b/frontend/src/components/profile/ProfileBio.tsx
@@ -5,7 +5,9 @@ import { User } from "@/types/user";
 import { Card, CardContent, CardHeader, CardTitle, CardFooter } from "@/components/ui/Card";
 import { Button } from "@/components/ui/Button";
 import { Input } from "@/components/ui/Input";
-import { Edit2, Twitter, Github, Twitch, ExternalLink, Save, X } from "lucide-react";
+import { Edit2, Twitter, Github, Twitch, Save, X, AlertTriangle } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { MAX_BIO_LENGTH, profileBioSchema } from "@/lib/validations/profile";
 
 interface ProfileBioProps {
   user: User;
@@ -15,11 +17,31 @@ interface ProfileBioProps {
 export function ProfileBio({ user, onSave }: ProfileBioProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [bio, setBio] = useState(user.bio || "");
+  const [bioError, setBioError] = useState<string | null>(null);
   const [twitter, setTwitter] = useState(user.socialLinks?.twitter || "");
   const [discord, setDiscord] = useState(user.socialLinks?.discord || "");
   const [twitch, setTwitch] = useState(user.socialLinks?.twitch || "");
 
+  const bioLength = bio.length;
+  const bioExceedsLimit = bioLength > MAX_BIO_LENGTH;
+  const bioNearLimit = bioLength >= Math.floor(MAX_BIO_LENGTH * 0.9);
+
+  function handleBioChange(e: React.ChangeEvent<HTMLTextAreaElement>) {
+    const value = e.target.value;
+    setBio(value);
+
+    const result = profileBioSchema.safeParse({ bio: value });
+    if (!result.success) {
+      const msg = result.error.issues.find((i) => i.path[0] === "bio")?.message ?? null;
+      setBioError(msg);
+    } else {
+      setBioError(null);
+    }
+  }
+
   const handleSave = () => {
+    if (bioExceedsLimit) return;
+
     onSave({
       bio,
       socialLinks: {
@@ -31,6 +53,15 @@ export function ProfileBio({ user, onSave }: ProfileBioProps) {
     });
     setIsEditing(false);
   };
+
+  function handleCancel() {
+    setBio(user.bio || "");
+    setBioError(null);
+    setTwitter(user.socialLinks?.twitter || "");
+    setDiscord(user.socialLinks?.discord || "");
+    setTwitch(user.socialLinks?.twitch || "");
+    setIsEditing(false);
+  }
 
   return (
     <Card className="h-full">
@@ -50,11 +81,36 @@ export function ProfileBio({ user, onSave }: ProfileBioProps) {
               <label htmlFor="bio" className="text-sm font-medium">Bio</label>
               <textarea
                 id="bio"
-                className="flex min-h-[100px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                aria-describedby="bio-counter bio-error"
+                aria-invalid={bioExceedsLimit}
+                className={cn(
+                  "flex min-h-[100px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+                  bioExceedsLimit && "border-destructive"
+                )}
                 value={bio}
-                onChange={(e) => setBio(e.target.value)}
+                onChange={handleBioChange}
                 placeholder="Tell us about yourself..."
               />
+              <p
+                id="bio-counter"
+                aria-live="polite"
+                className={cn(
+                  "text-xs text-right",
+                  bioNearLimit ? "text-destructive font-medium" : "text-muted-foreground"
+                )}
+              >
+                {bioLength} / {MAX_BIO_LENGTH}
+              </p>
+              {bioError && (
+                <p
+                  id="bio-error"
+                  role="alert"
+                  className="text-sm text-destructive flex items-center gap-1"
+                >
+                  <AlertTriangle className="h-4 w-4 flex-shrink-0" />
+                  {bioError}
+                </p>
+              )}
             </div>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div className="space-y-2">
@@ -121,11 +177,11 @@ export function ProfileBio({ user, onSave }: ProfileBioProps) {
       </CardContent>
       {isEditing && (
         <CardFooter className="flex justify-end gap-2 pt-0">
-          <Button variant="ghost" size="sm" onClick={() => setIsEditing(false)}>
+          <Button variant="ghost" size="sm" onClick={handleCancel}>
             <X className="h-4 w-4 mr-2" />
             Cancel
           </Button>
-          <Button size="sm" onClick={handleSave}>
+          <Button size="sm" onClick={handleSave} disabled={bioExceedsLimit}>
             <Save className="h-4 w-4 mr-2" />
             Save Changes
           </Button>

--- a/frontend/src/lib/validations/profile.ts
+++ b/frontend/src/lib/validations/profile.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+export const MAX_BIO_LENGTH = 280;
+
+export const profileBioSchema = z.object({
+  bio: z
+    .string()
+    .max(MAX_BIO_LENGTH, `Bio must be ${MAX_BIO_LENGTH} characters or less`)
+    .optional(),
+});
+
+export type ProfileBioFormData = z.infer<typeof profileBioSchema>;


### PR DESCRIPTION
Closes #550

---

## Summary

This PR improves the bio editing experience in `ProfileBio.tsx` by surfacing the character limit in real time, preventing users from discovering validation failures only at submission. It also eliminates a duplicated — and mismatched — length constant by introducing a shared source of truth in `src/lib/validations/`.

### Problem

- `ProfileBio.tsx` had no character counter or client-side length validation; users could type unlimited text and only discover the constraint after hitting Save.
- `profile/edit/page.tsx` defined `MAX_BIO_LENGTH = 500` locally, but the server Zod schema enforces `max(280)`, meaning the frontend silently allowed bios the server would reject.
- No shared constant existed, so the two surfaces were guaranteed to drift.

### Changes

#### `src/lib/validations/profile.ts` _(new)_
- Exports `MAX_BIO_LENGTH = 280` — the single source of truth, aligned with the server constraint.
- Exports `profileBioSchema` (Zod) that validates `bio` against this constant, used for client-side validation in `ProfileBio.tsx`.

#### `src/components/profile/ProfileBio.tsx`
- Imports `MAX_BIO_LENGTH` and `profileBioSchema` from the shared validation module.
- **Live character counter** displayed below the textarea in `{currentLength} / {MAX_BIO_LENGTH}` format, updated on every keystroke.
- **Warning style** (`text-destructive`, bold) applied to the counter when `bioLength >= floor(MAX_BIO_LENGTH * 0.9)` (i.e., ≥ 252 characters).
- **Inline Zod-driven error message** appears near the textarea and updates dynamically as the user edits; clears automatically once within the limit.
- **Save button disabled** (`disabled={bioExceedsLimit}`) and `handleSave` guards with an early return when the bio is over the limit.
- Accessibility: `aria-live="polite"` on the counter, `aria-invalid` on the textarea, `aria-describedby` linking textarea → counter and error, `role="alert"` on the error paragraph.

#### `src/app/[locale]/profile/edit/page.tsx`
- Removes the local `MAX_BIO_LENGTH = 500` constant and imports `MAX_BIO_LENGTH` from `@/lib/validations/profile`.
- Error message now uses the constant (`Bio must be ${MAX_BIO_LENGTH} characters or less`) instead of a hardcoded string.
- Added `id="profile-bio"` and `aria-label="Bio"` to the bio textarea for accessibility and testability.

#### `src/__tests__/profile-edit.test.tsx`
- Fixed broken import path (`@/app/profile/edit/page` → `@/app/[locale]/profile/edit/page`).
- Added missing `useSearchParams` mock required by the page.
- Updated test to use `MAX_BIO_LENGTH` from the shared constant so the threshold never drifts from the implementation.

#### `src/__tests__/profile-bio.test.tsx` _(new, 16 tests)_

| Group | Tests |
|---|---|
| Character counter | Initial display, live updates on input, reflects pre-existing bio length |
| Warning state | No warning below 90%, warning triggers at exactly 90%, persists above limit |
| Submission blocking | Save enabled at limit, disabled over limit, inline error shown/cleared, `onSave` not called when over limit |
| Successful submission | `onSave` called with correct bio, edit mode exits after save |
| Constant / schema consistency | Schema rejects over-limit bio, accepts exactly-at-limit bio, accepts undefined bio, `MAX_BIO_LENGTH` and schema max are in sync |

## Test plan

- [ ] Enter bio edit mode in `ProfileBio` — counter starts at `0 / 280`
- [ ] Type until ≥ 252 characters — counter turns red
- [ ] Type past 280 characters — Save button disables, inline error appears
- [ ] Delete back under 280 — error clears, Save re-enables
- [ ] Save within limit — `onSave` fires, edit mode closes
- [ ] Verify `profile/edit` page bio counter also reflects 280 (was 500)
- [ ] Run `node_modules/.bin/jest --testPathPatterns="profile-bio"` — all 16 pass

