### PR TITLE
perf(auth): reduce redundant profile requests with React Query caching

### DIFF
--- a/frontend/src/hooks/useAuth.tsx
+++ b/frontend/src/hooks/useAuth.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, createContext, useContext, useCallback } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { AuthUser, LoginRequest, RegisterRequest } from "@/types";
 import { api } from "@/lib/api";
 
@@ -23,6 +24,8 @@ const REFRESH_TOKEN_KEY = "auth_refresh_token";
 const STORAGE_KEY = "arenax_auth_user";
 const REMEMBER_KEY = "arenax_remember_me";
 const PENDING_VERIFICATION_EMAIL_KEY = "arenax_pending_email";
+
+export const AUTH_PROFILE_QUERY_KEY = ["auth", "profile"] as const;
 
 function getStorage(remember: boolean): Storage {
   return remember ? localStorage : sessionStorage;
@@ -86,11 +89,37 @@ export const useAuth = () => {
 };
 
 export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
-  const [user, setUser] = useState<AuthUser | null>(() => readStoredUser());
+  const queryClient = useQueryClient();
+  const [hasToken, setHasToken] = useState(() => !!getStoredToken());
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const clearError = useCallback(() => setError(null), []);
+
+  const profileQuery = useQuery({
+    queryKey: AUTH_PROFILE_QUERY_KEY,
+    queryFn: async (): Promise<AuthUser | null> => {
+      const stored = getStoredToken();
+      if (!stored) return null;
+      const profile = await api.getProfile();
+      return {
+        id: profile.id,
+        username: profile.username,
+        email: profile.email ?? "",
+        isVerified: profile.is_verified,
+        elo: typeof profile.elo === "number" ? profile.elo : 0,
+        createdAt: profile.created_at,
+        token: stored.token,
+        refreshToken: stored.refreshToken,
+      };
+    },
+    enabled: hasToken,
+    staleTime: 60_000,
+    gcTime: 300_000,
+    placeholderData: () => readStoredUser(),
+  });
+
+  const user = profileQuery.data ?? null;
 
   const persistSession = useCallback(
     (authUser: AuthUser, rememberMe: boolean) => {
@@ -119,8 +148,9 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
         response.tokens.accessToken,
         response.tokens.refreshToken
       );
-      setUser(authUser);
       persistSession(authUser, rememberMe);
+      queryClient.setQueryData(AUTH_PROFILE_QUERY_KEY, authUser);
+      setHasToken(true);
     } catch (err) {
       const message =
         err instanceof Error ? err.message : "Invalid email or password";
@@ -144,7 +174,8 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
         response.tokens.accessToken,
         response.tokens.refreshToken
       );
-      setUser(authUser);
+      queryClient.setQueryData(AUTH_PROFILE_QUERY_KEY, authUser);
+      setHasToken(true);
       localStorage.setItem(PENDING_VERIFICATION_EMAIL_KEY, userData.email);
       // Don't persist session yet - user needs to verify email
     } catch (err) {
@@ -161,10 +192,9 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
       setLoading(true);
       setError(null);
       await api.verifyEmail(token);
-      // If we have a stored user, update their isVerified status
       if (user) {
         const updatedUser = { ...user, isVerified: true };
-        setUser(updatedUser);
+        queryClient.setQueryData(AUTH_PROFILE_QUERY_KEY, updatedUser);
         const remember = localStorage.getItem(REMEMBER_KEY) === "true";
         persistSession(updatedUser, remember);
       }
@@ -201,9 +231,10 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     });
     localStorage.removeItem(REMEMBER_KEY);
     localStorage.removeItem(PENDING_VERIFICATION_EMAIL_KEY);
-    setUser(null);
+    setHasToken(false);
     setError(null);
-  }, []);
+    queryClient.removeQueries({ queryKey: AUTH_PROFILE_QUERY_KEY });
+  }, [queryClient]);
 
   return (
     <AuthContext.Provider

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -94,6 +94,17 @@ class ApiClient {
     );
   }
 
+  async getProfile() {
+    return this.request<{
+      id: string;
+      username: string;
+      email: string | null;
+      is_verified: boolean;
+      created_at: string;
+      elo?: number;
+    }>("/users/me");
+  }
+
   // Tournament endpoints
   async getTournaments(params?: Record<string, any>) {
     const queryString = params ? "?" + new URLSearchParams(params) : "";


### PR DESCRIPTION
Closes #545

---

## Summary

The `AuthProvider` previously stored authenticated user data in plain React `useState`, which meant every component mounting simultaneously would independently read from localStorage but had no shared in-memory cache for the profile. This PR wires the profile/auth state into React Query so that:

- **A single network request** is made for concurrent consumers — React Query deduplicates in-flight calls sharing the same key.
- **Cached data is reused for 60 s** without re-fetching (`staleTime: 60_000`).
- **Unused cache entries are GC'd after 5 min** (`gcTime: 300_000`).
- **Logout immediately evicts the cache** so no stale user data can leak across sessions.

## Changes

### `frontend/src/lib/api.ts`
- Added `api.getProfile()` — calls `GET /api/users/me` (existing backend route) using the authenticated `request` method that unwraps `{ data: ... }` and injects the `Authorization` header automatically.

### `frontend/src/hooks/useAuth.tsx`
- Exported `AUTH_PROFILE_QUERY_KEY = ["auth", "profile"] as const` — a single stable constant for all consumers to reference so React Query deduplication and cache-sharing work correctly.
- Replaced `useState<AuthUser | null>` with `useQuery` backed by `api.getProfile()`, configured with `staleTime: 60_000` and `gcTime: 300_000`.
- `enabled: hasToken` — the query only runs when a stored token exists, controlled by a lightweight boolean state updated on login/logout.
- `placeholderData: () => readStoredUser()` — serves the persisted localStorage value synchronously on mount so there is no loading flash for returning users.
- **Login / register** — `queryClient.setQueryData(AUTH_PROFILE_QUERY_KEY, authUser)` populates the cache immediately from the auth response, avoiding a redundant `GET /users/me` call right after sign-in.
- **verifyEmail** — patches the cache entry in-place (`isVerified: true`) rather than invalidating and re-fetching.
- **Logout** — `queryClient.removeQueries({ queryKey: AUTH_PROFILE_QUERY_KEY })` synchronously evicts the profile entry; combined with `setHasToken(false)` this ensures no background re-fetch is attempted and no stale data can be read from cache after sign-out.

## Behaviour preserved

- `AuthContextType` interface is unchanged — zero breaking changes for consumers of `useAuth`.
- `loading` still reflects in-progress auth mutations (login, register, verify), not the profile query state.
- Session persistence to `localStorage` / `sessionStorage` is unchanged.
- `rememberMe` logic is unchanged.

## Test plan

- [ ] Sign in — verify only a single `GET /users/me` request fires in the Network tab even when multiple auth-gated components are mounted.
- [ ] Navigate between protected pages within 60 s of login — confirm no additional `GET /users/me` requests appear (data served from cache).
- [ ] Leave the app idle for 5+ minutes with no auth-gated components mounted — confirm the React Query DevTools show the `["auth","profile"]` entry has been GC'd.
- [ ] Sign out — confirm the `["auth","profile"]` cache entry is immediately removed (React Query DevTools) and `user` becomes `null`.
- [ ] Hard-refresh the page with a valid stored session — confirm the stored user is shown immediately (no loading flash) and a single background `GET /users/me` fires to revalidate.
- [ ] Verify email flow — confirm `isVerified` updates in the UI without triggering an extra network request.
