### PR TITLE
feat: avatar fallback with deterministic initials in TournamentParticipants

### DIFF
--- a/frontend/src/__tests__/tournament-participants.test.tsx
+++ b/frontend/src/__tests__/tournament-participants.test.tsx
@@ -1,0 +1,305 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import {
+  ParticipantAvatar,
+  TournamentParticipants,
+  hashUsername,
+  getAvatarColor,
+  AVATAR_COLORS,
+} from '@/components/tournaments/TournamentParticipants';
+import type { Tournament } from '@/types/tournament';
+
+// ─── hashUsername ─────────────────────────────────────────────────────────────
+
+describe('hashUsername', () => {
+  it('returns the same value for the same username on every call', () => {
+    expect(hashUsername('AlexPro')).toBe(hashUsername('AlexPro'));
+    expect(hashUsername('RiverVoid123')).toBe(hashUsername('RiverVoid123'));
+  });
+
+  it('produces different values for different usernames', () => {
+    expect(hashUsername('alice')).not.toBe(hashUsername('bob'));
+  });
+
+  it('always returns a non-negative integer', () => {
+    const h = hashUsername('SomePlayer');
+    expect(Number.isInteger(h)).toBe(true);
+    expect(h).toBeGreaterThanOrEqual(0);
+  });
+
+  it('handles an empty string without throwing', () => {
+    expect(() => hashUsername('')).not.toThrow();
+    expect(typeof hashUsername('')).toBe('number');
+  });
+
+  it('handles unicode characters without throwing', () => {
+    expect(() => hashUsername('玩家123')).not.toThrow();
+  });
+});
+
+// ─── getAvatarColor ───────────────────────────────────────────────────────────
+
+describe('getAvatarColor', () => {
+  it('returns the same color for the same username across calls', () => {
+    const name = 'BlakeNexus42';
+    expect(getAvatarColor(name)).toBe(getAvatarColor(name));
+  });
+
+  it('always returns one of the defined palette colors', () => {
+    ['alice', 'bob', 'carol', 'dave', 'eve'].forEach((name) => {
+      expect(AVATAR_COLORS as readonly string[]).toContain(getAvatarColor(name));
+    });
+  });
+
+  it('produces more than one distinct color across several usernames', () => {
+    const names = ['alice', 'bob', 'carol', 'dave', 'eve', 'frank', 'grace', 'heidi'];
+    const unique = new Set(names.map(getAvatarColor));
+    expect(unique.size).toBeGreaterThan(1);
+  });
+
+  it('is stable across 20 repeated calls (no hidden randomness)', () => {
+    const username = 'TaylorDragon';
+    const results = Array.from({ length: 20 }, () => getAvatarColor(username));
+    expect(new Set(results).size).toBe(1);
+  });
+});
+
+// ─── ParticipantAvatar — valid image ─────────────────────────────────────────
+
+describe('ParticipantAvatar — valid avatarUrl', () => {
+  const URL = 'https://example.com/avatar.png';
+
+  it('renders an <img> element when avatarUrl is a non-empty string', () => {
+    render(<ParticipantAvatar username="alice" avatarUrl={URL} />);
+    expect(screen.getByRole('img', { name: 'alice' }).tagName).toBe('IMG');
+  });
+
+  it('sets the src attribute to the provided URL', () => {
+    render(<ParticipantAvatar username="alice" avatarUrl={URL} />);
+    expect((screen.getByRole('img', { name: 'alice' }) as HTMLImageElement).src).toBe(URL);
+  });
+
+  it('sets alt to the username for accessibility', () => {
+    render(<ParticipantAvatar username="BobElite" avatarUrl={URL} />);
+    expect(screen.getByAltText('BobElite')).toBeInTheDocument();
+  });
+
+  it('does not show the initials text when the image is present', () => {
+    render(<ParticipantAvatar username="alice" avatarUrl={URL} />);
+    expect(screen.queryByText('A')).not.toBeInTheDocument();
+  });
+
+  it('does not render the placeholder div when image is present', () => {
+    const { container } = render(<ParticipantAvatar username="alice" avatarUrl={URL} />);
+    // The placeholder carries role="img" + aria-label; a real <img> uses alt instead.
+    // When the image loads, there must be no placeholder div in the DOM.
+    expect(container.querySelector('div[role="img"]')).toBeNull();
+  });
+});
+
+// ─── ParticipantAvatar — missing / empty avatarUrl ───────────────────────────
+
+describe('ParticipantAvatar — missing avatarUrl', () => {
+  it('renders the initials placeholder when avatarUrl is null', () => {
+    render(<ParticipantAvatar username="carol" avatarUrl={null} />);
+    const el = screen.getByRole('img', { name: 'carol' });
+    expect(el.tagName).not.toBe('IMG');
+    expect(screen.getByText('C')).toBeInTheDocument();
+  });
+
+  it('renders the initials placeholder when avatarUrl is undefined', () => {
+    render(<ParticipantAvatar username="dave" avatarUrl={undefined} />);
+    expect(screen.getByText('D')).toBeInTheDocument();
+  });
+
+  it('renders the initials placeholder when avatarUrl is an empty string', () => {
+    render(<ParticipantAvatar username="eve" avatarUrl="" />);
+    expect(screen.getByText('E')).toBeInTheDocument();
+  });
+
+  it('never renders an <img> element when avatarUrl is falsy', () => {
+    const { container } = render(<ParticipantAvatar username="frank" avatarUrl={null} />);
+    expect(container.querySelector('img')).toBeNull();
+  });
+
+  it('placeholder has aria-label equal to the username', () => {
+    render(<ParticipantAvatar username="grace" avatarUrl={null} />);
+    expect(screen.getByRole('img', { name: 'grace' })).toHaveAttribute('aria-label', 'grace');
+  });
+});
+
+// ─── ParticipantAvatar — initials ────────────────────────────────────────────
+
+describe('ParticipantAvatar — initials rendering', () => {
+  it('shows the uppercased first character of the username', () => {
+    render(<ParticipantAvatar username="alice" avatarUrl={null} />);
+    expect(screen.getByText('A')).toBeInTheDocument();
+  });
+
+  it('uppercases a lowercase leading character', () => {
+    render(<ParticipantAvatar username="zara" avatarUrl={null} />);
+    expect(screen.getByText('Z')).toBeInTheDocument();
+  });
+
+  it('shows only the first character, not later ones', () => {
+    render(<ParticipantAvatar username="Quinn" avatarUrl={null} />);
+    expect(screen.getByText('Q')).toBeInTheDocument();
+    expect(screen.queryByText('u')).not.toBeInTheDocument();
+    expect(screen.queryByText('i')).not.toBeInTheDocument();
+  });
+});
+
+// ─── ParticipantAvatar — image load failure ───────────────────────────────────
+
+describe('ParticipantAvatar — image load failure', () => {
+  it('switches to the initials placeholder after the image fires an error event', () => {
+    render(
+      <ParticipantAvatar username="heidi" avatarUrl="https://broken.example.com/heidi.png" />,
+    );
+
+    const img = screen.getByRole('img', { name: 'heidi' });
+    expect(img.tagName).toBe('IMG');
+
+    fireEvent.error(img);
+
+    // img is gone; placeholder is shown
+    expect(screen.queryByRole('img', { name: 'heidi' })?.tagName).not.toBe('IMG');
+    expect(screen.getByText('H')).toBeInTheDocument();
+  });
+
+  it('removes the <img> element from the DOM so error events cannot repeat', () => {
+    const { container } = render(
+      <ParticipantAvatar username="ivan" avatarUrl="https://broken.example.com/ivan.png" />,
+    );
+
+    fireEvent.error(container.querySelector('img')!);
+
+    expect(container.querySelector('img')).toBeNull();
+  });
+
+  it('shows the correct initial after image failure', () => {
+    render(
+      <ParticipantAvatar username="Judy" avatarUrl="https://broken.example.com/judy.png" />,
+    );
+    fireEvent.error(screen.getByRole('img', { name: 'Judy' }));
+    expect(screen.getByText('J')).toBeInTheDocument();
+  });
+
+  it('placeholder retains role="img" and aria-label after failure', () => {
+    render(
+      <ParticipantAvatar username="karl" avatarUrl="https://broken.example.com/karl.png" />,
+    );
+    fireEvent.error(screen.getByRole('img', { name: 'karl' }));
+    const placeholder = screen.getByRole('img', { name: 'karl' });
+    expect(placeholder.tagName).not.toBe('IMG');
+    expect(placeholder).toHaveAttribute('aria-label', 'karl');
+  });
+
+  it('calling fireEvent.error twice does not cause additional re-renders', () => {
+    const { container } = render(
+      <ParticipantAvatar username="lena" avatarUrl="https://broken.example.com/lena.png" />,
+    );
+
+    const img = container.querySelector('img')!;
+    fireEvent.error(img); // img unmounted after this
+    // A second error call on the detached node should not throw or revert state
+    expect(() => fireEvent.error(img)).not.toThrow();
+    expect(container.querySelector('img')).toBeNull();
+    expect(screen.getByText('L')).toBeInTheDocument();
+  });
+});
+
+// ─── ParticipantAvatar — deterministic placeholder color ─────────────────────
+
+describe('ParticipantAvatar — deterministic placeholder color', () => {
+  it('applies a color class from the palette to the placeholder', () => {
+    const { container } = render(<ParticipantAvatar username="nina" avatarUrl={null} />);
+    const el = container.firstChild as HTMLElement;
+    const appliedPaletteColor = AVATAR_COLORS.some((c) => el.className.includes(c));
+    expect(appliedPaletteColor).toBe(true);
+  });
+
+  it('renders the exact class returned by getAvatarColor', () => {
+    const username = 'otto';
+    const expected = getAvatarColor(username);
+    const { container } = render(<ParticipantAvatar username={username} avatarUrl={null} />);
+    expect((container.firstChild as HTMLElement).className).toContain(expected);
+  });
+
+  it('applies the same class on every render for the same username', () => {
+    const getClass = () => {
+      const { container } = render(<ParticipantAvatar username="peggy" avatarUrl={null} />);
+      return (container.firstChild as HTMLElement).className;
+    };
+    expect(getClass()).toBe(getClass());
+  });
+
+  it('after image failure the placeholder carries the correct color class', () => {
+    const username = 'quincy';
+    const expected = getAvatarColor(username);
+    render(
+      <ParticipantAvatar username={username} avatarUrl="https://broken.example.com/q.png" />,
+    );
+    fireEvent.error(screen.getByRole('img', { name: username }));
+    const placeholder = screen.getByRole('img', { name: username });
+    expect(placeholder.className).toContain(expected);
+  });
+});
+
+// ─── TournamentParticipants integration ──────────────────────────────────────
+
+const baseTournament: Tournament = {
+  id: 't-1',
+  name: 'Arena Cup',
+  gameType: 'chess',
+  tournamentType: 'single_elimination',
+  entryFee: 0,
+  prizePool: 500,
+  maxParticipants: 8,
+  currentParticipants: 3,
+  status: 'registration_open',
+  visibility: 'public',
+  startTime: new Date().toISOString(),
+  createdBy: 'user-1',
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+describe('TournamentParticipants integration', () => {
+  it('renders without crashing', () => {
+    expect(() => render(<TournamentParticipants tournament={baseTournament} />)).not.toThrow();
+  });
+
+  it('shows the Participants heading', () => {
+    render(<TournamentParticipants tournament={baseTournament} />);
+    expect(screen.getByRole('heading', { name: /participants/i })).toBeInTheDocument();
+  });
+
+  it('renders at least one avatar element per participant', () => {
+    render(<TournamentParticipants tournament={baseTournament} />);
+    // Every row has a ParticipantAvatar — each resolves to role="img"
+    const avatars = screen.getAllByRole('img');
+    expect(avatars.length).toBeGreaterThanOrEqual(baseTournament.currentParticipants);
+  });
+
+  it('displays the correct filled/total slot text', () => {
+    render(<TournamentParticipants tournament={baseTournament} />);
+    expect(
+      screen.getByText(
+        `${baseTournament.currentParticipants} of ${baseTournament.maxParticipants} slots filled`,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('shows "Tournament is full" messaging when at capacity', () => {
+    const full = { ...baseTournament, currentParticipants: 8, maxParticipants: 8 };
+    render(<TournamentParticipants tournament={full} />);
+    expect(screen.getAllByText(/tournament is full/i).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('shows available slots count when not full', () => {
+    render(<TournamentParticipants tournament={baseTournament} />);
+    const available = baseTournament.maxParticipants - baseTournament.currentParticipants;
+    expect(screen.getAllByText(new RegExp(`${available} spot`)).length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/frontend/src/components/tournaments/TournamentParticipants.tsx
+++ b/frontend/src/components/tournaments/TournamentParticipants.tsx
@@ -1,42 +1,121 @@
-import React, { useMemo } from "react";
+"use client";
+
+import React, { useMemo, useState } from "react";
 import { Tournament } from "@/types/tournament";
 import { Card } from "@/components/ui/Card";
 import { Users, Trophy, Zap } from "lucide-react";
 
-interface TournamentParticipantsProps {
-  tournament: Tournament;
+// ─── Avatar color palette ─────────────────────────────────────────────────────
+// Full Tailwind class names appear as literals so JIT compilation includes them.
+
+export const AVATAR_COLORS = [
+  "bg-red-500",
+  "bg-orange-500",
+  "bg-amber-500",
+  "bg-yellow-500",
+  "bg-lime-500",
+  "bg-green-500",
+  "bg-emerald-500",
+  "bg-teal-500",
+  "bg-cyan-500",
+  "bg-blue-500",
+  "bg-indigo-500",
+  "bg-violet-500",
+  "bg-purple-500",
+  "bg-fuchsia-500",
+  "bg-pink-500",
+  "bg-rose-500",
+] as const;
+
+export type AvatarColor = (typeof AVATAR_COLORS)[number];
+
+/**
+ * djb2-style hash over UTF-16 code units.
+ * Uses Math.imul for 32-bit integer arithmetic and >>> 0 to keep the result
+ * unsigned, so the output is always a non-negative integer regardless of input.
+ */
+export function hashUsername(username: string): number {
+  let h = 5381;
+  for (let i = 0; i < username.length; i++) {
+    h = (Math.imul(h, 31) + username.charCodeAt(i)) >>> 0;
+  }
+  return h;
 }
 
-// Mock participant data
-const generateMockParticipants = (gameType: string, count: number) => {
+/** Maps a username to a stable entry in AVATAR_COLORS. */
+export function getAvatarColor(username: string): AvatarColor {
+  return AVATAR_COLORS[hashUsername(username) % AVATAR_COLORS.length];
+}
+
+// ─── ParticipantAvatar ────────────────────────────────────────────────────────
+
+interface ParticipantAvatarProps {
+  username: string;
+  avatarUrl: string | null | undefined;
+}
+
+/**
+ * Renders a participant's avatar image when a URL is available, and falls back
+ * to an initials-based placeholder otherwise.
+ *
+ * Failure handling:
+ *   - null / undefined / empty avatarUrl  → placeholder immediately
+ *   - image load error (onError)          → sets imgFailed=true, unmounts <img>
+ *     so the error event cannot fire again (no re-render loop)
+ */
+export function ParticipantAvatar({ username, avatarUrl }: ParticipantAvatarProps) {
+  const [imgFailed, setImgFailed] = useState(false);
+
+  const colorClass = getAvatarColor(username);
+  const initial = username.charAt(0).toUpperCase();
+
+  if (avatarUrl && !imgFailed) {
+    return (
+      <img
+        src={avatarUrl}
+        alt={username}
+        className="h-8 w-8 rounded-full object-cover flex-shrink-0"
+        onError={() => setImgFailed(true)}
+      />
+    );
+  }
+
+  return (
+    <div
+      role="img"
+      aria-label={username}
+      className={`h-8 w-8 rounded-full flex-shrink-0 flex items-center justify-center text-white text-xs font-bold ${colorClass}`}
+    >
+      {initial}
+    </div>
+  );
+}
+
+// ─── Mock participant data ────────────────────────────────────────────────────
+
+interface MockParticipant {
+  id: string;
+  username: string;
+  rank: number;
+  joinedAt: string;
+  avatar: string;
+  rating: number;
+}
+
+const generateMockParticipants = (
+  _gameType: string,
+  count: number,
+): MockParticipant[] => {
   const firstNames = [
-    "Alex",
-    "Jordan",
-    "Casey",
-    "Morgan",
-    "Riley",
-    "Avery",
-    "Sam",
-    "Taylor",
-    "Quinn",
-    "River",
-    "Blake",
-    "Drew",
+    "Alex", "Jordan", "Casey", "Morgan", "Riley",
+    "Avery", "Sam", "Taylor", "Quinn", "River", "Blake", "Drew",
   ];
   const lastNames = [
-    "Pro",
-    "Elite",
-    "Gaming",
-    "Storm",
-    "Shadow",
-    "Phoenix",
-    "Dragon",
-    "Titan",
-    "Nexus",
-    "Void",
+    "Pro", "Elite", "Gaming", "Storm", "Shadow",
+    "Phoenix", "Dragon", "Titan", "Nexus", "Void",
   ];
 
-  const participants = [];
+  const participants: MockParticipant[] = [];
   for (let i = 0; i < count; i++) {
     const firstName = firstNames[Math.floor(Math.random() * firstNames.length)];
     const lastName = lastNames[Math.floor(Math.random() * lastNames.length)];
@@ -46,9 +125,7 @@ const generateMockParticipants = (gameType: string, count: number) => {
       id: `participant-${i + 1}`,
       username,
       rank: i + 1,
-      joinedAt: new Date(
-        Date.now() - Math.random() * 86400000 * 7,
-      ).toISOString(),
+      joinedAt: new Date(Date.now() - Math.random() * 86400000 * 7).toISOString(),
       avatar: `https://api.dicebear.com/7.x/avataaars/svg?seed=${username}`,
       rating: Math.floor(Math.random() * 500) + 1000,
     });
@@ -57,19 +134,22 @@ const generateMockParticipants = (gameType: string, count: number) => {
   return participants;
 };
 
+// ─── TournamentParticipants ───────────────────────────────────────────────────
+
+interface TournamentParticipantsProps {
+  tournament: Tournament;
+}
+
 export function TournamentParticipants({
   tournament,
 }: TournamentParticipantsProps) {
-  const participants = useMemo(() => {
-    return generateMockParticipants(
-      tournament.gameType,
-      tournament.currentParticipants,
-    );
-  }, [tournament.gameType, tournament.currentParticipants]);
+  const participants = useMemo(
+    () => generateMockParticipants(tournament.gameType, tournament.currentParticipants),
+    [tournament.gameType, tournament.currentParticipants],
+  );
 
   const isFull = tournament.currentParticipants >= tournament.maxParticipants;
-  const availableSlots =
-    tournament.maxParticipants - tournament.currentParticipants;
+  const availableSlots = tournament.maxParticipants - tournament.currentParticipants;
 
   return (
     <Card className="border-0 shadow-none p-0">
@@ -137,19 +217,19 @@ export function TournamentParticipants({
               >
                 {/* Rank and User */}
                 <div className="col-span-6 flex items-center gap-3">
-                  {/* Rank */}
+                  {/* Rank badge */}
                   <div className="flex items-center justify-center h-8 w-8 rounded-full bg-gradient-to-br from-blue-500 to-purple-500 flex-shrink-0">
                     <span className="text-white text-xs font-bold">
                       {index + 1}
                     </span>
                   </div>
 
-                  {/* Avatar and Username */}
+                  {/* Avatar + Username */}
                   <div className="flex items-center gap-2 min-w-0 flex-1">
-                    {/* Avatar Placeholder */}
-                    <div className="h-8 w-8 rounded-full bg-gradient-to-br from-blue-500 to-purple-500 flex-shrink-0 flex items-center justify-center text-white text-xs font-bold">
-                      {participant.username.charAt(0).toUpperCase()}
-                    </div>
+                    <ParticipantAvatar
+                      username={participant.username}
+                      avatarUrl={participant.avatar}
+                    />
                     <div className="min-w-0 flex-1">
                       <p className="text-sm font-semibold text-foreground truncate">
                         {participant.username}
@@ -229,8 +309,7 @@ export function TournamentParticipants({
         <div className="text-center">
           <p className="text-2xl font-bold text-foreground">
             {Math.round(
-              (tournament.currentParticipants / tournament.maxParticipants) *
-                100,
+              (tournament.currentParticipants / tournament.maxParticipants) * 100,
             )}
             %
           </p>


### PR DESCRIPTION
Closes #548

---

## Problem

`TournamentParticipants` always rendered a hardcoded blue-to-purple gradient div for every participant, ignoring the `avatar` URL entirely. When images are present, users should see actual avatars; when they aren't — or when they fail to load — the browser's broken-image icon previously appeared.

## Solution

Replace the static gradient with a `ParticipantAvatar` component that:
1. Attempts to render the real avatar image when a URL is provided
2. Falls back gracefully to an initials placeholder when the URL is missing or the image fails
3. Assigns each user a consistent placeholder color derived from a deterministic hash of their username — no randomness, no server state
4. Carries proper accessibility labels in both the image and placeholder states

---

## Changes — `TournamentParticipants.tsx`

| Export | Purpose |
|---|---|
| `AVATAR_COLORS` | 16 Tailwind color classes, written as string literals so JIT compilation includes every one |
| `hashUsername(username)` | djb2-style hash via `Math.imul` + `>>> 0`; always returns a non-negative 32-bit integer |
| `getAvatarColor(username)` | `AVATAR_COLORS[hashUsername(username) % 16]` — deterministic, stable across rerenders |
| `ParticipantAvatar` | New component; renders `<img>` or initials placeholder based on URL availability and load state |

### How `ParticipantAvatar` works

```
avatarUrl present?
├── yes → <img src={avatarUrl} alt={username} onError={() => setImgFailed(true)}>
│         ├── loads OK → image displayed
│         └── fails    → imgFailed=true → img unmounted → no further error events
└── no  → <div role="img" aria-label={username}>{initial}</div>  (immediate)
```

Once `imgFailed` is `true` the `<img>` is removed from the DOM. The browser's `error` event cannot fire a second time, so there is no re-render loop.

### Accessibility

| State | Accessible label source |
|---|---|
| Image loads | `alt={username}` on `<img>` |
| Placeholder (no URL or failure) | `aria-label={username}` on `<div role="img">` |

Both satisfy WCAG 1.1.1.

---

## Tests — `tournament-participants.test.tsx` (37 tests)

**`hashUsername` (5)**
- Same username → same value every call
- Different usernames → different values
- Always returns a non-negative integer
- Empty string doesn't throw
- Unicode input doesn't throw

**`getAvatarColor` (4)**
- Same username → same color across calls
- Returned value is always in `AVATAR_COLORS`
- Eight names produce more than one distinct color
- 20 repeated calls yield the same result (no hidden randomness)

**`ParticipantAvatar` — valid image (5)**
- `<img>` element is rendered
- `src` matches the provided URL
- `alt` equals the username
- No initials text alongside the image
- No placeholder `<div>` in the DOM

**`ParticipantAvatar` — missing URL (5)**
- `null` → placeholder with initials and `aria-label`
- `undefined` → placeholder
- `""` → placeholder
- No `<img>` in the DOM for falsy URLs
- `aria-label` equals the username

**`ParticipantAvatar` — initials (3)**
- Uppercased first character shown
- Lowercase leading character is uppercased
- Only the first character is shown

**`ParticipantAvatar` — image load failure (5)**
- `fireEvent.error` → placeholder appears
- `<img>` removed from DOM after failure
- Correct initial shown after failure
- `role="img"` and `aria-label` retained on placeholder
- Second `fireEvent.error` on the detached node does not throw or revert state

**`ParticipantAvatar` — deterministic color (4)**
- A palette class is present on the placeholder
- Applied class matches `getAvatarColor` output exactly
- Same class produced across multiple renders of the same username
- Correct color class after image failure

**`TournamentParticipants` integration (6)**
- Renders without crashing
- Shows "Participants" heading
- At least one `role="img"` element per participant
- Correct slot count text
- Full-tournament messaging
- Available-slots messaging

---

## Manual test plan

- [ ] Open a tournament detail page — avatar images render for participants with valid URLs
- [ ] Block `api.dicebear.com` in DevTools Network → avatars switch to coloured initials with no broken-image icons and no console errors about re-renders
- [ ] Hard-reload with the same participant list — each placeholder has the same colour as before the reload
- [ ] Compare two different participants — they may have different placeholder colours
- [ ] Inspect any avatar `<img>` in DevTools → `alt` equals the player's username
- [ ] Run a screen reader over the participant list → each avatar announces the player's username in both image and placeholder states