### PR TITLE
fix: remove duplicate /api prefix in configure_routes and log internal errors  

### DIFF
--- a/backend/src/api_error.rs
+++ b/backend/src/api_error.rs
@@ -1,6 +1,7 @@
 use actix_web::{HttpResponse, ResponseError};
 use serde::Serialize;
 use thiserror::Error;
+use tracing::error;
 
 #[derive(Debug, Error)]
 pub enum ApiError {
@@ -44,7 +45,15 @@ impl ApiError {
         ApiError::BadRequest(message.into())
     }
 
+    /// Creates an `InternalServerError` response.
+    ///
+    /// The `message` is written to the structured log at ERROR level so
+    /// engineers can diagnose the root cause, but it is **never** forwarded
+    /// to API consumers — the public response always says "Internal server
+    /// error".
     pub fn internal_error(message: impl Into<String>) -> Self {
+        let msg = message.into();
+        error!(error.message = %msg, "Internal server error");
         ApiError::InternalServerError
     }
 

--- a/backend/src/http/auth_handler.rs
+++ b/backend/src/http/auth_handler.rs
@@ -215,10 +215,15 @@ pub async fn get_analytics(
     })))
 }
 
-/// Configure authentication routes
+/// Configure authentication routes.
+///
+/// This function is intended to be called via `.configure(...)` inside an
+/// existing `/api` scope.  It therefore opens a `/auth` sub-scope — **not**
+/// `/api/auth` — so the resulting paths resolve to `/api/auth/…` without a
+/// duplicate `/api` prefix.
 pub fn configure_routes(cfg: &mut web::ServiceConfig) {
     cfg.service(
-        web::scope("/api/auth")
+        web::scope("/auth")
             .route("/register", web::post().to(register))
             .route("/login", web::post().to(login))
             .route("/refresh", web::post().to(refresh_token))

--- a/backend/src/http/match_authority_handler.rs
+++ b/backend/src/http/match_authority_handler.rs
@@ -231,10 +231,14 @@ pub async fn reconcile_match(
 // ROUTE CONFIGURATION
 // =============================================================================
 
-/// Configure Match Authority routes
+/// Configure Match Authority routes.
+///
+/// Intended to be called via `.configure(...)` inside an existing `/api`
+/// scope.  Opens a `/matches` sub-scope — **not** `/api/matches` — so paths
+/// resolve to `/api/matches/…` without a duplicate `/api` prefix.
 pub fn configure_routes(cfg: &mut web::ServiceConfig) {
     cfg.service(
-        web::scope("/api/matches")
+        web::scope("/matches")
             .route("", web::post().to(create_match))
             .route("/{id}", web::get().to(get_match))
             .route("/{id}/start", web::post().to(start_match))

--- a/backend/src/http/reputation_handler.rs
+++ b/backend/src/http/reputation_handler.rs
@@ -279,10 +279,14 @@ pub struct PaginationQuery {
     pub offset: Option<i64>,
 }
 
-/// Configure routes
+/// Configure routes.
+///
+/// Intended to be called via `.configure(...)` inside an existing `/api`
+/// scope.  Opens a `/reputation` sub-scope — **not** `/api/reputation` — so
+/// paths resolve to `/api/reputation/…` without a duplicate `/api` prefix.
 pub fn configure_routes(cfg: &mut web::ServiceConfig) {
     cfg.service(
-        web::scope("/api/reputation")
+        web::scope("/reputation")
             // Public endpoints
             .route("/player/{user_id}", web::get().to(get_player_reputation))
             // Authenticated user endpoints

--- a/backend/src/http/users.rs
+++ b/backend/src/http/users.rs
@@ -92,10 +92,14 @@ pub async fn get_user_stats(
     })))
 }
 
-/// Configure user routes
+/// Configure user routes.
+///
+/// Intended to be called via `.configure(...)` inside an existing `/api`
+/// scope.  Opens a `/users` sub-scope — **not** `/api/users` — so paths
+/// resolve to `/api/users/…` without a duplicate `/api` prefix.
 pub fn configure_routes(cfg: &mut web::ServiceConfig) {
     cfg.service(
-        web::scope("/api/users")
+        web::scope("/users")
             .route("/{id}", web::get().to(get_user_profile))
             .route("/me", web::get().to(get_current_user_profile))
             .route("/me", web::put().to(update_user_profile))


### PR DESCRIPTION


closes  #628 

closes #629

## Summary

### Fix A — Duplicate /api prefix in route scopes

All configure_routes functions were opening their own scope with a /api/...
prefix, but main.rs already mounts them inside web::scope("/api"). Actix
concatenates the scopes, producing unreachable paths like /api/api/auth/...

Changed scope prefix from /api/<resource> → /<resource> in:
- src/http/auth_handler.rs
- src/http/reputation_handler.rs
- src/http/users.rs
- src/http/match_authority_handler.rs

Auth routes (/api/auth/register, /api/auth/login, etc.) now resolve correctly.

### Fix B — internal_error() silently discarding its message

ApiError::internal_error(message) accepted a message but returned
ApiError::InternalServerError without ever using it, destroying diagnostic
context at every call site.

Changed in src/api_error.rs:
- Added use tracing::error;
- internal_error() now calls tracing::error! with the message before returning
- Public HTTP response unchanged — clients still get "Internal server error" with no internal detail leaked

## Testing
- Existing unit tests in auth_handler and jwt_service_test still pass
- cargo check should compile cleanly
