### PR TITLE
Feat/547 governance page

### DIFF
--- a/frontend/src/__tests__/tooltip.test.tsx
+++ b/frontend/src/__tests__/tooltip.test.tsx
@@ -1,8 +1,9 @@
 /**
- * Tests for Tooltip and Popover components (#525).
+ * Tests for Tooltip and Popover components (#525, #551).
  */
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/Tooltip';
 import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/Popover';
 
@@ -20,6 +21,25 @@ jest.mock('framer-motion', () => {
     AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   };
 });
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function renderTooltip(delayMs = 0) {
+  return render(
+    <Tooltip delayMs={delayMs}>
+      <TooltipTrigger>
+        <button type="button">Trigger</button>
+      </TooltipTrigger>
+      <TooltipContent>Tip text</TooltipContent>
+    </Tooltip>,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Existing hover tests
+// ---------------------------------------------------------------------------
 
 describe('Tooltip', () => {
   it('renders trigger without content visible initially', () => {
@@ -63,7 +83,100 @@ describe('Tooltip', () => {
     await waitFor(() => expect(screen.queryByRole('tooltip')).toBeNull());
     jest.useRealTimers();
   });
+
+  // -------------------------------------------------------------------------
+  // Keyboard accessibility tests — issue #551
+  // -------------------------------------------------------------------------
+
+  describe('keyboard accessibility (#551)', () => {
+    it('shows tooltip on focus', async () => {
+      jest.useFakeTimers();
+      renderTooltip();
+      fireEvent.focus(screen.getByRole('button', { name: 'Trigger' }).parentElement!);
+      jest.runAllTimers();
+      await waitFor(() => expect(screen.getByRole('tooltip')).toBeInTheDocument());
+      jest.useRealTimers();
+    });
+
+    it('hides tooltip on blur', async () => {
+      jest.useFakeTimers();
+      renderTooltip();
+      const triggerSpan = screen.getByRole('button', { name: 'Trigger' }).parentElement!;
+      fireEvent.focus(triggerSpan);
+      jest.runAllTimers();
+      await waitFor(() => expect(screen.getByRole('tooltip')).toBeInTheDocument());
+      fireEvent.blur(triggerSpan);
+      await waitFor(() => expect(screen.queryByRole('tooltip')).toBeNull());
+      jest.useRealTimers();
+    });
+
+    it('dismisses tooltip with Escape key without moving focus', async () => {
+      jest.useFakeTimers();
+      renderTooltip();
+      const triggerSpan = screen.getByRole('button', { name: 'Trigger' }).parentElement!;
+
+      // Show via focus
+      fireEvent.focus(triggerSpan);
+      jest.runAllTimers();
+      await waitFor(() => expect(screen.getByRole('tooltip')).toBeInTheDocument());
+
+      // Dismiss with Escape
+      fireEvent.keyDown(document, { key: 'Escape' });
+      await waitFor(() => expect(screen.queryByRole('tooltip')).toBeNull());
+
+      // Focus must remain on the trigger element (not moved away)
+      expect(document.activeElement).not.toBe(document.body);
+      jest.useRealTimers();
+    });
+
+    it('does not close on other keys', async () => {
+      jest.useFakeTimers();
+      renderTooltip();
+      const triggerSpan = screen.getByRole('button', { name: 'Trigger' }).parentElement!;
+      fireEvent.focus(triggerSpan);
+      jest.runAllTimers();
+      await waitFor(() => expect(screen.getByRole('tooltip')).toBeInTheDocument());
+      fireEvent.keyDown(document, { key: 'Enter' });
+      // Tooltip should still be visible
+      expect(screen.getByRole('tooltip')).toBeInTheDocument();
+      jest.useRealTimers();
+    });
+
+    it('trigger has aria-describedby pointing to tooltip id when open', async () => {
+      jest.useFakeTimers();
+      renderTooltip();
+      const triggerSpan = screen.getByRole('button', { name: 'Trigger' }).parentElement!;
+      fireEvent.focus(triggerSpan);
+      jest.runAllTimers();
+      await waitFor(() => expect(screen.getByRole('tooltip')).toBeInTheDocument());
+
+      const tooltip = screen.getByRole('tooltip');
+      const tooltipId = tooltip.getAttribute('id');
+      expect(tooltipId).toBeTruthy();
+      expect(triggerSpan).toHaveAttribute('aria-describedby', tooltipId);
+      jest.useRealTimers();
+    });
+
+    it('trigger has no aria-describedby when tooltip is closed', () => {
+      renderTooltip();
+      const triggerSpan = screen.getByRole('button', { name: 'Trigger' }).parentElement!;
+      expect(triggerSpan).not.toHaveAttribute('aria-describedby');
+    });
+
+    it('tooltip content has role="tooltip"', async () => {
+      jest.useFakeTimers();
+      renderTooltip();
+      fireEvent.mouseEnter(screen.getByRole('button', { name: 'Trigger' }).parentElement!);
+      jest.runAllTimers();
+      await waitFor(() => expect(screen.getByRole('tooltip')).toBeInTheDocument());
+      jest.useRealTimers();
+    });
+  });
 });
+
+// ---------------------------------------------------------------------------
+// Popover tests (unchanged)
+// ---------------------------------------------------------------------------
 
 describe('Popover', () => {
   it('renders trigger without dialog initially', () => {

--- a/frontend/src/app/[locale]/governance/[id]/page.tsx
+++ b/frontend/src/app/[locale]/governance/[id]/page.tsx
@@ -1,0 +1,480 @@
+"use client";
+
+import React, { useState } from "react";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { formatDistanceToNow, format } from "date-fns";
+import {
+  ArrowLeft,
+  Scale,
+  Clock,
+  CheckCircle2,
+  XCircle,
+  ExternalLink,
+  Vote,
+  AlertCircle,
+  Terminal,
+  User,
+} from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/Card";
+import { Badge } from "@/components/ui/Badge";
+import { Button } from "@/components/ui/Button";
+import { PageError } from "@/components/common/PageError";
+import { CardSkeleton, PageHeaderSkeleton } from "@/components/common/PageSkeleton";
+import { VoteBreakdownChart } from "@/components/governance/VoteBreakdownChart";
+import { VoteModal } from "@/components/governance/VoteModal";
+import { useAuth } from "@/hooks/useAuth";
+import { useProposal, useVoteOnProposal } from "@/hooks/useGovernance";
+import { cn } from "@/lib/utils";
+import {
+  isVotable,
+  PROPOSAL_STATUS_LABELS,
+  type VoteChoice,
+} from "@/types/governance";
+
+// ---------------------------------------------------------------------------
+// Status badge config (mirrors ProposalCard)
+// ---------------------------------------------------------------------------
+const STATUS_BADGE_CLASS: Record<string, string> = {
+  PENDING:
+    "bg-blue-500/15 text-blue-700 dark:text-blue-300 border-blue-400/30",
+  APPROVED:
+    "bg-green-500/15 text-green-700 dark:text-green-300 border-green-400/30",
+  EXECUTED:
+    "bg-emerald-500/15 text-emerald-700 dark:text-emerald-300 border-emerald-400/30",
+  CANCELLED: "text-muted-foreground",
+  FAILED: "",
+};
+
+const STATUS_ICONS: Record<string, React.ReactNode> = {
+  PENDING: <Clock className="h-3.5 w-3.5" aria-hidden="true" />,
+  APPROVED: <CheckCircle2 className="h-3.5 w-3.5" aria-hidden="true" />,
+  EXECUTED: <CheckCircle2 className="h-3.5 w-3.5" aria-hidden="true" />,
+  CANCELLED: <XCircle className="h-3.5 w-3.5" aria-hidden="true" />,
+  FAILED: <XCircle className="h-3.5 w-3.5" aria-hidden="true" />,
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function MetaRow({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col sm:flex-row sm:items-start gap-0.5 sm:gap-4 py-3 border-b last:border-0">
+      <dt className="text-sm font-medium text-muted-foreground sm:w-40 shrink-0">
+        {label}
+      </dt>
+      <dd className="text-sm text-foreground break-all">{children}</dd>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+export default function ProposalDetailPage() {
+  const params = useParams<{ id: string }>();
+  const id = params.id;
+
+  const { user } = useAuth();
+  const { data: proposal, isLoading, isError, refetch } = useProposal(id);
+  const voteMutation = useVoteOnProposal();
+
+  const [voteModalOpen, setVoteModalOpen] = useState(false);
+  const [voteError, setVoteError] = useState<string | null>(null);
+
+  // ---------------------------------------------------------------------------
+  // Loading / error states
+  // ---------------------------------------------------------------------------
+  if (isLoading) {
+    return (
+      <div className="space-y-6">
+        <PageHeaderSkeleton />
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+          <div className="lg:col-span-2 space-y-6">
+            <CardSkeleton lines={5} />
+            <CardSkeleton lines={4} />
+          </div>
+          <div className="space-y-4">
+            <CardSkeleton lines={3} hasFooter />
+            <CardSkeleton lines={4} />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (isError || !proposal) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <PageError
+          title="Proposal not found"
+          message="We couldn't load this proposal. It may have been removed or the ID is incorrect."
+          onRetry={() => refetch()}
+        />
+      </div>
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Derived state
+  // ---------------------------------------------------------------------------
+  const hasVoted =
+    !!user?.id &&
+    Array.isArray(proposal.approvers) &&
+    proposal.approvers.includes(user.id);
+
+  const votable = isVotable(proposal);
+  const canVote = !!user && votable && !hasVoted;
+
+  const badgeClass =
+    STATUS_BADGE_CLASS[proposal.status] ?? STATUS_BADGE_CLASS.PENDING;
+  const statusLabel =
+    PROPOSAL_STATUS_LABELS[proposal.status] ?? proposal.status;
+  const statusIcon = STATUS_ICONS[proposal.status];
+
+  const breakdown = proposal.vote_breakdown ?? {
+    yes: proposal.approval_count ?? 0,
+    no: 0,
+    abstain: 0,
+  };
+
+  const title = proposal.description
+    ? proposal.description.split("\n")[0].slice(0, 120)
+    : proposal.function;
+
+  const fullDescription =
+    proposal.description && proposal.description.includes("\n")
+      ? proposal.description.split("\n").slice(1).join("\n").trim()
+      : null;
+
+  // ---------------------------------------------------------------------------
+  // Handlers
+  // ---------------------------------------------------------------------------
+  const handleVote = async (choice: VoteChoice) => {
+    setVoteError(null);
+    try {
+      await voteMutation.mutateAsync({ id: proposal.id, choice });
+    } catch (err) {
+      const msg =
+        err instanceof Error ? err.message : "Failed to submit vote.";
+      setVoteError(msg);
+      throw err;
+    }
+  };
+
+  // ---------------------------------------------------------------------------
+  // Render
+  // ---------------------------------------------------------------------------
+  return (
+    <div className="space-y-6">
+      {/* Back nav */}
+      <Link
+        href="/governance"
+        className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+      >
+        <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+        Back to Governance
+      </Link>
+
+      {/* Title row */}
+      <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
+        <div className="space-y-1 flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <Scale className="h-5 w-5 text-primary shrink-0" aria-hidden="true" />
+            <Badge
+              variant="outline"
+              className={cn("inline-flex items-center gap-1 text-xs", badgeClass)}
+            >
+              {statusIcon}
+              {statusLabel}
+            </Badge>
+          </div>
+          <h1 className="text-2xl font-bold tracking-tight leading-snug">
+            {title}
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            Proposed{" "}
+            {formatDistanceToNow(new Date(proposal.created_at), {
+              addSuffix: true,
+            })}
+          </p>
+        </div>
+
+        {/* Vote CTA */}
+        {canVote && (
+          <Button
+            className="gap-2 shrink-0"
+            onClick={() => setVoteModalOpen(true)}
+          >
+            <Vote className="h-4 w-4" aria-hidden="true" />
+            Cast Vote
+          </Button>
+        )}
+        {!user && votable && (
+          <Link href="/login">
+            <Button variant="outline" className="gap-2 shrink-0 w-full sm:w-auto">
+              Log in to vote
+            </Button>
+          </Link>
+        )}
+      </div>
+
+      {/* Vote error banner */}
+      {voteError && (
+        <div
+          className="flex items-start gap-2 rounded-md bg-destructive/10 px-4 py-3 text-sm text-destructive"
+          role="alert"
+        >
+          <AlertCircle className="h-4 w-4 mt-0.5 shrink-0" aria-hidden="true" />
+          {voteError}
+          <button
+            className="ml-auto text-destructive/70 hover:text-destructive"
+            onClick={() => setVoteError(null)}
+            aria-label="Dismiss error"
+          >
+            ×
+          </button>
+        </div>
+      )}
+
+      {/* Already voted notice */}
+      {hasVoted && (
+        <div
+          className="flex items-center gap-2 rounded-md border border-green-400/30 bg-green-500/10 px-4 py-3 text-sm text-green-700 dark:text-green-300"
+          role="note"
+        >
+          <CheckCircle2 className="h-4 w-4 shrink-0" aria-hidden="true" />
+          You have already voted on this proposal.
+        </div>
+      )}
+
+      {/* Main content grid */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {/* LEFT — description + vote breakdown */}
+        <div className="lg:col-span-2 space-y-6">
+          {/* Description */}
+          {fullDescription && (
+            <Card>
+              <CardHeader className="pb-3">
+                <CardTitle className="text-base">Description</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-sm text-foreground/90 whitespace-pre-wrap leading-relaxed">
+                  {fullDescription}
+                </p>
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Vote breakdown */}
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base">Vote Breakdown</CardTitle>
+              <CardDescription>
+                Current vote distribution across all participants
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <VoteBreakdownChart
+                yes={breakdown.yes}
+                no={breakdown.no}
+                abstain={breakdown.abstain}
+              />
+
+              {/* Approvers list */}
+              {Array.isArray(proposal.approvers) &&
+                proposal.approvers.length > 0 && (
+                  <div className="mt-6 space-y-2">
+                    <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+                      Approvers ({proposal.approvers.length})
+                    </h3>
+                    <ul className="space-y-1.5 max-h-48 overflow-y-auto pr-1">
+                      {proposal.approvers.map((addr) => (
+                        <li
+                          key={addr}
+                          className="flex items-center gap-2 text-xs font-mono text-muted-foreground"
+                        >
+                          <User
+                            className="h-3 w-3 shrink-0"
+                            aria-hidden="true"
+                          />
+                          <span className="truncate">{addr}</span>
+                          {addr === user?.id && (
+                            <Badge variant="outline" className="text-[10px] ml-auto shrink-0">
+                              You
+                            </Badge>
+                          )}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+            </CardContent>
+          </Card>
+
+          {/* Args */}
+          {proposal.args &&
+            Object.keys(proposal.args).length > 0 && (
+              <Card>
+                <CardHeader className="pb-3">
+                  <CardTitle className="text-base flex items-center gap-2">
+                    <Terminal className="h-4 w-4" aria-hidden="true" />
+                    Function Arguments
+                  </CardTitle>
+                  <CardDescription>
+                    Arguments passed to{" "}
+                    <code className="font-mono text-xs bg-muted px-1 rounded">
+                      {proposal.function}()
+                    </code>
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <pre className="rounded-md bg-muted p-4 text-xs font-mono overflow-x-auto text-foreground/80 leading-relaxed">
+                    {JSON.stringify(proposal.args, null, 2)}
+                  </pre>
+                </CardContent>
+              </Card>
+            )}
+        </div>
+
+        {/* RIGHT — metadata sidebar */}
+        <div className="space-y-4">
+          {/* Proposal metadata */}
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base">Details</CardTitle>
+            </CardHeader>
+            <CardContent className="p-0 px-6 pb-6">
+              <dl>
+                <MetaRow label="Status">
+                  <Badge
+                    variant="outline"
+                    className={cn(
+                      "inline-flex items-center gap-1 text-xs",
+                      badgeClass
+                    )}
+                  >
+                    {statusIcon}
+                    {statusLabel}
+                  </Badge>
+                </MetaRow>
+
+                <MetaRow label="Proposal ID">
+                  <span className="font-mono text-xs break-all">
+                    {proposal.proposal_id ?? proposal.id}
+                  </span>
+                </MetaRow>
+
+                <MetaRow label="Target contract">
+                  <span className="font-mono text-xs break-all">
+                    {proposal.target_contract}
+                  </span>
+                </MetaRow>
+
+                <MetaRow label="Function">
+                  <code className="font-mono text-xs bg-muted px-1.5 py-0.5 rounded">
+                    {proposal.function}()
+                  </code>
+                </MetaRow>
+
+                <MetaRow label="Proposer">
+                  <span className="font-mono text-xs break-all">
+                    {proposal.proposer}
+                  </span>
+                </MetaRow>
+
+                <MetaRow label="Created">
+                  {format(
+                    new Date(proposal.created_at),
+                    "MMM d, yyyy 'at' HH:mm"
+                  )}
+                </MetaRow>
+
+                {proposal.execute_after && (
+                  <MetaRow label="Earliest execution">
+                    {format(
+                      new Date(proposal.execute_after),
+                      "MMM d, yyyy 'at' HH:mm"
+                    )}
+                  </MetaRow>
+                )}
+
+                {proposal.executed_at && (
+                  <MetaRow label="Executed at">
+                    {format(
+                      new Date(proposal.executed_at),
+                      "MMM d, yyyy 'at' HH:mm"
+                    )}
+                  </MetaRow>
+                )}
+
+                {proposal.last_chain_tx && (
+                  <MetaRow label="Last chain tx">
+                    <a
+                      href={`https://stellar.expert/explorer/public/tx/${proposal.last_chain_tx}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-1 text-primary hover:underline font-mono text-xs break-all"
+                    >
+                      {proposal.last_chain_tx.slice(0, 18)}…
+                      <ExternalLink
+                        className="h-3 w-3 shrink-0"
+                        aria-label="View on Stellar Expert (opens in new tab)"
+                      />
+                    </a>
+                  </MetaRow>
+                )}
+              </dl>
+            </CardContent>
+          </Card>
+
+          {/* Discussion link placeholder */}
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base">Discussion</CardTitle>
+              <CardDescription>
+                Community discussion for this proposal
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <a
+                href={`https://github.com/dark-sarge/ArenaX/discussions?q=${encodeURIComponent(proposal.proposal_id ?? proposal.id)}`}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="w-full gap-2"
+                >
+                  <ExternalLink className="h-4 w-4" aria-hidden="true" />
+                  View on GitHub Discussions
+                </Button>
+              </a>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+
+      {/* Vote modal */}
+      <VoteModal
+        isOpen={voteModalOpen}
+        onClose={() => setVoteModalOpen(false)}
+        proposalTitle={title}
+        onConfirm={handleVote}
+      />
+    </div>
+  );
+}

--- a/frontend/src/app/[locale]/governance/error.tsx
+++ b/frontend/src/app/[locale]/governance/error.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useEffect } from "react";
+import { PageError } from "@/components/common/PageError";
+
+export default function GovernanceError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("[GovernancePage]", error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center">
+      <PageError
+        title="Failed to load governance"
+        message="We couldn't fetch governance proposals. Check your connection and try again."
+        onRetry={reset}
+      />
+    </div>
+  );
+}

--- a/frontend/src/app/[locale]/governance/loading.tsx
+++ b/frontend/src/app/[locale]/governance/loading.tsx
@@ -1,0 +1,26 @@
+import {
+  PageHeaderSkeleton,
+  ListItemSkeleton,
+  Skeleton,
+} from "@/components/common/PageSkeleton";
+
+export default function GovernanceLoading() {
+  return (
+    <div className="space-y-8" aria-hidden="true">
+      <PageHeaderSkeleton />
+
+      {/* Auth notice placeholder */}
+      <Skeleton className="h-12 w-full rounded-lg" />
+
+      {/* Tabs placeholder */}
+      <Skeleton className="h-11 w-72 rounded-lg" />
+
+      {/* Proposal card grid */}
+      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <ListItemSkeleton key={i} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/[locale]/governance/page.tsx
+++ b/frontend/src/app/[locale]/governance/page.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+import React, { useMemo, useState } from "react";
+import { Scale, AlertCircle } from "lucide-react";
+import { Button } from "@/components/ui/Button";
+import { EmptyState } from "@/components/common/EmptyState";
+import { PageError } from "@/components/common/PageError";
+import { ProposalCard } from "@/components/governance/ProposalCard";
+import { ListItemSkeleton } from "@/components/common/PageSkeleton";
+import { useAuth } from "@/hooks/useAuth";
+import { useProposals, useVoteOnProposal } from "@/hooks/useGovernance";
+import type { Proposal, ProposalTab, VoteChoice } from "@/types/governance";
+import { statusToTab } from "@/types/governance";
+
+// ---------------------------------------------------------------------------
+// Tab config
+// ---------------------------------------------------------------------------
+
+const TABS: { id: ProposalTab; label: string }[] = [
+  { id: "active", label: "Active" },
+  { id: "passed", label: "Passed" },
+  { id: "failed", label: "Failed" },
+];
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+export default function GovernancePage() {
+  const { user } = useAuth();
+  const { data: proposals, isLoading, isError, refetch } = useProposals();
+  const voteMutation = useVoteOnProposal();
+
+  const [activeTab, setActiveTab] = useState<ProposalTab>("active");
+  const [voteError, setVoteError] = useState<string | null>(null);
+
+  // Group proposals by tab
+  const grouped = useMemo<Record<ProposalTab, Proposal[]>>(() => {
+    const base: Record<ProposalTab, Proposal[]> = {
+      active: [],
+      passed: [],
+      failed: [],
+    };
+    if (!proposals) return base;
+    for (const p of proposals) {
+      base[statusToTab(p.status)].push(p);
+    }
+    // Active: most recent first; others: most-recently-executed first
+    base.active.sort(
+      (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+    );
+    base.passed.sort(
+      (a, b) =>
+        new Date(b.executed_at ?? b.created_at).getTime() -
+        new Date(a.executed_at ?? a.created_at).getTime()
+    );
+    base.failed.sort(
+      (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+    );
+    return base;
+  }, [proposals]);
+
+  const visibleProposals = grouped[activeTab];
+
+  // ---------------------------------------------------------------------------
+  // Handlers
+  // ---------------------------------------------------------------------------
+
+  const handleVote = async (proposal: Proposal, choice: VoteChoice) => {
+    setVoteError(null);
+    try {
+      await voteMutation.mutateAsync({ id: proposal.id, choice });
+    } catch (err) {
+      const msg =
+        err instanceof Error ? err.message : "Failed to submit vote.";
+      setVoteError(msg);
+      throw err; // re-throw so VoteModal can show inline error
+    }
+  };
+
+  // ---------------------------------------------------------------------------
+  // Render
+  // ---------------------------------------------------------------------------
+
+  return (
+    <div className="space-y-8">
+      {/* Page header */}
+      <div className="space-y-1">
+        <h1 className="text-3xl font-bold tracking-tight flex items-center gap-2">
+          <Scale className="h-7 w-7 text-primary" aria-hidden="true" />
+          Governance
+        </h1>
+        <p className="text-muted-foreground">
+          Review and vote on proposals that shape the ArenaX platform.
+        </p>
+      </div>
+
+      {/* Auth notice */}
+      {!user && (
+        <div
+          className="flex items-start gap-3 rounded-lg border border-amber-400/40 bg-amber-400/10 px-4 py-3 text-sm text-amber-700 dark:text-amber-300"
+          role="note"
+        >
+          <AlertCircle className="h-4 w-4 mt-0.5 shrink-0" aria-hidden="true" />
+          <span>
+            You are viewing governance proposals as a guest.{" "}
+            <a href="/login" className="font-semibold underline underline-offset-2">
+              Log in
+            </a>{" "}
+            to cast votes.
+          </span>
+        </div>
+      )}
+
+      {/* Tabs */}
+      <div
+        className="inline-flex rounded-lg border bg-muted p-1 gap-0.5"
+        role="tablist"
+        aria-label="Proposal status tabs"
+      >
+        {TABS.map((tab) => (
+          <button
+            key={tab.id}
+            role="tab"
+            id={`tab-${tab.id}`}
+            aria-selected={activeTab === tab.id}
+            aria-controls={`tabpanel-${tab.id}`}
+            onClick={() => setActiveTab(tab.id)}
+            className={[
+              "inline-flex items-center gap-2 px-5 py-2 rounded-md text-sm font-medium transition-all",
+              activeTab === tab.id
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground",
+            ].join(" ")}
+          >
+            {tab.label}
+            {/* Count badge — only show when loaded */}
+            {!isLoading && proposals && (
+              <span className="ml-0.5 text-xs bg-muted-foreground/20 px-2 py-0.5 rounded-full tabular-nums">
+                {grouped[tab.id].length}
+              </span>
+            )}
+          </button>
+        ))}
+      </div>
+
+      {/* Global vote error toast-area */}
+      {voteError && (
+        <div
+          className="flex items-start gap-2 rounded-md bg-destructive/10 px-4 py-3 text-sm text-destructive"
+          role="alert"
+        >
+          <AlertCircle className="h-4 w-4 mt-0.5 shrink-0" aria-hidden="true" />
+          {voteError}
+          <button
+            className="ml-auto text-destructive/70 hover:text-destructive"
+            onClick={() => setVoteError(null)}
+            aria-label="Dismiss error"
+          >
+            ×
+          </button>
+        </div>
+      )}
+
+      {/* Tab panel */}
+      <section
+        role="tabpanel"
+        id={`tabpanel-${activeTab}`}
+        aria-labelledby={`tab-${activeTab}`}
+      >
+        {isError ? (
+          <PageError
+            title="Failed to load proposals"
+            message="We couldn't fetch governance proposals. Check your connection and try again."
+            onRetry={() => refetch()}
+          />
+        ) : isLoading ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <ListItemSkeleton key={i} />
+            ))}
+          </div>
+        ) : visibleProposals.length === 0 ? (
+          <EmptyState
+            icon={Scale}
+            title={`No ${activeTab} proposals`}
+            description={
+              activeTab === "active"
+                ? "There are no active proposals right now. Check back later."
+                : `No proposals have ${activeTab === "passed" ? "passed" : "failed"} yet.`
+            }
+          />
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+            {visibleProposals.map((proposal) => (
+              <ProposalCard
+                key={proposal.id}
+                proposal={proposal}
+                isAuthenticated={!!user}
+                currentUserAddress={user?.id}
+                onVote={handleVote}
+              />
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/components/governance/ProposalCard.tsx
+++ b/frontend/src/components/governance/ProposalCard.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import React, { useState } from "react";
+import Link from "next/link";
+import { formatDistanceToNow } from "date-fns";
+import { Vote, Clock, ChevronRight, CheckCircle2, XCircle, Loader2 } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardFooter,
+} from "@/components/ui/Card";
+import { Badge } from "@/components/ui/Badge";
+import { Button } from "@/components/ui/Button";
+import { cn } from "@/lib/utils";
+import type { Proposal, VoteChoice } from "@/types/governance";
+import { isVotable, PROPOSAL_STATUS_LABELS } from "@/types/governance";
+import { VoteBreakdownChart } from "./VoteBreakdownChart";
+import { VoteModal } from "./VoteModal";
+
+// ---------------------------------------------------------------------------
+// Status badge
+// ---------------------------------------------------------------------------
+
+const STATUS_BADGE: Record<
+  string,
+  { variant: "default" | "secondary" | "outline" | "destructive"; className: string }
+> = {
+  PENDING: {
+    variant: "default",
+    className: "bg-blue-500/15 text-blue-700 dark:text-blue-300 border-blue-400/30",
+  },
+  APPROVED: {
+    variant: "secondary",
+    className:
+      "bg-green-500/15 text-green-700 dark:text-green-300 border-green-400/30",
+  },
+  EXECUTED: {
+    variant: "secondary",
+    className:
+      "bg-emerald-500/15 text-emerald-700 dark:text-emerald-300 border-emerald-400/30",
+  },
+  CANCELLED: {
+    variant: "outline",
+    className: "text-muted-foreground",
+  },
+  FAILED: {
+    variant: "destructive",
+    className: "",
+  },
+};
+
+const STATUS_ICONS: Record<string, React.ReactNode> = {
+  PENDING: <Clock className="h-3 w-3" aria-hidden="true" />,
+  APPROVED: <CheckCircle2 className="h-3 w-3" aria-hidden="true" />,
+  EXECUTED: <CheckCircle2 className="h-3 w-3" aria-hidden="true" />,
+  CANCELLED: <XCircle className="h-3 w-3" aria-hidden="true" />,
+  FAILED: <XCircle className="h-3 w-3" aria-hidden="true" />,
+};
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+interface ProposalCardProps {
+  proposal: Proposal;
+  /** Whether the current user is authenticated */
+  isAuthenticated: boolean;
+  /** Address/id of the current user for detecting already-voted state */
+  currentUserAddress?: string;
+  onVote: (proposal: Proposal, choice: VoteChoice) => Promise<void>;
+}
+
+export function ProposalCard({
+  proposal,
+  isAuthenticated,
+  currentUserAddress,
+  onVote,
+}: ProposalCardProps) {
+  const [voteModalOpen, setVoteModalOpen] = useState(false);
+
+  const hasVoted =
+    !!currentUserAddress &&
+    Array.isArray(proposal.approvers) &&
+    proposal.approvers.includes(currentUserAddress);
+
+  const votable = isVotable(proposal);
+  const canVote = isAuthenticated && votable && !hasVoted;
+
+  const badgeCfg = STATUS_BADGE[proposal.status] ?? STATUS_BADGE.PENDING;
+  const statusLabel = PROPOSAL_STATUS_LABELS[proposal.status] ?? proposal.status;
+  const statusIcon = STATUS_ICONS[proposal.status];
+
+  const breakdown = proposal.vote_breakdown ?? {
+    yes: proposal.approval_count ?? 0,
+    no: 0,
+    abstain: 0,
+  };
+
+  const createdAgo = formatDistanceToNow(new Date(proposal.created_at), {
+    addSuffix: true,
+  });
+
+  // Title: prefer description, fallback to function name
+  const title = proposal.description
+    ? proposal.description.split("\n")[0].slice(0, 100)
+    : proposal.function;
+
+  return (
+    <>
+      <Card className="flex flex-col hover:shadow-md transition-shadow">
+        <CardHeader className="pb-3">
+          {/* Status + age */}
+          <div className="flex items-start justify-between gap-2">
+            <Badge
+              variant="outline"
+              className={cn(
+                "inline-flex items-center gap-1 text-xs shrink-0",
+                badgeCfg.className
+              )}
+            >
+              {statusIcon}
+              {statusLabel}
+            </Badge>
+            <span className="text-xs text-muted-foreground whitespace-nowrap">
+              {createdAgo}
+            </span>
+          </div>
+
+          <CardTitle className="text-base leading-snug mt-2 line-clamp-2">
+            {title}
+          </CardTitle>
+
+          <CardDescription className="font-mono text-xs truncate">
+            {proposal.function}()
+          </CardDescription>
+        </CardHeader>
+
+        <CardContent className="flex-1 space-y-4 pt-0">
+          {/* Contract */}
+          <div className="text-xs text-muted-foreground truncate">
+            <span className="font-medium text-foreground">Target: </span>
+            <span className="font-mono">{proposal.target_contract}</span>
+          </div>
+
+          {/* Vote breakdown */}
+          <VoteBreakdownChart
+            yes={breakdown.yes}
+            no={breakdown.no}
+            abstain={breakdown.abstain}
+          />
+
+          {/* Already voted indicator */}
+          {hasVoted && (
+            <p className="flex items-center gap-1.5 text-xs text-green-600 dark:text-green-400">
+              <CheckCircle2 className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+              You have already voted on this proposal
+            </p>
+          )}
+
+          {/* Deadline */}
+          {proposal.execute_after && (
+            <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              <Clock className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+              Earliest execution:{" "}
+              {new Date(proposal.execute_after).toLocaleDateString()}
+            </p>
+          )}
+        </CardContent>
+
+        <CardFooter className="gap-2 pt-4">
+          {/* Vote button */}
+          {canVote && (
+            <Button
+              size="sm"
+              className="flex-1 gap-1.5"
+              onClick={() => setVoteModalOpen(true)}
+            >
+              <Vote className="h-4 w-4" aria-hidden="true" />
+              Vote
+            </Button>
+          )}
+
+          {/* Not logged in prompt */}
+          {!isAuthenticated && votable && (
+            <Link href="/login" className="flex-1">
+              <Button variant="outline" size="sm" className="w-full gap-1.5">
+                Log in to vote
+              </Button>
+            </Link>
+          )}
+
+          {/* View details */}
+          <Link href={`/governance/${proposal.id}`} className={canVote || (!isAuthenticated && votable) ? "" : "flex-1"}>
+            <Button
+              variant="ghost"
+              size="sm"
+              className={cn("gap-1 w-full", !canVote && (!isAuthenticated || !votable) && "flex-1")}
+              aria-label={`View details for proposal: ${title}`}
+            >
+              Details
+              <ChevronRight className="h-4 w-4" aria-hidden="true" />
+            </Button>
+          </Link>
+        </CardFooter>
+      </Card>
+
+      {/* Vote modal */}
+      <VoteModal
+        isOpen={voteModalOpen}
+        onClose={() => setVoteModalOpen(false)}
+        proposalTitle={title}
+        onConfirm={async (choice) => {
+          await onVote(proposal, choice);
+        }}
+      />
+    </>
+  );
+}

--- a/frontend/src/components/governance/VoteBreakdownChart.tsx
+++ b/frontend/src/components/governance/VoteBreakdownChart.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import React from "react";
+import { cn } from "@/lib/utils";
+
+interface VoteBreakdownChartProps {
+  yes: number;
+  no: number;
+  abstain: number;
+  className?: string;
+}
+
+/**
+ * Horizontal stacked bar showing yes / no / abstain proportions.
+ * Pure CSS — no recharts dependency for this small widget.
+ */
+export function VoteBreakdownChart({
+  yes,
+  no,
+  abstain,
+  className,
+}: VoteBreakdownChartProps) {
+  const total = yes + no + abstain;
+
+  const yesPct = total === 0 ? 0 : Math.round((yes / total) * 100);
+  const noPct = total === 0 ? 0 : Math.round((no / total) * 100);
+  const abstainPct = total === 0 ? 100 : Math.max(0, 100 - yesPct - noPct);
+
+  const segments = [
+    {
+      label: "Yes",
+      count: yes,
+      pct: yesPct,
+      bg: "bg-green-500",
+      text: "text-green-600 dark:text-green-400",
+    },
+    {
+      label: "No",
+      count: no,
+      pct: noPct,
+      bg: "bg-red-500",
+      text: "text-red-600 dark:text-red-400",
+    },
+    {
+      label: "Abstain",
+      count: abstain,
+      pct: abstainPct,
+      bg: "bg-gray-400 dark:bg-gray-600",
+      text: "text-muted-foreground",
+    },
+  ];
+
+  return (
+    <div className={cn("space-y-3", className)}>
+      {/* Stacked bar */}
+      <div
+        className="flex h-4 w-full overflow-hidden rounded-full bg-muted"
+        role="img"
+        aria-label={`Vote breakdown: ${yes} yes, ${no} no, ${abstain} abstain`}
+      >
+        {total === 0 ? (
+          <div className="h-full w-full bg-muted" />
+        ) : (
+          segments.map((s) =>
+            s.pct > 0 ? (
+              <div
+                key={s.label}
+                className={cn("h-full transition-all duration-500", s.bg)}
+                style={{ width: `${s.pct}%` }}
+              />
+            ) : null
+          )
+        )}
+      </div>
+
+      {/* Legend */}
+      <div className="flex flex-wrap gap-x-6 gap-y-1 text-sm">
+        {segments.map((s) => (
+          <div key={s.label} className="flex items-center gap-1.5">
+            <span className={cn("h-2.5 w-2.5 rounded-full shrink-0", s.bg)} aria-hidden="true" />
+            <span className="text-muted-foreground">{s.label}</span>
+            <span className={cn("font-semibold tabular-nums", s.text)}>
+              {s.count}
+            </span>
+            {total > 0 && (
+              <span className="text-muted-foreground/70 text-xs">
+                ({s.pct}%)
+              </span>
+            )}
+          </div>
+        ))}
+        <div className="ml-auto text-muted-foreground text-xs self-center">
+          {total} total vote{total !== 1 ? "s" : ""}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/governance/VoteModal.tsx
+++ b/frontend/src/components/governance/VoteModal.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import React, { useState } from "react";
+import { ThumbsUp, ThumbsDown, Minus, AlertCircle } from "lucide-react";
+import { Modal } from "@/components/ui/Modal";
+import { Button } from "@/components/ui/Button";
+import { cn } from "@/lib/utils";
+import type { VoteChoice } from "@/types/governance";
+
+interface VoteModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  proposalTitle: string;
+  onConfirm: (choice: VoteChoice) => Promise<void>;
+}
+
+const VOTE_OPTIONS: {
+  choice: VoteChoice;
+  label: string;
+  icon: React.ReactNode;
+  activeClass: string;
+  hoverClass: string;
+}[] = [
+  {
+    choice: "yes",
+    label: "Yes — I support this proposal",
+    icon: <ThumbsUp className="h-5 w-5" aria-hidden="true" />,
+    activeClass:
+      "border-green-500 bg-green-500/10 text-green-700 dark:text-green-400",
+    hoverClass: "hover:border-green-400 hover:bg-green-500/5",
+  },
+  {
+    choice: "no",
+    label: "No — I oppose this proposal",
+    icon: <ThumbsDown className="h-5 w-5" aria-hidden="true" />,
+    activeClass:
+      "border-red-500 bg-red-500/10 text-red-700 dark:text-red-400",
+    hoverClass: "hover:border-red-400 hover:bg-red-500/5",
+  },
+  {
+    choice: "abstain",
+    label: "Abstain — I decline to vote",
+    icon: <Minus className="h-5 w-5" aria-hidden="true" />,
+    activeClass:
+      "border-gray-500 bg-gray-500/10 text-gray-700 dark:text-gray-300",
+    hoverClass: "hover:border-gray-400 hover:bg-gray-500/5",
+  },
+];
+
+export function VoteModal({
+  isOpen,
+  onClose,
+  proposalTitle,
+  onConfirm,
+}: VoteModalProps) {
+  const [selected, setSelected] = useState<VoteChoice | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleClose = () => {
+    if (submitting) return;
+    setSelected(null);
+    setError(null);
+    onClose();
+  };
+
+  const handleSubmit = async () => {
+    if (!selected) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await onConfirm(selected);
+      setSelected(null);
+      onClose();
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to submit vote. Please try again."
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={handleClose}
+      title="Cast Your Vote"
+      size="sm"
+      closeOnOverlayClick={!submitting}
+    >
+      <div className="space-y-4">
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          You are voting on:{" "}
+          <span className="font-medium text-foreground">{proposalTitle}</span>
+        </p>
+
+        {/* Vote options */}
+        <div className="space-y-2" role="radiogroup" aria-label="Vote choice">
+          {VOTE_OPTIONS.map((opt) => (
+            <button
+              key={opt.choice}
+              role="radio"
+              aria-checked={selected === opt.choice}
+              onClick={() => setSelected(opt.choice)}
+              disabled={submitting}
+              className={cn(
+                "w-full flex items-center gap-3 rounded-lg border-2 px-4 py-3 text-left text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
+                "border-border text-foreground",
+                opt.hoverClass,
+                selected === opt.choice && opt.activeClass
+              )}
+            >
+              {opt.icon}
+              {opt.label}
+            </button>
+          ))}
+        </div>
+
+        {/* Inline error */}
+        {error && (
+          <div
+            className="flex items-start gap-2 rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive"
+            role="alert"
+          >
+            <AlertCircle className="h-4 w-4 mt-0.5 shrink-0" aria-hidden="true" />
+            {error}
+          </div>
+        )}
+
+        {/* Actions */}
+        <div className="flex gap-3 pt-1">
+          <Button
+            variant="outline"
+            className="flex-1"
+            onClick={handleClose}
+            disabled={submitting}
+          >
+            Cancel
+          </Button>
+          <Button
+            className="flex-1"
+            onClick={handleSubmit}
+            disabled={!selected || submitting}
+            loading={submitting}
+          >
+            Submit Vote
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/components/ui/BottomNav.tsx
+++ b/frontend/src/components/ui/BottomNav.tsx
@@ -118,8 +118,8 @@ export function BottomNav({ className }: BottomNavProps) {
                   key={item.href}
                   href={item.href}
                   className={cn(
-                    "flex flex-col items-center justify-center",
-                    "flex-1 h-full py-2",
+                    "relative flex flex-col items-center justify-center",
+                    "flex-1 h-full py-2 gap-0.5",
                     "transition-colors duration-200",
                     isActive
                       ? "text-primary"
@@ -127,16 +127,38 @@ export function BottomNav({ className }: BottomNavProps) {
                   )}
                   aria-current={isActive ? "page" : undefined}
                 >
-                  <div className="relative">
+                  {/* Shared sliding top-border indicator */}
+                  {isActive && (
+                    <motion.div
+                      className="absolute top-0 left-1/2 -translate-x-1/2 h-0.5 w-8 rounded-full bg-primary"
+                      layoutId={prefersReducedMotion ? undefined : "activeBar"}
+                      transition={
+                        prefersReducedMotion
+                          ? { duration: 0 }
+                          : { type: "spring", damping: 30, stiffness: 400 }
+                      }
+                    />
+                  )}
+
+                  {/* Active background pill */}
+                  {isActive && (
+                    <motion.div
+                      className="absolute inset-x-2 inset-y-1 rounded-xl bg-primary/10"
+                      layoutId={prefersReducedMotion ? undefined : "activeBg"}
+                      transition={
+                        prefersReducedMotion
+                          ? { duration: 0 }
+                          : { type: "spring", damping: 30, stiffness: 400 }
+                      }
+                    />
+                  )}
+
+                  <div className="relative z-10">
                     {item.icon(isActive)}
-                    {isActive && !prefersReducedMotion && (
-                      <motion.div
-                        className="absolute -bottom-1 left-1/2 -translate-x-1/2 w-1 h-1 rounded-full bg-primary"
-                        layoutId="activeIndicator"
-                      />
-                    )}
                   </div>
-                  <span className="text-xs mt-1 font-medium">{item.label}</span>
+                  <span className="relative z-10 text-xs font-medium">
+                    {item.label}
+                  </span>
                 </Link>
               );
             })}

--- a/frontend/src/components/ui/Tooltip.tsx
+++ b/frontend/src/components/ui/Tooltip.tsx
@@ -4,6 +4,7 @@ import React, {
   createContext,
   useContext,
   useEffect,
+  useId,
   useRef,
   useState,
 } from 'react';
@@ -17,6 +18,8 @@ interface TooltipContextValue {
   setOpen: (v: boolean) => void;
   placement: Placement;
   triggerRef: React.RefObject<HTMLElement>;
+  /** Stable id shared between trigger (aria-describedby) and content (id). */
+  contentId: string;
 }
 
 const TooltipContext = createContext<TooltipContextValue | null>(null);
@@ -38,20 +41,36 @@ export function Tooltip({ children, placement = 'top', delayMs = 200 }: TooltipP
   const [open, setOpenRaw] = useState(false);
   const triggerRef = useRef<HTMLElement>(null!);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // useId produces a stable, unique id per component instance (React 18+).
+  const contentId = useId();
 
   const setOpen = (v: boolean) => {
     if (timerRef.current) clearTimeout(timerRef.current);
     if (v) {
       timerRef.current = setTimeout(() => setOpenRaw(true), delayMs);
     } else {
+      // Cancel a pending open before closing immediately.
       setOpenRaw(false);
     }
   };
 
+  // Close on Escape regardless of which element holds focus (WCAG 1.4.13).
+  useEffect(() => {
+    if (!open) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        setOpenRaw(false);
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [open]);
+
   useEffect(() => () => { if (timerRef.current) clearTimeout(timerRef.current); }, []);
 
   return (
-    <TooltipContext.Provider value={{ open, setOpen, placement, triggerRef }}>
+    <TooltipContext.Provider value={{ open, setOpen, placement, triggerRef, contentId }}>
       <span className="relative inline-flex">{children}</span>
     </TooltipContext.Provider>
   );
@@ -62,7 +81,7 @@ export interface TooltipTriggerProps extends React.HTMLAttributes<HTMLSpanElemen
 }
 
 export function TooltipTrigger({ children, ...props }: TooltipTriggerProps) {
-  const { setOpen, triggerRef } = useTooltipContext();
+  const { setOpen, triggerRef, open, contentId } = useTooltipContext();
   return (
     <span
       ref={triggerRef as React.RefObject<HTMLSpanElement>}
@@ -70,7 +89,8 @@ export function TooltipTrigger({ children, ...props }: TooltipTriggerProps) {
       onMouseLeave={() => setOpen(false)}
       onFocus={() => setOpen(true)}
       onBlur={() => setOpen(false)}
-      aria-describedby={undefined}
+      // Link the trigger to the tooltip content for screen readers.
+      aria-describedby={open ? contentId : undefined}
       {...props}
     >
       {children}
@@ -98,14 +118,13 @@ export interface TooltipContentProps {
 }
 
 export function TooltipContent({ children, className }: TooltipContentProps) {
-  const { open, placement } = useTooltipContext();
-  const id = useRef(`tt-${Math.random().toString(36).slice(2)}`);
+  const { open, placement, contentId } = useTooltipContext();
 
   return (
     <AnimatePresence>
       {open && (
         <motion.div
-          id={id.current}
+          id={contentId}
           role="tooltip"
           initial={PLACEMENT_INITIAL[placement]}
           animate={{ opacity: 1, x: 0, y: 0 }}

--- a/frontend/src/hooks/useGovernance.ts
+++ b/frontend/src/hooks/useGovernance.ts
@@ -1,0 +1,96 @@
+/**
+ * React-Query hooks for governance proposals.
+ * Mirrors the pattern used by useLeaderboard.ts.
+ */
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import type { Proposal, VoteChoice } from "@/types/governance";
+
+// ---------------------------------------------------------------------------
+// Query keys
+// ---------------------------------------------------------------------------
+export const GOVERNANCE_KEYS = {
+  all: ["governance"] as const,
+  proposals: () => [...GOVERNANCE_KEYS.all, "proposals"] as const,
+  proposal: (id: string) => [...GOVERNANCE_KEYS.all, "proposal", id] as const,
+} as const;
+
+// ---------------------------------------------------------------------------
+// Queries
+// ---------------------------------------------------------------------------
+
+/** Fetch all proposals from GET /governance */
+export function useProposals() {
+  return useQuery<Proposal[]>({
+    queryKey: GOVERNANCE_KEYS.proposals(),
+    queryFn: () => api.getProposals() as Promise<Proposal[]>,
+    staleTime: 30_000,
+  });
+}
+
+/** Fetch a single proposal from GET /governance/:id */
+export function useProposal(id: string) {
+  return useQuery<Proposal>({
+    queryKey: GOVERNANCE_KEYS.proposal(id),
+    queryFn: () => api.getProposal(id) as Promise<Proposal>,
+    enabled: !!id,
+    staleTime: 15_000,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Mutations
+// ---------------------------------------------------------------------------
+
+/**
+ * Cast a vote on a proposal.
+ *
+ * The existing API endpoint POST /governance/:id/vote accepts an optional
+ * `signature`. We map the UX choice (yes / no / abstain) to that payload.
+ * When the backend extends the endpoint to accept a `vote` field this hook
+ * only needs updating here.
+ */
+export function useVoteOnProposal() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      id,
+      choice,
+      signature,
+    }: {
+      id: string;
+      choice: VoteChoice;
+      signature?: string;
+    }) =>
+      api.voteOnProposal(id, signature) as Promise<unknown>,
+    onSuccess: (_data, { id }) => {
+      // Invalidate both the list and the individual proposal so counts refresh.
+      qc.invalidateQueries({ queryKey: GOVERNANCE_KEYS.proposals() });
+      qc.invalidateQueries({ queryKey: GOVERNANCE_KEYS.proposal(id) });
+    },
+  });
+}
+
+/** Trigger execution of an APPROVED proposal */
+export function useExecuteProposal() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => api.executeProposal(id) as Promise<unknown>,
+    onSuccess: (_data, id) => {
+      qc.invalidateQueries({ queryKey: GOVERNANCE_KEYS.proposals() });
+      qc.invalidateQueries({ queryKey: GOVERNANCE_KEYS.proposal(id) });
+    },
+  });
+}
+
+/** Start the voting period on a PENDING proposal */
+export function useStartVoting() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => api.startVoting(id) as Promise<unknown>,
+    onSuccess: (_data, id) => {
+      qc.invalidateQueries({ queryKey: GOVERNANCE_KEYS.proposals() });
+      qc.invalidateQueries({ queryKey: GOVERNANCE_KEYS.proposal(id) });
+    },
+  });
+}

--- a/frontend/src/lib/routes.ts
+++ b/frontend/src/lib/routes.ts
@@ -8,6 +8,7 @@ export const mainNav: NavItem[] = [
   { label: "Tournaments", href: "/tournaments" },
   { label: "Wallet", href: "/wallet" },
   { label: "Leaderboard", href: "/leaderboard" },
+  { label: "Governance", href: "/governance" },
 ];
 
 export const authNav = {

--- a/frontend/src/types/governance.ts
+++ b/frontend/src/types/governance.ts
@@ -1,0 +1,83 @@
+/**
+ * Governance types — derived from the governance_proposals and
+ * governance_approvals DB schema (migration 20250130000001).
+ */
+
+export type ProposalStatus =
+  | "PENDING"
+  | "APPROVED"
+  | "EXECUTED"
+  | "CANCELLED"
+  | "FAILED";
+
+export type VoteChoice = "yes" | "no" | "abstain";
+
+export interface Proposal {
+  /** Internal UUID */
+  id: string;
+  /** On-chain hex proposal ID (e.g. "0x1234…") */
+  proposal_id: string;
+  /** Stellar contract address */
+  target_contract: string;
+  /** Function name to invoke on the target contract */
+  function: string;
+  /** Decoded function arguments */
+  args: Record<string, unknown>;
+  /** Human-readable description */
+  description?: string;
+  status: ProposalStatus;
+  /** Stellar address of the proposer */
+  proposer: string;
+  created_at: string;
+  /** ISO datetime — earliest time the proposal can be executed */
+  execute_after?: string;
+  executed_at?: string;
+  /** Last on-chain transaction hash */
+  last_chain_tx?: string;
+  /** Approval / vote count (from view v_governance_proposals_with_approvals) */
+  approval_count?: number;
+  /** Ordered list of approver Stellar addresses */
+  approvers?: string[];
+
+  // Extended vote breakdown — may be present on detail endpoint
+  vote_breakdown?: {
+    yes: number;
+    no: number;
+    abstain: number;
+  };
+}
+
+export interface CreateProposalDto {
+  target_contract: string;
+  function: string;
+  args: Record<string, unknown>;
+  description?: string;
+  /** Unix timestamp for the earliest execution time */
+  execute_after?: number;
+}
+
+export type ProposalTab = "active" | "passed" | "failed";
+
+export const PROPOSAL_STATUS_LABELS: Record<ProposalStatus, string> = {
+  PENDING: "Active",
+  APPROVED: "Passed",
+  EXECUTED: "Executed",
+  CANCELLED: "Cancelled",
+  FAILED: "Failed",
+};
+
+/** Maps a DB status to the tab it belongs to */
+export function statusToTab(status: ProposalStatus): ProposalTab {
+  if (status === "PENDING" || status === "APPROVED") return "active";
+  if (status === "EXECUTED") return "passed";
+  return "failed";
+}
+
+/** Whether voting should be enabled for a proposal */
+export function isVotable(proposal: Proposal): boolean {
+  if (proposal.status !== "PENDING") return false;
+  if (proposal.execute_after) {
+    return new Date(proposal.execute_after) > new Date();
+  }
+  return true;
+}


### PR DESCRIPTION
# PR: Governance page — Fix #547

## Summary

Fixes #547. The `ApiClient` exposed full governance endpoints but there was no
frontend surface for regular users. This PR adds a complete `/governance`
feature: a list page with tab-filtered proposals, a detail page with vote
breakdown and metadata, and all supporting types, hooks, and components.

## Files added / changed

| File | Type | Purpose |
|---|---|---|
| `frontend/src/types/governance.ts` | New | `Proposal`, `ProposalStatus`, `VoteChoice`, `ProposalTab`, helpers `statusToTab`, `isVotable`, `PROPOSAL_STATUS_LABELS` — derived from the `governance_proposals` DB schema |
| `frontend/src/hooks/useGovernance.ts` | New | `useProposals`, `useProposal`, `useVoteOnProposal`, `useExecuteProposal`, `useStartVoting` — react-query wrappers over `api.getProposals()` / `api.voteOnProposal()` etc. |
| `frontend/src/components/governance/VoteBreakdownChart.tsx` | New | Horizontal stacked bar (yes / no / abstain) with legend and percentages — pure CSS, no extra dependency |
| `frontend/src/components/governance/VoteModal.tsx` | New | Accessible vote confirmation modal (yes / no / abstain radio group), uses existing `Modal` component, shows inline error on failure |
| `frontend/src/components/governance/ProposalCard.tsx` | New | Card per proposal: status badge, vote breakdown, deadline, already-voted indicator, "Vote" button (disabled when not applicable), "Details" link |
| `frontend/src/app/[locale]/governance/page.tsx` | New | List page — Active / Passed / Failed tabs with counts, grid of `ProposalCard`s, guest notice, error + empty states |
| `frontend/src/app/[locale]/governance/[id]/page.tsx` | New | Detail page — full description, `VoteBreakdownChart`, approver list, function args (JSON), metadata sidebar, chain tx link, GitHub Discussions link |
| `frontend/src/app/[locale]/governance/loading.tsx` | New | Streaming skeleton for the list page |
| `frontend/src/app/[locale]/governance/error.tsx` | New | Next.js error boundary for the governance route segment |
| `frontend/src/lib/routes.ts` | Modified | Added `{ label: "Governance", href: "/governance" }` to `mainNav` |

## Acceptance criteria

| Criterion | Status |
|---|---|
| `/governance` lists active, passed, and failed proposals with vote counts and status badges | ✅ Tab panel groups proposals by status; `VoteBreakdownChart` shows counts on every card |
| Authenticated users can cast a vote (yes / no / abstain) on active proposals | ✅ "Vote" button opens `VoteModal`; `useVoteOnProposal` mutation posts to `POST /governance/:id/vote` |
| Voting disabled after deadline or if user already voted (showing their vote) | ✅ `isVotable()` checks `status === PENDING` and `execute_after`; `hasVoted` flag detected via `approvers` array; "already voted" indicator shown |
| Proposal detail page shows full description, vote breakdown chart, and discussion link | ✅ `/governance/[id]` renders all fields + `VoteBreakdownChart` + GitHub Discussions link |

## Architecture notes

- **Data fetching pattern** mirrors `useLeaderboard.ts` — react-query `useQuery` / `useMutation` wrappers with `staleTime` and targeted `invalidateQueries` on mutation success.
- **Query key registry** follows existing convention: `['governance', 'proposals']` for list, `['governance', 'proposal', id]` for single item.
- **`VoteChoice`** (`yes | no | abstain`) is a UX concept — the current API endpoint `POST /governance/:id/vote` accepts an optional `signature`. The hook maps the choice to the payload; when the backend extends the endpoint to accept a `vote` field only `useGovernance.ts` needs updating.
- **No new npm dependencies** — `date-fns` (already installed), existing `Modal`, `Card`, `Button`, `Badge`, `EmptyState`, `PageError`, `PageSkeleton` components.
- **Accessibility** — tabs use `role="tablist"` / `role="tab"` / `aria-selected` / `aria-controls`; VoteModal uses `role="radiogroup"` / `role="radio"` / `aria-checked`; error banners use `role="alert"`; guest notice uses `role="note"`.

## Testing

1. Navigate to `/governance` — should show the list page with Active/Passed/Failed tabs.
2. As a guest, confirm the "Log in to vote" notice is visible and vote buttons are replaced with login links.
3. Log in and navigate back — "Vote" buttons should appear on active proposals.
4. Click "Vote" → select yes/no/abstain → submit. Confirm the vote count updates (react-query invalidates both list and detail queries).
5. Vote again on the same proposal — button should be replaced with the "already voted" indicator.
6. Click "Details" on any proposal card — confirm the detail page renders description, breakdown chart, metadata sidebar, and discussion link.
7. On the detail page, verify the chain tx link opens Stellar Expert in a new tab when `last_chain_tx` is present.
