### PR TITLE
feat(error-handling): comprehensive error boundaries, logging, and re…

### DIFF
--- a/frontend/ERROR_HANDLING.md
+++ b/frontend/ERROR_HANDLING.md
@@ -1,0 +1,411 @@
+# ArenaX Frontend — Error Handling Architecture
+
+This document describes the complete error handling system for the ArenaX frontend.
+
+---
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Error Types](#error-types)
+3. [Error Logger](#error-logger)
+4. [Error Boundaries](#error-boundaries)
+5. [Error Recovery Hook](#error-recovery-hook)
+6. [Error Provider & Context](#error-provider--context)
+7. [Query Layer Integration](#query-layer-integration)
+8. [Error Monitor Dashboard](#error-monitor-dashboard)
+9. [Analytics & Monitoring](#analytics--monitoring)
+10. [Testing](#testing)
+11. [Decision Log](#decision-log)
+
+---
+
+## Overview
+
+The error handling system is built around three principles:
+
+| Principle | Implementation |
+|-----------|---------------|
+| **Structured errors** | All application errors extend `ArenaXError` with `category` and `severity` |
+| **Single source of truth** | `errorLogger` singleton captures every error — boundaries, hooks, query cache |
+| **Progressive disclosure** | Full-page → page-section → inline, depending on how critical the failure is |
+
+```
+                    ┌────────────────────────────────────┐
+                    │          ErrorBoundary             │  ← full-page, wraps locale layout
+                    │   (src/components/ui)              │
+                    └──────────────┬─────────────────────┘
+                                   │
+                    ┌──────────────▼─────────────────────┐
+                    │       PageErrorBoundary            │  ← per-page, lightweight
+                    │   (src/components/common)          │
+                    └──────────────┬─────────────────────┘
+                                   │
+                    ┌──────────────▼─────────────────────┐
+                    │     SectionErrorBoundary           │  ← per-widget, inline fallback
+                    │   (src/components/common)          │
+                    └──────────────┬─────────────────────┘
+                                   │
+                    ┌──────────────▼─────────────────────┐
+                    │       useErrorRecovery             │  ← async retry / back-off
+                    │   (src/hooks)                      │
+                    └──────────────┬─────────────────────┘
+                                   │
+                    ┌──────────────▼─────────────────────┐
+                    │          errorLogger               │  ← structured logging + analytics
+                    │   (src/lib/errorLogger.ts)         │
+                    └────────────────────────────────────┘
+```
+
+---
+
+## Error Types
+
+**File:** `src/lib/errors.ts`
+
+### Base class
+
+```ts
+new ArenaXError(message, category?, severity?, metadata?)
+```
+
+All application errors extend `ArenaXError`, which attaches:
+- `category: ErrorCategory` — what part of the system failed
+- `severity: ErrorSeverity` — how serious the failure is
+- `metadata?: Record<string, unknown>` — arbitrary structured context
+
+### Specialised subclasses
+
+| Class | Category | Default Severity | Use when |
+|-------|----------|-----------------|----------|
+| `NetworkError` | `NETWORK` | `HIGH` | fetch/XHR failure, offline |
+| `AuthenticationError` | `AUTHENTICATION` | `HIGH` | 401 / expired token |
+| `ValidationError` | `VALIDATION` | `LOW` | form input is invalid |
+| `ApiError` | `API` | `HIGH` (5xx) / `MEDIUM` (4xx) | API endpoint returned an error status |
+
+### Enums
+
+```ts
+enum ErrorCategory { NETWORK, AUTHENTICATION, VALIDATION, RUNTIME, API, UNKNOWN }
+enum ErrorSeverity { LOW, MEDIUM, HIGH, CRITICAL }
+```
+
+### Recovery strategies
+
+```ts
+getRecoveryStrategy(category: ErrorCategory): RecoveryStrategy | null
+```
+
+Returns `null` for non-retryable categories (`AUTHENTICATION`, `VALIDATION`, `UNKNOWN`).
+Returns a `RecoveryStrategy` for retryable categories:
+
+| Category | maxAttempts | baseDelayMs | Exponential | maxDelayMs |
+|----------|-------------|-------------|-------------|-----------|
+| NETWORK | 3 | 1 000 | ✓ | 15 000 |
+| API | 2 | 2 000 | ✓ | 10 000 |
+| RUNTIME | 1 | 500 | ✗ | 500 |
+
+---
+
+## Error Logger
+
+**File:** `src/lib/errorLogger.ts`
+
+A singleton `errorLogger` instance is created at module load time.  It:
+
+1. Captures `window.error` and `unhandledrejection` globally
+2. Persists up to 100 recent errors in `localStorage` (`arenax_errors`)
+3. Emits structured console output scaled to severity (error / warn / info)
+4. Fires `gtag("event", "exception", …)` if Google Analytics is present
+5. Calls `DD_RUM.addError(…)` if Datadog RUM is initialised
+
+### API
+
+```ts
+// Convenience functions
+logError(error: Error, metadata?)    // log + return LoggedError
+getLoggedErrors()                    // return all stored errors
+clearLoggedErrors()                  // wipe storage
+getErrorSummary()                    // return ErrorSummary counts
+
+// Singleton methods
+errorLogger.recordRecoveryAttempt(id, succeeded)
+errorLogger.getErrorsByCategory(category)
+errorLogger.getErrorsBySeverity(severity)
+errorLogger.getRecentErrors(windowMs?)     // default 60 s
+errorLogger.getSummary()                   // ErrorSummary
+```
+
+### LoggedError shape
+
+```ts
+interface LoggedError {
+  id: string;           // e.g. "1720000000000-x7k3m"
+  timestamp: number;    // unix ms
+  message: string;
+  stack?: string;
+  category: ErrorCategory;
+  severity: ErrorSeverity;
+  metadata?: Record<string, unknown>;
+  recoveryAttempts?: number;
+  recovered?: boolean;
+}
+```
+
+---
+
+## Error Boundaries
+
+### `ErrorBoundary` — full-page
+
+**File:** `src/components/ui/ErrorBoundary.tsx`
+
+Wraps the entire locale layout.  Catches any render error that escapes inner boundaries.  Shows a full-screen fallback with context-aware actions (Retry, Go Home, Report, Sign In for auth errors).
+
+```tsx
+<ErrorBoundary fallback={<CustomFallback />} onError={handler}>
+  {children}
+</ErrorBoundary>
+```
+
+### `PageErrorBoundary` — per-page
+
+**File:** `src/components/common/PageErrorBoundary.tsx`
+
+Lightweight boundary for individual pages.  Uses the shared `PageError` component.
+
+```tsx
+<PageErrorBoundary title="Tournament Page Error">
+  <TournamentDetail />
+</PageErrorBoundary>
+```
+
+### `SectionErrorBoundary` — inline widget
+
+**File:** `src/components/common/SectionErrorBoundary.tsx`
+
+Use this around individual panels, cards, or data-fetching widgets so one widget failure never breaks the whole page.  Shows a compact inline fallback with up to 3 retries.
+
+```tsx
+<SectionErrorBoundary label="Match Feed">
+  <MatchFeedWidget />
+</SectionErrorBoundary>
+```
+
+Props:
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `label` | `string?` | Section name shown in the fallback, e.g. `"Match Feed"` |
+| `fallback` | `ReactNode?` | Custom fallback overrides the default UI |
+| `className` | `string?` | Extra Tailwind classes on the wrapper |
+| `onError` | `(error, info) => void` | Optional error callback |
+
+### `ErrorBoundaryWithRetry` — configurable retries
+
+**File:** `src/components/common/ErrorBoundaryWithRetry.tsx`
+
+A design-system–compliant boundary with a configurable `maxRetries` prop.  After all retries are exhausted it shows either a custom `fallback` or a "contact support" message.
+
+```tsx
+<ErrorBoundaryWithRetry maxRetries={2}>
+  <HeavyWidget />
+</ErrorBoundaryWithRetry>
+```
+
+### `MobileErrorBoundary` — mobile-specific
+
+**File:** `src/components/ui/MobileErrorBoundary.tsx`
+
+Identical to `ErrorBoundary` but tuned for mobile: maps error categories to mobile-friendly messages (network, timeout, offline, auth) using the shared `determineErrorCategory` utility.
+
+---
+
+## Error Recovery Hook
+
+**File:** `src/hooks/useErrorRecovery.ts`
+
+```tsx
+const { execute, status, attempts, error, loggedError, reset, isRetryable } =
+  useErrorRecovery<TResult>(options?);
+```
+
+Wraps any `() => Promise<T>` with automatic retry and exponential back-off.
+
+### Options
+
+```ts
+interface UseErrorRecoveryOptions {
+  strategy?: Partial<RecoveryStrategy>;  // override defaults per-call
+  onExhausted?: (error: Error, attempts: number) => void;
+  onRecovered?: (attempts: number) => void;
+}
+```
+
+### Status transitions
+
+```
+idle → (execute called)
+  → succeeded          (no error or recovered)
+  → retrying           (error caught, attempt < max)
+  → failed             (non-retryable OR attempts exhausted)
+```
+
+### Example
+
+```tsx
+function TournamentList() {
+  const { execute, status, error } = useErrorRecovery<Tournament[]>({
+    onExhausted: (err) => toast.error(`Could not load tournaments: ${err.message}`),
+  });
+
+  const load = useCallback(
+    () => execute(() => api.getTournaments()),
+    [execute],
+  );
+
+  useEffect(() => { load(); }, [load]);
+
+  if (status === "retrying") return <Spinner label="Retrying…" />;
+  if (status === "failed") return <PageError message={error?.message} onRetry={load} />;
+  // …
+}
+```
+
+---
+
+## Error Provider & Context
+
+**File:** `src/components/providers/ErrorProvider.tsx`
+
+Wraps the app and exposes a React context for components that need to imperatively log errors or read the error list.
+
+```tsx
+const { errors, addError, clearErrors, getByCategory, getBySeverity, summary } = useError();
+```
+
+The `summary` field (`ErrorSummary`) is updated after every `addError` / `clearErrors` call and is consumed by `ErrorMonitorDashboard`.
+
+---
+
+## Query Layer Integration
+
+**File:** `src/components/providers/QueryProvider.tsx`
+
+`QueryClient` is configured with `QueryCache` and `MutationCache` global error handlers that call `logError` for every failed query or mutation.  This means all TanStack Query errors are automatically tracked without any per-call boilerplate.
+
+```ts
+// Behind the scenes — no action needed from feature developers
+queryCache: new QueryCache({
+  onError: (error, query) => logError(error, { queryKey: … }),
+}),
+mutationCache: new MutationCache({
+  onError: (error, _, __, mutation) => logError(error, { mutationKey: … }),
+}),
+```
+
+---
+
+## Error Monitor Dashboard
+
+**File:** `src/components/common/ErrorMonitorDashboard.tsx`
+
+A read-only developer/admin component that visualises all logged errors.
+
+Features:
+- Summary cards: total, last-60s, critical+high, recovered
+- Per-category count grid
+- Filterable error list (by category and severity)
+- Expandable rows showing stack trace, metadata, recovery status
+- Clear and Refresh controls
+
+Usage (e.g. in `/analytics` or an admin page):
+
+```tsx
+import { ErrorMonitorDashboard } from "@/components/common/ErrorMonitorDashboard";
+
+export default function AnalyticsPage() {
+  return (
+    <div className="p-6">
+      <ErrorMonitorDashboard />
+    </div>
+  );
+}
+```
+
+> **Note:** Do not render this component for end-users in production.  Guard it behind an admin role check.
+
+---
+
+## Analytics & Monitoring
+
+Every logged error is dispatched to the following sinks automatically by `errorLogger`:
+
+| Sink | Condition | Data sent |
+|------|-----------|-----------|
+| `console.error/warn/info` | Always (dev + prod) | Error object + metadata |
+| Google Analytics (`gtag`) | If `window.gtag` is present | `exception` event with `fatal`, `error_id`, `error_severity` |
+| Datadog RUM (`DD_RUM`) | If `window.DD_RUM` is present | `addError` with `errorId`, `category`, `severity` |
+
+To integrate an additional sink (e.g. Sentry):
+
+```ts
+import { errorLogger } from "@/lib/errorLogger";
+
+errorLogger.setOnError((entry) => {
+  Sentry.captureException(new Error(entry.message), {
+    extra: { errorId: entry.id, category: entry.category },
+  });
+});
+```
+
+---
+
+## Testing
+
+### Test files
+
+| File | What it covers |
+|------|---------------|
+| `src/__tests__/error-handling.test.ts` | `ArenaXError` + subclasses, utility functions, recovery strategies, `errorLogger` |
+| `src/__tests__/error-boundaries.test.tsx` | All four boundary components (render, catch, retry, callbacks) |
+| `src/__tests__/error-recovery.test.tsx` | `useErrorRecovery` hook (success, retry, exhaustion, non-retryable, reset) |
+
+### Running tests
+
+```bash
+# All tests (single run)
+npm test -- --testPathPattern="error"
+
+# Watch mode
+npm run test:watch
+```
+
+### Writing new tests
+
+When testing components that use error boundaries, suppress React's expected `console.error` output:
+
+```ts
+const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+afterEach(() => spy.mockRestore());
+```
+
+Use fake timers when testing `useErrorRecovery` to avoid real delays:
+
+```ts
+beforeEach(() => jest.useFakeTimers());
+afterEach(() => { jest.runAllTimers(); jest.useRealTimers(); });
+```
+
+---
+
+## Decision Log
+
+| Decision | Rationale |
+|----------|-----------|
+| Single `errorLogger` singleton | Avoids React context overhead for pure logging; boundaries and hooks can both call it without a provider |
+| Exponential back-off in `useErrorRecovery` | Prevents thundering-herd against a flaky API |
+| `SectionErrorBoundary` separate from `ErrorBoundaryWithRetry` | Different concerns: section boundary is for UI isolation; retry boundary is for transient failures |
+| `determineErrorCategory` shared across all boundaries | Single place to update keyword heuristics; previously each boundary duplicated this logic |
+| `QueryCache`/`MutationCache` global handlers | Zero-boilerplate — every TanStack Query error is logged without modifying individual `useQuery` calls |
+| No automatic retry for `AUTHENTICATION` / `VALIDATION` | Auth errors need user action (sign in); validation errors are deterministic and would just fail again |

--- a/frontend/src/__tests__/error-boundaries.test.tsx
+++ b/frontend/src/__tests__/error-boundaries.test.tsx
@@ -1,0 +1,315 @@
+/**
+ * Error Boundary component tests
+ *
+ * Covers:
+ *  - ErrorBoundary (full-page)
+ *  - SectionErrorBoundary (inline)
+ *  - ErrorBoundaryWithRetry (configurable max-retries)
+ *  - PageErrorBoundary
+ *
+ * We intentionally suppress React's console.error output for expected render
+ * errors to keep the test output clean.
+ */
+
+import React, { ReactNode } from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { ErrorBoundary } from "@/components/ui/ErrorBoundary";
+import { SectionErrorBoundary } from "@/components/common/SectionErrorBoundary";
+import { ErrorBoundaryWithRetry } from "@/components/common/ErrorBoundaryWithRetry";
+import { PageErrorBoundary } from "@/components/common/PageErrorBoundary";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** A component that throws when `shouldThrow` is true. */
+function Bomb({
+  shouldThrow = true,
+  message = "Test render error",
+}: {
+  shouldThrow?: boolean;
+  message?: string;
+}) {
+  if (shouldThrow) throw new Error(message);
+  return <div>All good</div>;
+}
+
+/** Suppress expected React error output during boundary tests. */
+function suppressConsoleError() {
+  const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+  return spy;
+}
+
+// ─── ErrorBoundary (full-page) ────────────────────────────────────────────────
+
+describe("ErrorBoundary", () => {
+  let consoleSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleSpy = suppressConsoleError();
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it("renders children when there is no error", () => {
+    render(
+      <ErrorBoundary>
+        <Bomb shouldThrow={false} />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText("All good")).toBeInTheDocument();
+  });
+
+  it("renders fallback UI when a child throws", () => {
+    render(
+      <ErrorBoundary>
+        <Bomb />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByRole("heading", { level: 1 })).toBeInTheDocument();
+    // The error message should appear in technical details
+    expect(screen.getByText(/Test render error/i)).toBeInTheDocument();
+  });
+
+  it("renders a custom fallback when provided", () => {
+    render(
+      <ErrorBoundary fallback={<div>Custom fallback</div>}>
+        <Bomb />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText("Custom fallback")).toBeInTheDocument();
+  });
+
+  it("shows authentication UI for auth errors", () => {
+    render(
+      <ErrorBoundary>
+        <Bomb message="Unauthorized access denied" />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText(/Go to Login/i)).toBeInTheDocument();
+  });
+
+  it("calls onError callback when an error is caught", () => {
+    const onError = jest.fn();
+    render(
+      <ErrorBoundary onError={onError}>
+        <Bomb />
+      </ErrorBoundary>,
+    );
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0][0]).toBeInstanceOf(Error);
+  });
+
+  it("resets and re-renders children after retry", () => {
+    let shouldThrow = true;
+
+    function Toggle() {
+      if (shouldThrow) throw new Error("toggle error");
+      return <div>Recovered</div>;
+    }
+
+    render(
+      <ErrorBoundary>
+        <Toggle />
+      </ErrorBoundary>,
+    );
+
+    // Fallback is shown
+    expect(screen.queryByText("Recovered")).not.toBeInTheDocument();
+
+    // Fix the source of error then click Retry
+    shouldThrow = false;
+    fireEvent.click(screen.getByRole("button", { name: /refresh|retry/i }));
+    expect(screen.getByText("Recovered")).toBeInTheDocument();
+  });
+});
+
+// ─── SectionErrorBoundary ─────────────────────────────────────────────────────
+
+describe("SectionErrorBoundary", () => {
+  let consoleSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleSpy = suppressConsoleError();
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it("renders children normally", () => {
+    render(
+      <SectionErrorBoundary label="Widget">
+        <Bomb shouldThrow={false} />
+      </SectionErrorBoundary>,
+    );
+    expect(screen.getByText("All good")).toBeInTheDocument();
+  });
+
+  it("shows inline error fallback with section label", () => {
+    render(
+      <SectionErrorBoundary label="Match Feed">
+        <Bomb />
+      </SectionErrorBoundary>,
+    );
+    expect(screen.getByText(/Match Feed failed to load/i)).toBeInTheDocument();
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+  });
+
+  it("shows Retry button by default (not yet exhausted)", () => {
+    render(
+      <SectionErrorBoundary>
+        <Bomb />
+      </SectionErrorBoundary>,
+    );
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+  });
+
+  it("shows Sign in again for auth errors", () => {
+    render(
+      <SectionErrorBoundary>
+        <Bomb message="Unauthorized — please authenticate" />
+      </SectionErrorBoundary>,
+    );
+    expect(screen.getByRole("button", { name: /sign in again/i })).toBeInTheDocument();
+  });
+
+  it("calls onError callback", () => {
+    const onError = jest.fn();
+    render(
+      <SectionErrorBoundary onError={onError}>
+        <Bomb />
+      </SectionErrorBoundary>,
+    );
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders custom fallback when provided", () => {
+    render(
+      <SectionErrorBoundary fallback={<span>Section fallback</span>}>
+        <Bomb />
+      </SectionErrorBoundary>,
+    );
+    expect(screen.getByText("Section fallback")).toBeInTheDocument();
+  });
+});
+
+// ─── ErrorBoundaryWithRetry ───────────────────────────────────────────────────
+
+describe("ErrorBoundaryWithRetry", () => {
+  let consoleSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleSpy = suppressConsoleError();
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it("renders children normally", () => {
+    render(
+      <ErrorBoundaryWithRetry>
+        <Bomb shouldThrow={false} />
+      </ErrorBoundaryWithRetry>,
+    );
+    expect(screen.getByText("All good")).toBeInTheDocument();
+  });
+
+  it("shows error fallback when child throws", () => {
+    render(
+      <ErrorBoundaryWithRetry>
+        <Bomb />
+      </ErrorBoundaryWithRetry>,
+    );
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(screen.getByText(/Something went wrong/i)).toBeInTheDocument();
+  });
+
+  it("shows Retry button within maxRetries", () => {
+    render(
+      <ErrorBoundaryWithRetry maxRetries={3}>
+        <Bomb />
+      </ErrorBoundaryWithRetry>,
+    );
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+  });
+
+  it("shows exhausted message when maxRetries is 0", () => {
+    render(
+      <ErrorBoundaryWithRetry maxRetries={0}>
+        <Bomb />
+      </ErrorBoundaryWithRetry>,
+    );
+    expect(screen.getByText(/Maximum retries/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /retry/i })).not.toBeInTheDocument();
+  });
+
+  it("shows custom fallback after retries exhausted", () => {
+    render(
+      <ErrorBoundaryWithRetry maxRetries={0} fallback={<div>Custom exhausted</div>}>
+        <Bomb />
+      </ErrorBoundaryWithRetry>,
+    );
+    expect(screen.getByText("Custom exhausted")).toBeInTheDocument();
+  });
+});
+
+// ─── PageErrorBoundary ────────────────────────────────────────────────────────
+
+// PageErrorBoundary uses next-intl's useTranslations via PageError.
+// We mock it to avoid setting up an intl provider in every test.
+
+jest.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+describe("PageErrorBoundary", () => {
+  let consoleSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleSpy = suppressConsoleError();
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it("renders children when there is no error", () => {
+    render(
+      <PageErrorBoundary>
+        <Bomb shouldThrow={false} />
+      </PageErrorBoundary>,
+    );
+    expect(screen.getByText("All good")).toBeInTheDocument();
+  });
+
+  it("renders PageError fallback when child throws", () => {
+    render(
+      <PageErrorBoundary title="Page failed">
+        <Bomb />
+      </PageErrorBoundary>,
+    );
+    expect(screen.getByText("Page failed")).toBeInTheDocument();
+  });
+
+  it("shows the retry button and resets on click", () => {
+    let shouldThrow = true;
+
+    function Toggle() {
+      if (shouldThrow) throw new Error("page error");
+      return <div>Page OK</div>;
+    }
+
+    render(
+      <PageErrorBoundary>
+        <Toggle />
+      </PageErrorBoundary>,
+    );
+
+    shouldThrow = false;
+    fireEvent.click(screen.getByRole("button", { name: /retry|common\.retry/i }));
+    expect(screen.getByText("Page OK")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/error-handling.test.ts
+++ b/frontend/src/__tests__/error-handling.test.ts
@@ -1,86 +1,363 @@
+/**
+ * Error Handling — comprehensive unit tests
+ *
+ * Covers:
+ *  - ArenaXError and specialised subclasses
+ *  - Utility functions (determineErrorCategory, determineErrorSeverity, etc.)
+ *  - getRecoveryStrategy / isRetryableError
+ *  - serializeError
+ *  - ErrorLogger (logError, query helpers, getSummary, recordRecoveryAttempt)
+ *  - useErrorRecovery hook (retry, back-off, exhaustion, non-retryable errors)
+ */
+
 import {
   ArenaXError,
+  NetworkError,
+  AuthenticationError,
+  ValidationError,
+  ApiError,
   ErrorCategory,
   ErrorSeverity,
   determineErrorCategory,
   determineErrorSeverity,
   generateErrorId,
+  getRecoveryStrategy,
+  isRetryableError,
+  serializeError,
 } from "@/lib/errors";
 
-describe("Error Types and Utilities", () => {
-  describe("ArenaXError", () => {
-    it("should create an instance with default values", () => {
-      const error = new ArenaXError("Test error");
-      expect(error).toBeInstanceOf(Error);
-      expect(error.name).toBe("ArenaXError");
-      expect(error.message).toBe("Test error");
-      expect(error.category).toBe(ErrorCategory.UNKNOWN);
-      expect(error.severity).toBe(ErrorSeverity.MEDIUM);
-    });
+// ─── Helpers ──────────────────────────────────────────────────────────────────
 
-    it("should create an instance with custom values", () => {
-      const error = new ArenaXError(
-        "Network error",
-        ErrorCategory.NETWORK,
-        ErrorSeverity.HIGH,
-        { url: "https://example.com" }
-      );
-      expect(error.category).toBe(ErrorCategory.NETWORK);
-      expect(error.severity).toBe(ErrorSeverity.HIGH);
-      expect(error.metadata).toEqual({ url: "https://example.com" });
-    });
+function makeError(message: string): Error {
+  return new Error(message);
+}
+
+// ─── ArenaXError ──────────────────────────────────────────────────────────────
+
+describe("ArenaXError", () => {
+  it("creates with defaults", () => {
+    const err = new ArenaXError("oops");
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe("ArenaXError");
+    expect(err.message).toBe("oops");
+    expect(err.category).toBe(ErrorCategory.UNKNOWN);
+    expect(err.severity).toBe(ErrorSeverity.MEDIUM);
+    expect(err.metadata).toBeUndefined();
   });
 
-  describe("determineErrorCategory", () => {
-    it("should determine network error", () => {
-      const error = new Error("Network error occurred");
-      expect(determineErrorCategory(error)).toBe(ErrorCategory.NETWORK);
-    });
-
-    it("should determine authentication error", () => {
-      const error = new Error("Unauthorized access");
-      expect(determineErrorCategory(error)).toBe(ErrorCategory.AUTHENTICATION);
-    });
-
-    it("should determine validation error", () => {
-      const error = new Error("Invalid input");
-      expect(determineErrorCategory(error)).toBe(ErrorCategory.VALIDATION);
-    });
-
-    it("should determine API error", () => {
-      const error = new Error("API server error");
-      expect(determineErrorCategory(error)).toBe(ErrorCategory.API);
-    });
-
-    it("should use category from ArenaXError", () => {
-      const error = new ArenaXError("Test", ErrorCategory.RUNTIME);
-      expect(determineErrorCategory(error)).toBe(ErrorCategory.RUNTIME);
-    });
+  it("creates with explicit category, severity and metadata", () => {
+    const err = new ArenaXError(
+      "net fail",
+      ErrorCategory.NETWORK,
+      ErrorSeverity.HIGH,
+      { url: "https://example.com" },
+    );
+    expect(err.category).toBe(ErrorCategory.NETWORK);
+    expect(err.severity).toBe(ErrorSeverity.HIGH);
+    expect(err.metadata).toEqual({ url: "https://example.com" });
   });
 
-  describe("determineErrorSeverity", () => {
-    it("should determine critical error", () => {
-      const error = new Error("Critical failure");
-      expect(determineErrorSeverity(error)).toBe(ErrorSeverity.CRITICAL);
-    });
+  it("has a non-empty stack trace", () => {
+    const err = new ArenaXError("trace me");
+    expect(typeof err.stack).toBe("string");
+    expect(err.stack!.length).toBeGreaterThan(0);
+  });
+});
 
-    it("should determine high severity for network errors", () => {
-      const error = new Error("Network timeout");
-      expect(determineErrorSeverity(error)).toBe(ErrorSeverity.HIGH);
-    });
+// ─── Specialised error subclasses ─────────────────────────────────────────────
 
-    it("should use severity from ArenaXError", () => {
-      const error = new ArenaXError("Test", ErrorCategory.UNKNOWN, ErrorSeverity.LOW);
-      expect(determineErrorSeverity(error)).toBe(ErrorSeverity.LOW);
-    });
+describe("NetworkError", () => {
+  it("has correct category and severity", () => {
+    const err = new NetworkError("timeout");
+    expect(err.name).toBe("NetworkError");
+    expect(err.category).toBe(ErrorCategory.NETWORK);
+    expect(err.severity).toBe(ErrorSeverity.HIGH);
+  });
+});
+
+describe("AuthenticationError", () => {
+  it("has correct category and severity", () => {
+    const err = new AuthenticationError("401");
+    expect(err.name).toBe("AuthenticationError");
+    expect(err.category).toBe(ErrorCategory.AUTHENTICATION);
+    expect(err.severity).toBe(ErrorSeverity.HIGH);
+  });
+});
+
+describe("ValidationError", () => {
+  it("stores optional field name", () => {
+    const err = new ValidationError("Email invalid", "email");
+    expect(err.name).toBe("ValidationError");
+    expect(err.category).toBe(ErrorCategory.VALIDATION);
+    expect(err.severity).toBe(ErrorSeverity.LOW);
+    expect(err.field).toBe("email");
   });
 
-  describe("generateErrorId", () => {
-    it("should generate unique IDs", () => {
-      const id1 = generateErrorId();
-      const id2 = generateErrorId();
-      expect(id1).not.toBe(id2);
-      expect(id1).toMatch(/^\d+-[a-z0-9]+$/);
-    });
+  it("works without a field name", () => {
+    const err = new ValidationError("Bad input");
+    expect(err.field).toBeUndefined();
+  });
+});
+
+describe("ApiError", () => {
+  it("uses HIGH severity for 5xx status codes", () => {
+    const err = new ApiError("Internal Server Error", 500);
+    expect(err.category).toBe(ErrorCategory.API);
+    expect(err.severity).toBe(ErrorSeverity.HIGH);
+    expect(err.statusCode).toBe(500);
+  });
+
+  it("uses MEDIUM severity for 4xx status codes", () => {
+    const err = new ApiError("Not Found", 404);
+    expect(err.severity).toBe(ErrorSeverity.MEDIUM);
+  });
+});
+
+// ─── determineErrorCategory ───────────────────────────────────────────────────
+
+describe("determineErrorCategory", () => {
+  it.each([
+    ["Network error occurred", ErrorCategory.NETWORK],
+    ["fetch failed", ErrorCategory.NETWORK],
+    ["Request timeout", ErrorCategory.NETWORK],
+    ["Unauthorized access", ErrorCategory.AUTHENTICATION],
+    ["403 Forbidden", ErrorCategory.AUTHENTICATION],
+    ["Invalid email", ErrorCategory.VALIDATION],
+    ["API server error", ErrorCategory.API],
+    ["Something random", ErrorCategory.UNKNOWN],
+  ] as [string, ErrorCategory][])(
+    '"%s" → %s',
+    (message, expected) => {
+      expect(determineErrorCategory(makeError(message))).toBe(expected);
+    },
+  );
+
+  it("returns the category embedded in ArenaXError directly", () => {
+    const err = new ArenaXError("x", ErrorCategory.RUNTIME);
+    expect(determineErrorCategory(err)).toBe(ErrorCategory.RUNTIME);
+  });
+});
+
+// ─── determineErrorSeverity ───────────────────────────────────────────────────
+
+describe("determineErrorSeverity", () => {
+  it("returns CRITICAL for messages containing 'critical'", () => {
+    expect(determineErrorSeverity(makeError("Critical failure"))).toBe(ErrorSeverity.CRITICAL);
+  });
+
+  it("returns HIGH for network/timeout messages", () => {
+    expect(determineErrorSeverity(makeError("network timeout"))).toBe(ErrorSeverity.HIGH);
+  });
+
+  it("returns MEDIUM for generic messages", () => {
+    expect(determineErrorSeverity(makeError("oops"))).toBe(ErrorSeverity.MEDIUM);
+  });
+
+  it("returns the severity embedded in ArenaXError directly", () => {
+    const err = new ArenaXError("x", ErrorCategory.UNKNOWN, ErrorSeverity.LOW);
+    expect(determineErrorSeverity(err)).toBe(ErrorSeverity.LOW);
+  });
+});
+
+// ─── generateErrorId ──────────────────────────────────────────────────────────
+
+describe("generateErrorId", () => {
+  it("generates unique IDs", () => {
+    const ids = new Set(Array.from({ length: 100 }, () => generateErrorId()));
+    expect(ids.size).toBe(100);
+  });
+
+  it("matches expected format (timestamp-alphanum)", () => {
+    expect(generateErrorId()).toMatch(/^\d+-[a-z0-9]+$/);
+  });
+});
+
+// ─── getRecoveryStrategy ──────────────────────────────────────────────────────
+
+describe("getRecoveryStrategy", () => {
+  it("returns a strategy for NETWORK errors", () => {
+    const s = getRecoveryStrategy(ErrorCategory.NETWORK);
+    expect(s).not.toBeNull();
+    expect(s!.maxAttempts).toBeGreaterThan(0);
+  });
+
+  it("returns a strategy for API errors", () => {
+    expect(getRecoveryStrategy(ErrorCategory.API)).not.toBeNull();
+  });
+
+  it("returns a strategy for RUNTIME errors", () => {
+    expect(getRecoveryStrategy(ErrorCategory.RUNTIME)).not.toBeNull();
+  });
+
+  it("returns null for AUTHENTICATION errors (non-retryable)", () => {
+    expect(getRecoveryStrategy(ErrorCategory.AUTHENTICATION)).toBeNull();
+  });
+
+  it("returns null for VALIDATION errors (non-retryable)", () => {
+    expect(getRecoveryStrategy(ErrorCategory.VALIDATION)).toBeNull();
+  });
+
+  it("returns null for UNKNOWN errors", () => {
+    expect(getRecoveryStrategy(ErrorCategory.UNKNOWN)).toBeNull();
+  });
+});
+
+// ─── isRetryableError ────────────────────────────────────────────────────────
+
+describe("isRetryableError", () => {
+  it("returns true for network errors", () => {
+    expect(isRetryableError(new NetworkError("down"))).toBe(true);
+  });
+
+  it("returns true for API errors", () => {
+    expect(isRetryableError(new ApiError("500"))).toBe(true);
+  });
+
+  it("returns false for authentication errors", () => {
+    expect(isRetryableError(new AuthenticationError("401"))).toBe(false);
+  });
+
+  it("returns false for validation errors", () => {
+    expect(isRetryableError(new ValidationError("bad"))).toBe(false);
+  });
+});
+
+// ─── serializeError ───────────────────────────────────────────────────────────
+
+describe("serializeError", () => {
+  it("serialises a plain Error", () => {
+    const err = new Error("boom");
+    const obj = serializeError(err);
+    expect(obj.name).toBe("Error");
+    expect(obj.message).toBe("boom");
+    expect(typeof obj.stack).toBe("string");
+    expect(obj.category).toBeUndefined();
+  });
+
+  it("serialises an ArenaXError with extended fields", () => {
+    const err = new ArenaXError("net", ErrorCategory.NETWORK, ErrorSeverity.HIGH, { url: "/" });
+    const obj = serializeError(err);
+    expect(obj.category).toBe(ErrorCategory.NETWORK);
+    expect(obj.severity).toBe(ErrorSeverity.HIGH);
+    expect(obj.metadata).toEqual({ url: "/" });
+  });
+});
+
+// ─── ErrorLogger (isolated) ───────────────────────────────────────────────────
+// We import the class internals via the singleton's public API.
+
+describe("ErrorLogger (via singleton)", () => {
+  // Dynamically import to get a fresh module — jest module cache is shared,
+  // so we rely on the singleton but reset between tests via clearErrors.
+  let logError: typeof import("@/lib/errorLogger").logError;
+  let getLoggedErrors: typeof import("@/lib/errorLogger").getLoggedErrors;
+  let clearLoggedErrors: typeof import("@/lib/errorLogger").clearLoggedErrors;
+  let getErrorSummary: typeof import("@/lib/errorLogger").getErrorSummary;
+  let errorLogger: typeof import("@/lib/errorLogger").errorLogger;
+
+  beforeAll(async () => {
+    const mod = await import("@/lib/errorLogger");
+    logError = mod.logError;
+    getLoggedErrors = mod.getLoggedErrors;
+    clearLoggedErrors = mod.clearLoggedErrors;
+    getErrorSummary = mod.getErrorSummary;
+    errorLogger = mod.errorLogger;
+  });
+
+  beforeEach(() => {
+    clearLoggedErrors();
+  });
+
+  it("logs an error and returns a LoggedError entry", () => {
+    const entry = logError(new Error("test"));
+    expect(entry.id).toBeTruthy();
+    expect(entry.message).toBe("test");
+    expect(entry.timestamp).toBeLessThanOrEqual(Date.now());
+  });
+
+  it("stored errors are retrievable", () => {
+    logError(new Error("a"));
+    logError(new Error("b"));
+    expect(getLoggedErrors()).toHaveLength(2);
+  });
+
+  it("most-recent error is at index 0", () => {
+    logError(new Error("first"));
+    logError(new Error("second"));
+    expect(getLoggedErrors()[0].message).toBe("second");
+  });
+
+  it("clearErrors empties the list", () => {
+    logError(new Error("gone"));
+    clearLoggedErrors();
+    expect(getLoggedErrors()).toHaveLength(0);
+  });
+
+  it("getSummary counts totals correctly", () => {
+    logError(new NetworkError("down"));
+    logError(new AuthenticationError("401"));
+    logError(new NetworkError("again"));
+
+    const summary = getErrorSummary();
+    expect(summary.total).toBe(3);
+    expect(summary.byCategory[ErrorCategory.NETWORK]).toBe(2);
+    expect(summary.byCategory[ErrorCategory.AUTHENTICATION]).toBe(1);
+  });
+
+  it("recordRecoveryAttempt marks an error as recovered", () => {
+    const entry = logError(new NetworkError("flaky"));
+    errorLogger.recordRecoveryAttempt(entry.id, true);
+    const updated = getLoggedErrors().find((e) => e.id === entry.id);
+    expect(updated?.recovered).toBe(true);
+    expect(updated?.recoveryAttempts).toBe(1);
+
+    const summary = getErrorSummary();
+    expect(summary.recoveredCount).toBe(1);
+  });
+
+  it("attaches provided metadata to the entry", () => {
+    const entry = logError(new Error("meta test"), { userId: "u-123" });
+    expect((entry.metadata as Record<string, unknown>)?.userId).toBe("u-123");
+  });
+});
+
+// ─── useErrorRecovery hook ────────────────────────────────────────────────────
+
+// We test the hook logic directly (without renderHook) by exercising the
+// underlying retry utilities, since the hook is straightforward composition.
+
+describe("Recovery strategy — delay computation", () => {
+  /**
+   * Mirrors the private `computeDelay` logic from the hook so we can test
+   * expected back-off timings without importing private helpers.
+   */
+  function computeDelay(baseMs: number, attempt: number, maxMs: number): number {
+    return Math.min(baseMs * Math.pow(2, attempt), maxMs);
+  }
+
+  it("doubles delay each attempt (exponential back-off)", () => {
+    expect(computeDelay(1_000, 0, 30_000)).toBe(1_000);
+    expect(computeDelay(1_000, 1, 30_000)).toBe(2_000);
+    expect(computeDelay(1_000, 2, 30_000)).toBe(4_000);
+  });
+
+  it("caps at maxDelayMs", () => {
+    expect(computeDelay(1_000, 10, 5_000)).toBe(5_000);
+  });
+});
+
+describe("isRetryableError — exhaustive matrix", () => {
+  const cases: [string, boolean][] = [
+    ["Network error", true],
+    ["fetch failed", true],
+    ["Request timeout", true],
+    ["API server error", true],
+    ["Unauthorized", false],
+    ["invalid input", false],
+    ["Something else entirely", false],
+  ];
+
+  it.each(cases)('"%s" is retryable: %s', (message, expected) => {
+    expect(isRetryableError(new Error(message))).toBe(expected);
   });
 });

--- a/frontend/src/__tests__/error-recovery.test.tsx
+++ b/frontend/src/__tests__/error-recovery.test.tsx
@@ -1,0 +1,182 @@
+/**
+ * useErrorRecovery hook tests
+ *
+ * Uses @testing-library/react's renderHook to exercise the retry/back-off
+ * logic.  Timers are faked so tests run without real delays.
+ */
+
+import { renderHook, act } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { useErrorRecovery } from "@/hooks/useErrorRecovery";
+import { NetworkError, AuthenticationError, ValidationError } from "@/lib/errors";
+
+// ─── Setup: fake timers ───────────────────────────────────────────────────────
+
+beforeEach(() => {
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.runAllTimers();
+  jest.useRealTimers();
+});
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Creates an action that fails `failTimes` then succeeds.
+ */
+function makeFlaky<T>(failTimes: number, successValue: T): () => Promise<T> {
+  let callCount = 0;
+  return async () => {
+    callCount++;
+    if (callCount <= failTimes) {
+      throw new NetworkError(`Attempt ${callCount} failed`);
+    }
+    return successValue;
+  };
+}
+
+/**
+ * Creates an action that always rejects with the given error.
+ */
+function makeAlwaysFail(error: Error): () => Promise<never> {
+  return async () => { throw error; };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("useErrorRecovery", () => {
+  it("starts in idle state", () => {
+    const { result } = renderHook(() => useErrorRecovery());
+    expect(result.current.status).toBe("idle");
+    expect(result.current.attempts).toBe(0);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("returns the result on immediate success", async () => {
+    const { result } = renderHook(() => useErrorRecovery<string>());
+
+    let returnValue: string | undefined;
+    await act(async () => {
+      returnValue = await result.current.execute(async () => "hello");
+    });
+
+    expect(returnValue).toBe("hello");
+    expect(result.current.status).toBe("succeeded");
+    expect(result.current.attempts).toBe(0);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("retries a flaky action and eventually succeeds", async () => {
+    const action = makeFlaky(2, "done");
+    const { result } = renderHook(() => useErrorRecovery<string>());
+
+    let returnValue: string | undefined;
+    await act(async () => {
+      const promise = result.current.execute(action);
+      // Advance through retry delays
+      jest.runAllTimers();
+      returnValue = await promise;
+    });
+
+    expect(returnValue).toBe("done");
+    expect(result.current.status).toBe("succeeded");
+  });
+
+  it("transitions to failed after exhausting all retries", async () => {
+    const onExhausted = jest.fn();
+    const { result } = renderHook(() =>
+      useErrorRecovery({ onExhausted, strategy: { maxAttempts: 2 } }),
+    );
+
+    await act(async () => {
+      const promise = result.current.execute(makeAlwaysFail(new NetworkError("down")));
+      jest.runAllTimers();
+      await promise;
+    });
+
+    expect(result.current.status).toBe("failed");
+    expect(onExhausted).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry non-retryable (auth) errors", async () => {
+    const onExhausted = jest.fn();
+    const { result } = renderHook(() => useErrorRecovery({ onExhausted }));
+
+    await act(async () => {
+      await result.current.execute(makeAlwaysFail(new AuthenticationError("401")));
+    });
+
+    expect(result.current.status).toBe("failed");
+    expect(result.current.attempts).toBe(0);
+    expect(onExhausted).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry non-retryable (validation) errors", async () => {
+    const { result } = renderHook(() => useErrorRecovery());
+
+    await act(async () => {
+      await result.current.execute(makeAlwaysFail(new ValidationError("bad email")));
+    });
+
+    expect(result.current.status).toBe("failed");
+    expect(result.current.isRetryable).toBe(false);
+  });
+
+  it("calls onRecovered when a retry succeeds", async () => {
+    const onRecovered = jest.fn();
+    const action = makeFlaky(1, "ok");
+    const { result } = renderHook(() => useErrorRecovery<string>({ onRecovered }));
+
+    await act(async () => {
+      const promise = result.current.execute(action);
+      jest.runAllTimers();
+      await promise;
+    });
+
+    expect(onRecovered).toHaveBeenCalledWith(1);
+  });
+
+  it("reset() returns hook to idle", async () => {
+    const { result } = renderHook(() => useErrorRecovery());
+
+    await act(async () => {
+      await result.current.execute(makeAlwaysFail(new NetworkError("x")));
+    });
+
+    expect(result.current.status).toBe("failed");
+
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.status).toBe("idle");
+    expect(result.current.error).toBeNull();
+    expect(result.current.attempts).toBe(0);
+  });
+
+  it("captures the error object on failure", async () => {
+    const err = new NetworkError("captured");
+    const { result } = renderHook(() => useErrorRecovery({ strategy: { maxAttempts: 0 } }));
+
+    await act(async () => {
+      await result.current.execute(makeAlwaysFail(err));
+    });
+
+    expect(result.current.error).toBe(err);
+  });
+
+  it("creates a loggedError entry on first failure", async () => {
+    const { result } = renderHook(() =>
+      useErrorRecovery({ strategy: { maxAttempts: 0 } }),
+    );
+
+    await act(async () => {
+      await result.current.execute(makeAlwaysFail(new NetworkError("log me")));
+    });
+
+    expect(result.current.loggedError).not.toBeNull();
+    expect(result.current.loggedError?.message).toBe("log me");
+  });
+});

--- a/frontend/src/components/common/ErrorBoundaryWithRetry.tsx
+++ b/frontend/src/components/common/ErrorBoundaryWithRetry.tsx
@@ -1,59 +1,147 @@
-import React, { Component, ReactNode } from 'react';
+"use client";
 
-export interface ErrorBoundaryProps {
+import React, { Component, ReactNode } from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/Button";
+import { logError } from "@/lib/errorLogger";
+import { determineErrorCategory, ErrorCategory } from "@/lib/errors";
+import { cn } from "@/lib/utils";
+
+// ─── Props / State ────────────────────────────────────────────────────────────
+
+export interface ErrorBoundaryWithRetryProps {
   children: ReactNode;
+  /** Maximum number of automatic retry attempts before giving up (default: 3). */
   maxRetries?: number;
+  /** Custom fallback rendered after all retries are exhausted. */
+  fallback?: ReactNode;
+  /** Extra classes for the error card wrapper. */
+  className?: string;
+  /** Called on every caught error. */
+  onError?: (error: Error, info: React.ErrorInfo) => void;
 }
 
-export interface ErrorBoundaryState {
+export interface ErrorBoundaryWithRetryState {
   hasError: boolean;
   error: Error | null;
   retryCount: number;
 }
 
+// ─── Component ────────────────────────────────────────────────────────────────
+
 /**
- * Component for Advanced Error Recovery with Retry Logic (Resolves #598)
+ * Error boundary with configurable max-retry logic.  Uses the design system
+ * (Button, Tailwind tokens) and integrates with `errorLogger`.
+ *
+ * @example
+ * ```tsx
+ * <ErrorBoundaryWithRetry maxRetries={2} label="Match Feed">
+ *   <MatchFeed />
+ * </ErrorBoundaryWithRetry>
+ * ```
  */
-export class ErrorBoundaryWithRetry extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
-  constructor(props: ErrorBoundaryProps) {
+export class ErrorBoundaryWithRetry extends Component<
+  ErrorBoundaryWithRetryProps,
+  ErrorBoundaryWithRetryState
+> {
+  constructor(props: ErrorBoundaryWithRetryProps) {
     super(props);
     this.state = { hasError: false, error: null, retryCount: 0 };
   }
 
-  static getDerivedStateFromError(error: Error): Partial<ErrorBoundaryState> {
+  static getDerivedStateFromError(error: Error): Partial<ErrorBoundaryWithRetryState> {
     return { hasError: true, error };
   }
 
-  handleRetry = () => {
-    this.setState((prevState) => ({
+  componentDidCatch(error: Error, info: React.ErrorInfo): void {
+    logError(error, {
+      source: "ErrorBoundaryWithRetry",
+      componentStack: info.componentStack,
+      retryCount: this.state.retryCount,
+    });
+    this.props.onError?.(error, info);
+  }
+
+  handleRetry = (): void => {
+    this.setState((prev) => ({
       hasError: false,
       error: null,
-      retryCount: prevState.retryCount + 1,
+      retryCount: prev.retryCount + 1,
     }));
   };
 
   render() {
-    const { maxRetries = 3 } = this.props;
+    const { hasError, error, retryCount } = this.state;
+    const { children, maxRetries = 3, fallback, className } = this.props;
 
-    if (this.state.hasError) {
+    if (!hasError) return children;
+
+    // All retries exhausted — show custom fallback or a final message
+    if (retryCount >= maxRetries) {
+      if (fallback) return fallback;
       return (
-        <div className="error-recovery p-4 bg-red-100 border border-red-400 rounded text-red-700">
-          <h2>Something went wrong.</h2>
-          <p>{this.state.error?.message}</p>
-          {this.state.retryCount < maxRetries ? (
-            <button
-              onClick={this.handleRetry}
-              className="mt-2 px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700"
-            >
-              Retry
-            </button>
-          ) : (
-            <p>Maximum retries exceeded. Please contact support.</p>
+        <div
+          role="alert"
+          className={cn(
+            "rounded-lg border border-destructive/30 bg-destructive/5 p-6 text-center",
+            className,
           )}
+        >
+          <AlertTriangle className="mx-auto mb-3 h-8 w-8 text-destructive" aria-hidden="true" />
+          <p className="text-sm font-medium text-foreground">
+            Something went wrong and couldn&apos;t be recovered.
+          </p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Maximum retries ({maxRetries}) exceeded.{" "}
+            <a href="/contact?error=true" className="underline underline-offset-2">
+              Contact support
+            </a>
+          </p>
         </div>
       );
     }
 
-    return this.props.children;
+    const category = error ? determineErrorCategory(error) : ErrorCategory.UNKNOWN;
+    const isAuth = category === ErrorCategory.AUTHENTICATION;
+
+    return (
+      <div
+        role="alert"
+        aria-live="polite"
+        className={cn(
+          "rounded-lg border border-destructive/30 bg-destructive/5 p-6 text-center",
+          className,
+        )}
+      >
+        <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-destructive/10">
+          <AlertTriangle className="h-6 w-6 text-destructive" aria-hidden="true" />
+        </div>
+
+        <p className="mb-1 text-sm font-medium text-foreground">
+          Something went wrong
+        </p>
+
+        {error && (
+          <p className="mb-4 text-xs text-muted-foreground line-clamp-2">
+            {error.message}
+          </p>
+        )}
+
+        {isAuth ? (
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => { window.location.href = "/login"; }}
+          >
+            Sign in again
+          </Button>
+        ) : (
+          <Button size="sm" variant="outline" onClick={this.handleRetry}>
+            <RefreshCw className="mr-1.5 h-3.5 w-3.5" aria-hidden="true" />
+            Retry ({retryCount}/{maxRetries})
+          </Button>
+        )}
+      </div>
+    );
   }
 }

--- a/frontend/src/components/common/ErrorMonitorDashboard.tsx
+++ b/frontend/src/components/common/ErrorMonitorDashboard.tsx
@@ -1,0 +1,285 @@
+"use client";
+
+import React, { useState } from "react";
+import { AlertTriangle, RefreshCw, Trash2, ChevronDown, ChevronUp } from "lucide-react";
+import { Button } from "@/components/ui/Button";
+import { useError } from "@/components/providers/ErrorProvider";
+import { ErrorCategory, ErrorSeverity } from "@/lib/errors";
+import { LoggedError } from "@/lib/errors";
+import { cn } from "@/lib/utils";
+import { formatDistanceToNow } from "date-fns";
+
+// ─── Severity badge ───────────────────────────────────────────────────────────
+
+const SEVERITY_STYLES: Record<ErrorSeverity, string> = {
+  [ErrorSeverity.LOW]: "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300",
+  [ErrorSeverity.MEDIUM]: "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/40 dark:text-yellow-300",
+  [ErrorSeverity.HIGH]: "bg-orange-100 text-orange-700 dark:bg-orange-900/40 dark:text-orange-300",
+  [ErrorSeverity.CRITICAL]: "bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300",
+};
+
+const CATEGORY_LABELS: Record<ErrorCategory, string> = {
+  [ErrorCategory.NETWORK]: "Network",
+  [ErrorCategory.AUTHENTICATION]: "Auth",
+  [ErrorCategory.VALIDATION]: "Validation",
+  [ErrorCategory.API]: "API",
+  [ErrorCategory.RUNTIME]: "Runtime",
+  [ErrorCategory.UNKNOWN]: "Unknown",
+};
+
+// ─── Individual error row ─────────────────────────────────────────────────────
+
+function ErrorRow({ entry }: { entry: LoggedError }) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div className="border border-border rounded-md overflow-hidden text-left">
+      {/* Header row */}
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        className="w-full flex items-center gap-3 px-4 py-3 bg-card hover:bg-muted/50 transition-colors text-left"
+        aria-expanded={expanded}
+      >
+        {/* Severity badge */}
+        <span
+          className={cn(
+            "shrink-0 rounded-full px-2 py-0.5 text-xs font-medium uppercase tracking-wide",
+            SEVERITY_STYLES[entry.severity],
+          )}
+        >
+          {entry.severity}
+        </span>
+
+        {/* Category */}
+        <span className="shrink-0 text-xs text-muted-foreground w-20">
+          {CATEGORY_LABELS[entry.category]}
+        </span>
+
+        {/* Message */}
+        <span className="flex-1 text-sm text-foreground truncate">{entry.message}</span>
+
+        {/* Timestamp */}
+        <span className="shrink-0 text-xs text-muted-foreground">
+          {formatDistanceToNow(entry.timestamp, { addSuffix: true })}
+        </span>
+
+        {/* Recovery badge */}
+        {entry.recovered && (
+          <span className="shrink-0 rounded-full bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300 px-2 py-0.5 text-xs font-medium">
+            Recovered
+          </span>
+        )}
+
+        {expanded ? (
+          <ChevronUp className="shrink-0 h-4 w-4 text-muted-foreground" aria-hidden="true" />
+        ) : (
+          <ChevronDown className="shrink-0 h-4 w-4 text-muted-foreground" aria-hidden="true" />
+        )}
+      </button>
+
+      {/* Expanded details */}
+      {expanded && (
+        <div className="px-4 py-3 bg-muted/30 border-t border-border space-y-2">
+          <p className="text-xs text-muted-foreground">
+            <strong>ID:</strong> {entry.id}
+          </p>
+          <p className="text-xs text-muted-foreground">
+            <strong>Timestamp:</strong> {new Date(entry.timestamp).toISOString()}
+          </p>
+          {entry.recoveryAttempts !== undefined && entry.recoveryAttempts > 0 && (
+            <p className="text-xs text-muted-foreground">
+              <strong>Recovery attempts:</strong> {entry.recoveryAttempts}
+            </p>
+          )}
+          {entry.stack && (
+            <pre className="text-xs bg-muted rounded p-2 overflow-x-auto whitespace-pre-wrap break-all">
+              {entry.stack}
+            </pre>
+          )}
+          {entry.metadata && (
+            <pre className="text-xs bg-muted rounded p-2 overflow-x-auto whitespace-pre-wrap break-all">
+              {JSON.stringify(entry.metadata, null, 2)}
+            </pre>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Summary card ─────────────────────────────────────────────────────────────
+
+function SummaryCard({
+  label,
+  value,
+  highlight,
+}: {
+  label: string;
+  value: number;
+  highlight?: boolean;
+}) {
+  return (
+    <div
+      className={cn(
+        "rounded-lg border p-4 text-center",
+        highlight && value > 0 ? "border-destructive/40 bg-destructive/5" : "border-border bg-card",
+      )}
+    >
+      <p className={cn("text-2xl font-bold", highlight && value > 0 ? "text-destructive" : "text-foreground")}>
+        {value}
+      </p>
+      <p className="mt-1 text-xs text-muted-foreground">{label}</p>
+    </div>
+  );
+}
+
+// ─── Main dashboard ───────────────────────────────────────────────────────────
+
+/**
+ * `ErrorMonitorDashboard` — read-only developer/admin view of all errors
+ * captured by `errorLogger` in the current session.
+ *
+ * Renders summary counts, per-category breakdowns, and an expandable list of
+ * individual error entries with stack traces and metadata.
+ *
+ * Intended for use in `/analytics` or an admin panel page — not shown to
+ * end-users in production.
+ */
+export function ErrorMonitorDashboard() {
+  const { errors, summary, clearErrors, refreshSummary } = useError();
+
+  const [filterCategory, setFilterCategory] = useState<ErrorCategory | "all">("all");
+  const [filterSeverity, setFilterSeverity] = useState<ErrorSeverity | "all">("all");
+
+  const filtered = errors.filter((e) => {
+    if (filterCategory !== "all" && e.category !== filterCategory) return false;
+    if (filterSeverity !== "all" && e.severity !== filterSeverity) return false;
+    return true;
+  });
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <AlertTriangle className="h-5 w-5 text-destructive" aria-hidden="true" />
+          <h2 className="text-lg font-semibold text-foreground">Error Monitor</h2>
+          <span className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+            {summary.total} total
+          </span>
+        </div>
+
+        <div className="flex gap-2">
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={refreshSummary}
+            aria-label="Refresh error summary"
+          >
+            <RefreshCw className="h-3.5 w-3.5 mr-1.5" aria-hidden="true" />
+            Refresh
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={clearErrors}
+            aria-label="Clear all logged errors"
+          >
+            <Trash2 className="h-3.5 w-3.5 mr-1.5" aria-hidden="true" />
+            Clear
+          </Button>
+        </div>
+      </div>
+
+      {/* Summary grid */}
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <SummaryCard label="Total Errors" value={summary.total} />
+        <SummaryCard label="Last 60 s" value={summary.recentCount} highlight />
+        <SummaryCard label="Critical / High" value={(summary.bySeverity[ErrorSeverity.CRITICAL] ?? 0) + (summary.bySeverity[ErrorSeverity.HIGH] ?? 0)} highlight />
+        <SummaryCard label="Recovered" value={summary.recoveredCount} />
+      </div>
+
+      {/* Category breakdown */}
+      <div className="grid grid-cols-3 gap-2 sm:grid-cols-6">
+        {Object.values(ErrorCategory).map((cat) => (
+          <div
+            key={cat}
+            className="rounded-md border border-border bg-card px-3 py-2 text-center"
+          >
+            <p className="text-lg font-semibold text-foreground">
+              {summary.byCategory[cat] ?? 0}
+            </p>
+            <p className="text-xs text-muted-foreground">{CATEGORY_LABELS[cat]}</p>
+          </div>
+        ))}
+      </div>
+
+      {/* Filters */}
+      <div className="flex flex-wrap gap-3">
+        <div className="flex items-center gap-2">
+          <label htmlFor="filter-category" className="text-xs text-muted-foreground">
+            Category
+          </label>
+          <select
+            id="filter-category"
+            value={filterCategory}
+            onChange={(e) => setFilterCategory(e.target.value as ErrorCategory | "all")}
+            className="rounded border border-border bg-background px-2 py-1 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+          >
+            <option value="all">All</option>
+            {Object.values(ErrorCategory).map((c) => (
+              <option key={c} value={c}>
+                {CATEGORY_LABELS[c]}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <label htmlFor="filter-severity" className="text-xs text-muted-foreground">
+            Severity
+          </label>
+          <select
+            id="filter-severity"
+            value={filterSeverity}
+            onChange={(e) => setFilterSeverity(e.target.value as ErrorSeverity | "all")}
+            className="rounded border border-border bg-background px-2 py-1 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+          >
+            <option value="all">All</option>
+            {Object.values(ErrorSeverity).map((s) => (
+              <option key={s} value={s}>
+                {s}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {(filterCategory !== "all" || filterSeverity !== "all") && (
+          <button
+            type="button"
+            onClick={() => { setFilterCategory("all"); setFilterSeverity("all"); }}
+            className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground"
+          >
+            Clear filters
+          </button>
+        )}
+      </div>
+
+      {/* Error list */}
+      {filtered.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-border py-12 text-center">
+          <p className="text-sm text-muted-foreground">
+            {errors.length === 0 ? "No errors logged yet." : "No errors match the current filters."}
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {filtered.map((entry) => (
+            <ErrorRow key={entry.id} entry={entry} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/common/SectionErrorBoundary.tsx
+++ b/frontend/src/components/common/SectionErrorBoundary.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { Component, ReactNode } from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/Button";
+import { logError } from "@/lib/errorLogger";
+import { determineErrorCategory, ErrorCategory } from "@/lib/errors";
+import { cn } from "@/lib/utils";
+
+// ─── Props / State ────────────────────────────────────────────────────────────
+
+interface SectionErrorBoundaryProps {
+  children: ReactNode;
+  /** Section label shown in the fallback UI (e.g. "Tournament Bracket"). */
+  label?: string;
+  /** Custom fallback to render instead of the default UI. */
+  fallback?: ReactNode;
+  /** Optional extra class names for the wrapper div. */
+  className?: string;
+  /** Called when an error is caught — useful for parent-level reporting. */
+  onError?: (error: Error, info: React.ErrorInfo) => void;
+}
+
+interface SectionErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+  retryCount: number;
+}
+
+const MAX_SECTION_RETRIES = 3;
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+/**
+ * Lightweight error boundary intended for individual page sections (cards,
+ * panels, widgets).  Unlike `ErrorBoundary` it does **not** take over the full
+ * screen — it renders a compact inline fallback so the rest of the page stays
+ * usable.
+ *
+ * Features:
+ * - Up to 3 inline retry attempts before showing a "contact support" message
+ * - Integrates with `errorLogger` for structured tracking
+ * - Auth errors skip retry and show a "sign in again" nudge
+ */
+export class SectionErrorBoundary extends Component<
+  SectionErrorBoundaryProps,
+  SectionErrorBoundaryState
+> {
+  constructor(props: SectionErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, error: null, retryCount: 0 };
+  }
+
+  static getDerivedStateFromError(error: Error): Partial<SectionErrorBoundaryState> {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo): void {
+    logError(error, {
+      source: "SectionErrorBoundary",
+      section: this.props.label,
+      componentStack: info.componentStack,
+    });
+    this.props.onError?.(error, info);
+  }
+
+  handleRetry = (): void => {
+    this.setState((prev) => ({
+      hasError: false,
+      error: null,
+      retryCount: prev.retryCount + 1,
+    }));
+  };
+
+  render() {
+    const { hasError, error, retryCount } = this.state;
+    const { children, fallback, label, className } = this.props;
+
+    if (!hasError) return children;
+
+    // Allow custom fallback
+    if (fallback) return fallback;
+
+    const category = error ? determineErrorCategory(error) : ErrorCategory.UNKNOWN;
+    const isAuth = category === ErrorCategory.AUTHENTICATION;
+    const exhausted = retryCount >= MAX_SECTION_RETRIES;
+
+    return (
+      <div
+        role="alert"
+        aria-live="polite"
+        className={cn(
+          "flex flex-col items-center justify-center gap-3 rounded-lg border border-destructive/30 bg-destructive/5 p-6 text-center",
+          className,
+        )}
+      >
+        <div className="flex h-10 w-10 items-center justify-center rounded-full bg-destructive/10">
+          <AlertTriangle className="h-5 w-5 text-destructive" aria-hidden="true" />
+        </div>
+
+        <div>
+          <p className="text-sm font-medium text-foreground">
+            {label ? `${label} failed to load` : "This section failed to load"}
+          </p>
+          {error && (
+            <p className="mt-1 text-xs text-muted-foreground line-clamp-2">
+              {error.message}
+            </p>
+          )}
+        </div>
+
+        {isAuth ? (
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => { window.location.href = "/login"; }}
+          >
+            Sign in again
+          </Button>
+        ) : exhausted ? (
+          <p className="text-xs text-muted-foreground">
+            Still having trouble?{" "}
+            <a href="/contact?error=true" className="underline underline-offset-2">
+              Contact support
+            </a>
+          </p>
+        ) : (
+          <Button size="sm" variant="outline" onClick={this.handleRetry}>
+            <RefreshCw className="mr-1.5 h-3.5 w-3.5" aria-hidden="true" />
+            Retry{retryCount > 0 ? ` (${retryCount}/${MAX_SECTION_RETRIES})` : ""}
+          </Button>
+        )}
+      </div>
+    );
+  }
+}

--- a/frontend/src/components/providers/ErrorProvider.tsx
+++ b/frontend/src/components/providers/ErrorProvider.tsx
@@ -1,40 +1,91 @@
 "use client";
 
-import React, { createContext, useContext, useState, useCallback, ReactNode } from "react";
-import { LoggedError, logError } from "@/lib/errorLogger";
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  ReactNode,
+} from "react";
+import { errorLogger, ErrorSummary } from "@/lib/errorLogger";
+import { LoggedError, ErrorCategory, ErrorSeverity } from "@/lib/errors";
+
+// ─── Context shape ────────────────────────────────────────────────────────────
 
 interface ErrorContextType {
+  /** All errors captured during this session (most-recent first). */
   errors: LoggedError[];
+  /** Log a new error and add it to the session list. */
   addError: (error: Error, metadata?: Record<string, unknown>) => LoggedError;
+  /** Remove all errors from the session list (does NOT clear localStorage). */
   clearErrors: () => void;
+  /** Retrieve only errors of a given category. */
+  getByCategory: (category: ErrorCategory) => LoggedError[];
+  /** Retrieve only errors of a given severity. */
+  getBySeverity: (severity: ErrorSeverity) => LoggedError[];
+  /** Aggregate summary counts useful for the monitoring dashboard. */
+  summary: ErrorSummary;
+  /** Force a summary refresh (call after bulk operations). */
+  refreshSummary: () => void;
 }
+
+// ─── Context ──────────────────────────────────────────────────────────────────
 
 const ErrorContext = createContext<ErrorContextType | undefined>(undefined);
 
-export function ErrorProvider({ children }: { children: ReactNode }) {
-  const [errors, setErrors] = useState<LoggedError[]>([]);
+// ─── Provider ─────────────────────────────────────────────────────────────────
 
-  const addError = useCallback((error: Error, metadata?: Record<string, unknown>) => {
-    const loggedError = logError(error, metadata);
-    setErrors((prev) => [loggedError, ...prev]);
-    return loggedError;
+export function ErrorProvider({ children }: { children: ReactNode }) {
+  const [errors, setErrors] = useState<LoggedError[]>(() => errorLogger.getErrors());
+  const [summary, setSummary] = useState<ErrorSummary>(() => errorLogger.getSummary());
+
+  const refreshSummary = useCallback(() => {
+    setSummary(errorLogger.getSummary());
   }, []);
+
+  const addError = useCallback(
+    (error: Error, metadata?: Record<string, unknown>): LoggedError => {
+      const entry = errorLogger.logError(error, metadata);
+      setErrors(errorLogger.getErrors());
+      setSummary(errorLogger.getSummary());
+      return entry;
+    },
+    [],
+  );
 
   const clearErrors = useCallback(() => {
+    errorLogger.clearErrors();
     setErrors([]);
+    setSummary(errorLogger.getSummary());
   }, []);
 
+  const getByCategory = useCallback(
+    (category: ErrorCategory): LoggedError[] =>
+      errors.filter((e) => e.category === category),
+    [errors],
+  );
+
+  const getBySeverity = useCallback(
+    (severity: ErrorSeverity): LoggedError[] =>
+      errors.filter((e) => e.severity === severity),
+    [errors],
+  );
+
   return (
-    <ErrorContext.Provider value={{ errors, addError, clearErrors }}>
+    <ErrorContext.Provider
+      value={{ errors, addError, clearErrors, getByCategory, getBySeverity, summary, refreshSummary }}
+    >
       {children}
     </ErrorContext.Provider>
   );
 }
 
-export function useError() {
-  const context = useContext(ErrorContext);
-  if (!context) {
+// ─── Hook ─────────────────────────────────────────────────────────────────────
+
+export function useError(): ErrorContextType {
+  const ctx = useContext(ErrorContext);
+  if (!ctx) {
     throw new Error("useError must be used within an ErrorProvider");
   }
-  return context;
+  return ctx;
 }

--- a/frontend/src/components/providers/QueryProvider.tsx
+++ b/frontend/src/components/providers/QueryProvider.tsx
@@ -1,7 +1,30 @@
 "use client";
 
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClient, QueryClientProvider, MutationCache, QueryCache } from "@tanstack/react-query";
 import { useState } from "react";
+import { logError } from "@/lib/errorLogger";
+import { ArenaXError, ErrorCategory, ErrorSeverity } from "@/lib/errors";
+
+// ─── Query error handler ──────────────────────────────────────────────────────
+
+/**
+ * Translates a TanStack Query error into an `ArenaXError` so it flows through
+ * the structured logging / analytics pipeline.
+ */
+function handleQueryError(error: unknown, context?: Record<string, unknown>): void {
+  const err =
+    error instanceof Error
+      ? error
+      : new ArenaXError(
+          String(error ?? "Unknown query error"),
+          ErrorCategory.API,
+          ErrorSeverity.MEDIUM,
+        );
+
+  logError(err, { source: "QueryClient", ...context });
+}
+
+// ─── Provider ─────────────────────────────────────────────────────────────────
 
 export function QueryProvider({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(
@@ -14,6 +37,20 @@ export function QueryProvider({ children }: { children: React.ReactNode }) {
             staleTime: 20_000,
           },
         },
+        queryCache: new QueryCache({
+          onError: (error, query) =>
+            handleQueryError(error, {
+              queryKey: JSON.stringify(query.queryKey),
+            }),
+        }),
+        mutationCache: new MutationCache({
+          onError: (error, _variables, _context, mutation) =>
+            handleQueryError(error, {
+              mutationKey: mutation.options.mutationKey
+                ? JSON.stringify(mutation.options.mutationKey)
+                : undefined,
+            }),
+        }),
       }),
   );
 

--- a/frontend/src/components/ui/ErrorBoundary.tsx
+++ b/frontend/src/components/ui/ErrorBoundary.tsx
@@ -4,24 +4,14 @@ import { Component, ReactNode } from "react";
 import { Button } from "./Button";
 import { AlertTriangle, RefreshCw, Home, Mail, Copy, Check } from "lucide-react";
 import { logError } from "@/lib/errorLogger";
-import { ErrorCategory } from "@/lib/errors";
-import { useState } from "react";
+import { determineErrorCategory, ErrorCategory } from "@/lib/errors";
 
-interface ErrorBoundaryProps {
-  children: ReactNode;
-  fallback?: ReactNode;
-  onError?: (error: Error, errorInfo: React.ErrorInfo) => void;
-}
+// ─── Error message catalogue ──────────────────────────────────────────────────
 
-interface ErrorBoundaryState {
-  hasError: boolean;
-  error: Error | null;
-  errorInfo: React.ErrorInfo | null;
-  copied: boolean;
-}
-
-// Error messages by category
-const ERROR_MESSAGES = {
+const ERROR_MESSAGES: Record<
+  ErrorCategory,
+  { title: string; message: string; action: string }
+> = {
   [ErrorCategory.NETWORK]: {
     title: "Connection Lost",
     message: "Please check your internet connection and try again.",
@@ -54,6 +44,31 @@ const ERROR_MESSAGES = {
   },
 };
 
+// ─── Props / State ────────────────────────────────────────────────────────────
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  fallback?: ReactNode;
+  onError?: (error: Error, errorInfo: React.ErrorInfo) => void;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+  errorInfo: React.ErrorInfo | null;
+  copied: boolean;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+/**
+ * Top-level error boundary.  Wraps the entire locale layout so any uncaught
+ * React render error is caught here.
+ *
+ * Integrates with `errorLogger` for structured logging + analytics tracking.
+ * Uses `determineErrorCategory` from `errors.ts` rather than duplicating
+ * keyword-matching logic inline.
+ */
 export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
   constructor(props: ErrorBoundaryProps) {
     super(props);
@@ -64,147 +79,130 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
     return { hasError: true, error };
   }
 
-  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
     this.setState({ errorInfo });
-    logError(error, { componentStack: errorInfo.componentStack });
+    logError(error, {
+      source: "ErrorBoundary",
+      componentStack: errorInfo.componentStack,
+    });
     this.props.onError?.(error, errorInfo);
   }
 
-  handleRetry = () => {
+  // ── Actions ──────────────────────────────────────────────────────────────────
+
+  handleRetry = (): void => {
     this.setState({ hasError: false, error: null, errorInfo: null });
   };
 
-  handleGoHome = () => {
+  handleGoHome = (): void => {
     window.location.href = "/";
   };
 
-  handleGoToLogin = () => {
+  handleGoToLogin = (): void => {
     window.location.href = "/login";
   };
 
-  handleReportIssue = () => {
+  handleReportIssue = (): void => {
     window.location.href = "/contact?error=true";
   };
 
-  handleCopyErrorDetails = () => {
+  handleCopyErrorDetails = (): void => {
     const { error, errorInfo } = this.state;
-    const details = `Error: ${error?.message}\nStack: ${error?.stack}\nComponent Stack: ${errorInfo?.componentStack}`;
+    const details = [
+      `Error: ${error?.message ?? "unknown"}`,
+      `Stack: ${error?.stack ?? "–"}`,
+      `Component stack: ${errorInfo?.componentStack ?? "–"}`,
+    ].join("\n");
+
     navigator.clipboard.writeText(details).then(() => {
       this.setState({ copied: true });
-      setTimeout(() => this.setState({ copied: false }), 2000);
+      setTimeout(() => this.setState({ copied: false }), 2_000);
     });
   };
 
-  getErrorCategory = (): ErrorCategory => {
-    const { error } = this.state;
-    if (!error) return ErrorCategory.UNKNOWN;
-    if (error instanceof Error) {
-      const message = error.message.toLowerCase();
-      if (message.includes("network") || message.includes("fetch") || message.includes("timeout")) {
-        return ErrorCategory.NETWORK;
-      }
-      if (message.includes("unauthorized") || message.includes("forbidden") || message.includes("authentication")) {
-        return ErrorCategory.AUTHENTICATION;
-      }
-      if (message.includes("validation") || message.includes("invalid")) {
-        return ErrorCategory.VALIDATION;
-      }
-      if (message.includes("api") || message.includes("server")) {
-        return ErrorCategory.API;
-      }
-      return ErrorCategory.RUNTIME;
-    }
-    return ErrorCategory.UNKNOWN;
-  };
+  // ── Render ───────────────────────────────────────────────────────────────────
 
   render() {
-    if (this.state.hasError) {
-      if (this.props.fallback) {
-        return this.props.fallback;
-      }
+    if (!this.state.hasError) return this.props.children;
 
-      const errorCategory = this.getErrorCategory();
-      const errorInfo = ERROR_MESSAGES[errorCategory];
+    if (this.props.fallback) return this.props.fallback;
 
-      return (
-        <div className="min-h-screen bg-background flex items-center justify-center p-4">
-          <div className="w-full max-w-md text-center">
-            {/* Error Icon */}
-            <div className="mx-auto w-16 h-16 rounded-full bg-destructive/10 flex items-center justify-center mb-6">
-              <AlertTriangle className="w-8 h-8 text-destructive" />
-            </div>
+    const { error, errorInfo, copied } = this.state;
+    const category = error ? determineErrorCategory(error) : ErrorCategory.UNKNOWN;
+    const { title, message, action } = ERROR_MESSAGES[category];
 
-            {/* Error Title */}
-            <h1 className="text-xl font-bold text-foreground mb-2">
-              {errorInfo.title}
-            </h1>
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center p-4">
+        <div className="w-full max-w-md text-center">
+          {/* Icon */}
+          <div className="mx-auto w-16 h-16 rounded-full bg-destructive/10 flex items-center justify-center mb-6">
+            <AlertTriangle className="w-8 h-8 text-destructive" aria-hidden="true" />
+          </div>
 
-            {/* Error Message */}
-            <p className="text-sm text-muted-foreground mb-6">
-              {errorInfo.message}
-            </p>
+          {/* Title */}
+          <h1 className="text-xl font-bold text-foreground mb-2">{title}</h1>
 
-            {/* Error Details */}
-            {(this.state.error || this.state.errorInfo) && (
-              <details className="mb-6 text-left">
-                <summary className="text-xs text-muted-foreground cursor-pointer">
-                  Technical Details
-                </summary>
-                <div className="mt-2 space-y-2">
-                  {this.state.error && (
-                    <pre className="p-2 bg-muted rounded text-xs overflow-x-auto">
-                      {this.state.error.message}
-                    </pre>
-                  )}
-                  <div className="flex gap-2">
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="flex-1 text-xs"
-                      onClick={this.handleCopyErrorDetails}
-                    >
-                      {this.state.copied ? (
-                        <Check className="w-3 h-3 mr-1" />
-                      ) : (
-                        <Copy className="w-3 h-3 mr-1" />
-                      )}
-                      {this.state.copied ? "Copied!" : "Copy Details"}
-                    </Button>
-                  </div>
+          {/* Message */}
+          <p className="text-sm text-muted-foreground mb-6">{message}</p>
+
+          {/* Collapsible technical details */}
+          {(error || errorInfo) && (
+            <details className="mb-6 text-left">
+              <summary className="text-xs text-muted-foreground cursor-pointer select-none">
+                Technical Details
+              </summary>
+              <div className="mt-2 space-y-2">
+                {error && (
+                  <pre className="p-2 bg-muted rounded text-xs overflow-x-auto">
+                    {error.message}
+                  </pre>
+                )}
+                <div className="flex gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="flex-1 text-xs"
+                    onClick={this.handleCopyErrorDetails}
+                    aria-label="Copy error details to clipboard"
+                  >
+                    {copied ? (
+                      <Check className="w-3 h-3 mr-1" aria-hidden="true" />
+                    ) : (
+                      <Copy className="w-3 h-3 mr-1" aria-hidden="true" />
+                    )}
+                    {copied ? "Copied!" : "Copy Details"}
+                  </Button>
                 </div>
-              </details>
+              </div>
+            </details>
+          )}
+
+          {/* Action buttons */}
+          <div className="space-y-3">
+            {category === ErrorCategory.AUTHENTICATION ? (
+              <Button onClick={this.handleGoToLogin} className="w-full" size="lg">
+                {action}
+              </Button>
+            ) : (
+              <Button onClick={this.handleRetry} className="w-full" size="lg">
+                <RefreshCw className="w-4 h-4 mr-2" aria-hidden="true" />
+                {action}
+              </Button>
             )}
 
-            {/* Action Buttons */}
-            <div className="space-y-3">
-              {errorCategory === ErrorCategory.AUTHENTICATION ? (
-                <Button onClick={this.handleGoToLogin} className="w-full" size="lg">
-                  {errorInfo.action}
-                </Button>
-              ) : (
-                <Button onClick={this.handleRetry} className="w-full" size="lg">
-                  <RefreshCw className="w-4 h-4 mr-2" />
-                  {errorInfo.action}
-                </Button>
-              )}
-
-              <div className="flex gap-3">
-                <Button onClick={this.handleGoHome} variant="outline" className="flex-1">
-                  <Home className="w-4 h-4 mr-2" />
-                  Home
-                </Button>
-
-                <Button onClick={this.handleReportIssue} variant="ghost" className="flex-1">
-                  <Mail className="w-4 h-4 mr-2" />
-                  Report
-                </Button>
-              </div>
+            <div className="flex gap-3">
+              <Button onClick={this.handleGoHome} variant="outline" className="flex-1">
+                <Home className="w-4 h-4 mr-2" aria-hidden="true" />
+                Home
+              </Button>
+              <Button onClick={this.handleReportIssue} variant="ghost" className="flex-1">
+                <Mail className="w-4 h-4 mr-2" aria-hidden="true" />
+                Report
+              </Button>
             </div>
           </div>
         </div>
-      );
-    }
-
-    return this.props.children;
+      </div>
+    );
   }
 }

--- a/frontend/src/components/ui/MobileErrorBoundary.tsx
+++ b/frontend/src/components/ui/MobileErrorBoundary.tsx
@@ -1,23 +1,30 @@
-// filepath: frontend/src/components/ui/MobileErrorBoundary.tsx
 "use client";
 
 import { Component, ReactNode } from "react";
 import { Button } from "@/components/ui/Button";
 import { AlertTriangle, RefreshCw, Home, Mail } from "lucide-react";
+import { logError } from "@/lib/errorLogger";
+import { determineErrorCategory, ErrorCategory } from "@/lib/errors";
 
-interface ErrorBoundaryProps {
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface MobileErrorBoundaryProps {
   children: ReactNode;
   fallback?: ReactNode;
   onError?: (error: Error, errorInfo: React.ErrorInfo) => void;
 }
 
-interface ErrorBoundaryState {
+interface MobileErrorBoundaryState {
   hasError: boolean;
   error: Error | null;
 }
 
-// Mobile-specific error messages
-const MOBILE_ERROR_MESSAGES = {
+// ─── Error message map ────────────────────────────────────────────────────────
+
+const MOBILE_ERROR_MESSAGES: Record<
+  "network" | "timeout" | "offline" | "auth" | "generic",
+  { title: string; message: string; action: string }
+> = {
   network: {
     title: "Connection Lost",
     message: "Please check your internet connection and try again.",
@@ -28,156 +35,156 @@ const MOBILE_ERROR_MESSAGES = {
     message: "The server took too long to respond. Please try again.",
     action: "Try Again",
   },
+  offline: {
+    title: "You\u2019re Offline",
+    message: "Please connect to the internet to continue.",
+    action: "Go Back",
+  },
+  auth: {
+    title: "Session Expired",
+    message: "Please sign in again to continue.",
+    action: "Sign In",
+  },
   generic: {
     title: "Something Went Wrong",
     message: "An unexpected error occurred. Please try again.",
     action: "Refresh",
   },
-  offline: {
-    title: "You're Offline",
-    message: "Please connect to the internet to continue.",
-    action: "Go Back",
-  },
 };
 
+type MobileErrorType = keyof typeof MOBILE_ERROR_MESSAGES;
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
 export class MobileErrorBoundary extends Component<
-  ErrorBoundaryProps,
-  ErrorBoundaryState
+  MobileErrorBoundaryProps,
+  MobileErrorBoundaryState
 > {
-  constructor(props: ErrorBoundaryProps) {
+  constructor(props: MobileErrorBoundaryProps) {
     super(props);
     this.state = { hasError: false, error: null };
   }
 
-  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+  static getDerivedStateFromError(error: Error): MobileErrorBoundaryState {
     return { hasError: true, error };
   }
 
-  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
-    console.error("Mobile Error Boundary caught:", error, errorInfo);
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
+    logError(error, {
+      source: "MobileErrorBoundary",
+      componentStack: errorInfo.componentStack,
+    });
     this.props.onError?.(error, errorInfo);
   }
 
-  handleRetry = () => {
+  handleRetry = (): void => {
     this.setState({ hasError: false, error: null });
   };
 
-  handleGoHome = () => {
+  handleGoHome = (): void => {
     window.location.href = "/";
   };
 
-  handleReportIssue = () => {
+  handleReportIssue = (): void => {
     window.location.href = "/contact?error=true";
   };
 
-  getErrorType = (): keyof typeof MOBILE_ERROR_MESSAGES => {
+  getErrorType(): MobileErrorType {
     const { error } = this.state;
     if (!error) return "generic";
 
-    const message = error.message.toLowerCase();
-    if (message.includes("network") || message.includes("fetch")) {
-      return "network";
+    const category = determineErrorCategory(error);
+
+    switch (category) {
+      case ErrorCategory.NETWORK:
+        return error.message.toLowerCase().includes("timeout") ? "timeout" : "network";
+      case ErrorCategory.AUTHENTICATION:
+        return "auth";
+      default: {
+        const msg = error.message.toLowerCase();
+        if (msg.includes("offline")) return "offline";
+        return "generic";
+      }
     }
-    if (message.includes("timeout") || message.includes("timed out")) {
-      return "timeout";
-    }
-    if (message.includes("offline")) {
-      return "offline";
-    }
-    return "generic";
-  };
+  }
 
   render() {
-    if (this.state.hasError) {
-      if (this.props.fallback) {
-        return this.props.fallback;
-      }
+    if (!this.state.hasError) return this.props.children;
 
-      const errorType = this.getErrorType();
-      const errorInfo = MOBILE_ERROR_MESSAGES[errorType];
+    if (this.props.fallback) return this.props.fallback;
 
-      return (
-        <div className="min-h-screen bg-background flex items-center justify-center p-4">
-          <div className="w-full max-w-md text-center">
-            {/* Error Icon */}
-            <div className="mx-auto w-16 h-16 rounded-full bg-destructive/10 flex items-center justify-center mb-6">
-              <AlertTriangle className="w-8 h-8 text-destructive" />
-            </div>
+    const errorType = this.getErrorType();
+    const info = MOBILE_ERROR_MESSAGES[errorType];
 
-            {/* Error Title */}
-            <h1 className="text-xl font-bold text-foreground mb-2">
-              {errorInfo.title}
-            </h1>
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center p-4">
+        <div className="w-full max-w-md text-center">
+          {/* Icon */}
+          <div className="mx-auto w-16 h-16 rounded-full bg-destructive/10 flex items-center justify-center mb-6">
+            <AlertTriangle className="w-8 h-8 text-destructive" aria-hidden="true" />
+          </div>
 
-            {/* Error Message */}
-            <p className="text-sm text-muted-foreground mb-6">
-              {errorInfo.message}
-            </p>
+          {/* Title */}
+          <h1 className="text-xl font-bold text-foreground mb-2">{info.title}</h1>
 
-            {/* Error Code (for debugging) */}
-            {this.state.error && (
-              <details className="mb-6 text-left">
-                <summary className="text-xs text-muted-foreground cursor-pointer">
-                  Technical Details
-                </summary>
-                <pre className="mt-2 p-2 bg-muted rounded text-xs overflow-x-auto">
-                  {this.state.error.message}
-                </pre>
-              </details>
-            )}
+          {/* Message */}
+          <p className="text-sm text-muted-foreground mb-6">{info.message}</p>
 
-            {/* Action Buttons */}
-            <div className="space-y-3">
+          {/* Technical details (collapsed) */}
+          {this.state.error && (
+            <details className="mb-6 text-left">
+              <summary className="text-xs text-muted-foreground cursor-pointer select-none">
+                Technical details
+              </summary>
+              <pre className="mt-2 p-2 bg-muted rounded text-xs overflow-x-auto">
+                {this.state.error.message}
+              </pre>
+            </details>
+          )}
+
+          {/* Actions */}
+          <div className="space-y-3">
+            {errorType === "auth" ? (
               <Button
-                onClick={this.handleRetry}
+                onClick={() => { window.location.href = "/login"; }}
                 className="w-full"
                 size="lg"
               >
-                <RefreshCw className="w-4 h-4 mr-2" />
-                {errorInfo.action}
+                {info.action}
               </Button>
+            ) : (
+              <Button onClick={this.handleRetry} className="w-full" size="lg">
+                <RefreshCw className="w-4 h-4 mr-2" aria-hidden="true" />
+                {info.action}
+              </Button>
+            )}
 
-              <div className="flex gap-3">
-                <Button
-                  onClick={this.handleGoHome}
-                  variant="outline"
-                  className="flex-1"
-                >
-                  <Home className="w-4 h-4 mr-2" />
-                  Home
-                </Button>
-
-                <Button
-                  onClick={this.handleReportIssue}
-                  variant="ghost"
-                  className="flex-1"
-                >
-                  <Mail className="w-4 h-4 mr-2" />
-                  Report
-                </Button>
-              </div>
+            <div className="flex gap-3">
+              <Button onClick={this.handleGoHome} variant="outline" className="flex-1">
+                <Home className="w-4 h-4 mr-2" aria-hidden="true" />
+                Home
+              </Button>
+              <Button onClick={this.handleReportIssue} variant="ghost" className="flex-1">
+                <Mail className="w-4 h-4 mr-2" aria-hidden="true" />
+                Report
+              </Button>
             </div>
           </div>
         </div>
-      );
-    }
-
-    return this.props.children;
+      </div>
+    );
   }
 }
 
-// Hook for mobile-specific error handling
+// ─── Hook ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Thin hook for imperatively handling errors inside mobile-specific components.
+ * Logs the error via `errorLogger` and fires gtag if available.
+ */
 export function useMobileErrorHandler() {
-  const handleError = (error: Error) => {
-    console.error("[Mobile Error]:", error);
-    
-    // Track error for analytics
-    if (typeof window !== "undefined" && (window as any).gtag) {
-      (window as any).gtag("event", "exception", {
-        description: error.message,
-        fatal: false,
-      });
-    }
+  const handleError = (error: Error, metadata?: Record<string, unknown>): void => {
+    logError(error, { source: "useMobileErrorHandler", ...metadata });
   };
 
   return { handleError };

--- a/frontend/src/hooks/useErrorRecovery.ts
+++ b/frontend/src/hooks/useErrorRecovery.ts
@@ -1,0 +1,180 @@
+"use client";
+
+import { useState, useCallback, useRef } from "react";
+import {
+  ErrorCategory,
+  ErrorSeverity,
+  determineErrorCategory,
+  getRecoveryStrategy,
+  isRetryableError,
+  RecoveryStrategy,
+} from "@/lib/errors";
+import { errorLogger } from "@/lib/errorLogger";
+import { LoggedError } from "@/lib/errors";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type RecoveryStatus = "idle" | "retrying" | "succeeded" | "failed";
+
+export interface UseErrorRecoveryOptions {
+  /** Override the default recovery strategy derived from the error category. */
+  strategy?: Partial<RecoveryStrategy>;
+  /** Called when all retry attempts are exhausted without success. */
+  onExhausted?: (error: Error, attempts: number) => void;
+  /** Called when a retry attempt succeeds. */
+  onRecovered?: (attempts: number) => void;
+}
+
+export interface UseErrorRecoveryResult<T> {
+  /** Execute the async action with automatic retry / back-off on failure. */
+  execute: (action: () => Promise<T>) => Promise<T | undefined>;
+  /** The current recovery state. */
+  status: RecoveryStatus;
+  /** How many retry attempts have been made in the current run. */
+  attempts: number;
+  /** The last error that was caught (null when idle or succeeded). */
+  error: Error | null;
+  /** The logged-error entry created by the logger (null until first failure). */
+  loggedError: LoggedError | null;
+  /** Manually reset state back to idle. */
+  reset: () => void;
+  /** Whether the last error is considered retryable. */
+  isRetryable: boolean;
+}
+
+// ─── Sleep helper ─────────────────────────────────────────────────────────────
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Computes the delay for attempt `n` (0-based) given a strategy.
+ */
+function computeDelay(strategy: RecoveryStrategy, attempt: number): number {
+  if (!strategy.exponentialBackoff) return strategy.baseDelayMs;
+  const delay = strategy.baseDelayMs * Math.pow(2, attempt);
+  return Math.min(delay, strategy.maxDelayMs);
+}
+
+// ─── Hook ─────────────────────────────────────────────────────────────────────
+
+/**
+ * `useErrorRecovery` wraps an async action with automatic retry logic and
+ * exponential back-off.  It integrates with the global `errorLogger` so every
+ * failure and recovery attempt is tracked.
+ *
+ * @example
+ * ```tsx
+ * const { execute, status, error } = useErrorRecovery<Tournament[]>();
+ *
+ * const loadTournaments = () =>
+ *   execute(() => api.getTournaments());
+ * ```
+ */
+export function useErrorRecovery<T = unknown>(
+  options: UseErrorRecoveryOptions = {},
+): UseErrorRecoveryResult<T> {
+  const [status, setStatus] = useState<RecoveryStatus>("idle");
+  const [attempts, setAttempts] = useState(0);
+  const [error, setError] = useState<Error | null>(null);
+  const [loggedError, setLoggedError] = useState<LoggedError | null>(null);
+  const [isRetryable, setIsRetryable] = useState(false);
+
+  // Use a ref so the abort signal survives re-renders
+  const abortRef = useRef(false);
+
+  const reset = useCallback(() => {
+    abortRef.current = false;
+    setStatus("idle");
+    setAttempts(0);
+    setError(null);
+    setLoggedError(null);
+    setIsRetryable(false);
+  }, []);
+
+  const execute = useCallback(
+    async (action: () => Promise<T>): Promise<T | undefined> => {
+      abortRef.current = false;
+      setStatus("idle");
+      setAttempts(0);
+      setError(null);
+      setLoggedError(null);
+
+      let attempt = 0;
+
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        try {
+          const result = await action();
+
+          // Succeeded — record recovery if this was a retry
+          if (attempt > 0 && loggedError) {
+            errorLogger.recordRecoveryAttempt(loggedError.id, true);
+            options.onRecovered?.(attempt);
+          }
+
+          setStatus("succeeded");
+          setAttempts(attempt);
+          return result;
+        } catch (caught) {
+          if (abortRef.current) return undefined;
+
+          const err = caught instanceof Error ? caught : new Error(String(caught));
+          const category = determineErrorCategory(err);
+          const retryable = isRetryableError(err);
+
+          // Log on first failure
+          let logged = loggedError;
+          if (attempt === 0) {
+            logged = errorLogger.logError(err, {
+              source: "useErrorRecovery",
+              category,
+              attempt,
+            });
+            setLoggedError(logged);
+            setIsRetryable(retryable);
+          } else if (logged) {
+            errorLogger.recordRecoveryAttempt(logged.id, false);
+          }
+
+          setError(err);
+
+          // Determine strategy (explicit override > category-derived > give up)
+          const baseStrategy = getRecoveryStrategy(category);
+          if (!retryable || !baseStrategy) {
+            setStatus("failed");
+            setAttempts(attempt);
+            options.onExhausted?.(err, attempt);
+            return undefined;
+          }
+
+          const strategy: RecoveryStrategy = {
+            ...baseStrategy,
+            ...options.strategy,
+          };
+
+          attempt += 1;
+          setAttempts(attempt);
+
+          if (attempt > strategy.maxAttempts) {
+            setStatus("failed");
+            options.onExhausted?.(err, attempt - 1);
+            return undefined;
+          }
+
+          setStatus("retrying");
+
+          const delay = computeDelay(strategy, attempt - 1);
+          await sleep(delay);
+
+          if (abortRef.current) return undefined;
+        }
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [options.onExhausted, options.onRecovered, options.strategy],
+  );
+
+  return { execute, status, attempts, error, loggedError, reset, isRetryable };
+}

--- a/frontend/src/lib/errorLogger.ts
+++ b/frontend/src/lib/errorLogger.ts
@@ -6,102 +6,178 @@ import {
   determineErrorCategory,
   determineErrorSeverity,
   generateErrorId,
+  serializeError,
 } from "./errors";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface ErrorLoggerOptions {
+  maxErrors?: number;
+  storageKey?: string;
+  /** Called after every logged error — use for external sinks (Datadog, Sentry). */
+  onError?: (entry: LoggedError) => void;
+}
+
+// ─── ErrorLogger class ────────────────────────────────────────────────────────
 
 class ErrorLogger {
   private errors: LoggedError[] = [];
-  private readonly maxErrors = 100;
-  private readonly storageKey = "arenax_errors";
+  private readonly maxErrors: number;
+  private readonly storageKey: string;
+  private onError?: (entry: LoggedError) => void;
 
-  constructor() {
+  constructor(options: ErrorLoggerOptions = {}) {
+    this.maxErrors = options.maxErrors ?? 100;
+    this.storageKey = options.storageKey ?? "arenax_errors";
+    this.onError = options.onError;
+
     this.loadFromStorage();
     this.setupGlobalErrorHandlers();
   }
 
-  private loadFromStorage() {
-    if (typeof window !== "undefined") {
-      try {
-        const stored = localStorage.getItem(this.storageKey);
-        if (stored) {
-          this.errors = JSON.parse(stored);
-        }
-      } catch (e) {
-        console.error("Failed to load errors from storage:", e);
-      }
+  // ── Persistence ─────────────────────────────────────────────────────────────
+
+  private loadFromStorage(): void {
+    if (typeof window === "undefined") return;
+    try {
+      const raw = localStorage.getItem(this.storageKey);
+      if (raw) this.errors = JSON.parse(raw) as LoggedError[];
+    } catch {
+      // Storage may be unavailable (private browsing, quota exceeded, etc.)
     }
   }
 
-  private saveToStorage() {
-    if (typeof window !== "undefined") {
-      try {
-        localStorage.setItem(this.storageKey, JSON.stringify(this.errors));
-      } catch (e) {
-        console.error("Failed to save errors to storage:", e);
-      }
+  private saveToStorage(): void {
+    if (typeof window === "undefined") return;
+    try {
+      localStorage.setItem(this.storageKey, JSON.stringify(this.errors));
+    } catch {
+      // Silently ignore — storage errors must not cascade into more errors
     }
   }
 
-  private setupGlobalErrorHandlers() {
-    if (typeof window !== "undefined") {
-      // Handle uncaught errors
-      window.addEventListener("error", (event) => {
-        this.logError(event.error, {
-          event: "uncaught_error",
-          filename: event.filename,
-          lineno: event.lineno,
-          colno: event.colno,
-        });
+  // ── Global window handlers ───────────────────────────────────────────────────
+
+  private setupGlobalErrorHandlers(): void {
+    if (typeof window === "undefined") return;
+
+    window.addEventListener("error", (event) => {
+      this.logError(event.error instanceof Error ? event.error : new Error(String(event.error ?? "Unknown error")), {
+        source: "uncaught_error",
+        filename: event.filename,
+        lineno: event.lineno,
+        colno: event.colno,
       });
+    });
 
-      // Handle unhandled promise rejections
-      window.addEventListener("unhandledrejection", (event) => {
-        this.logError(
-          event.reason instanceof Error ? event.reason : new Error(String(event.reason)),
-          { event: "unhandled_promise_rejection" }
-        );
-      });
-    }
+    window.addEventListener("unhandledrejection", (event) => {
+      const error =
+        event.reason instanceof Error
+          ? event.reason
+          : new Error(String(event.reason ?? "Unhandled promise rejection"));
+      this.logError(error, { source: "unhandled_promise_rejection" });
+    });
   }
 
-  logError(
-    error: Error,
-    metadata?: Record<string, unknown>
-  ): LoggedError {
-    const loggedError: LoggedError = {
+  // ── Core logging ─────────────────────────────────────────────────────────────
+
+  logError(error: Error, metadata?: Record<string, unknown>): LoggedError {
+    const category = determineErrorCategory(error);
+    const severity = determineErrorSeverity(error);
+
+    const entry: LoggedError = {
       id: generateErrorId(),
       timestamp: Date.now(),
       message: error.message,
       stack: error.stack,
-      category: determineErrorCategory(error),
-      severity: determineErrorSeverity(error),
-      metadata,
+      category,
+      severity,
+      metadata: {
+        ...(error instanceof ArenaXError ? error.metadata : {}),
+        ...metadata,
+        serialized: serializeError(error),
+      },
+      recoveryAttempts: 0,
+      recovered: false,
     };
 
-    this.errors.unshift(loggedError);
+    // Prepend so the most recent error is at index 0
+    this.errors.unshift(entry);
 
+    // Cap to maxErrors
     if (this.errors.length > this.maxErrors) {
-      this.errors.pop();
+      this.errors.length = this.maxErrors;
     }
 
     this.saveToStorage();
+    this.emitToConsole(entry, error);
+    this.trackAnalytics(entry);
+    this.onError?.(entry);
 
-    // Log to console for development
-    console.error(`[Error] [${loggedError.category}] [${loggedError.severity}]`, error, metadata);
-
-    // Track with analytics
-    this.trackError(loggedError);
-
-    return loggedError;
+    return entry;
   }
 
-  private trackError(loggedError: LoggedError) {
-    if (typeof window !== "undefined" && (window as any).gtag) {
-      (window as any).gtag("event", "exception", {
-        description: `${loggedError.category}: ${loggedError.message}`,
-        fatal: loggedError.severity === ErrorSeverity.CRITICAL || loggedError.severity === ErrorSeverity.HIGH,
+  /**
+   * Record that a recovery attempt was made for an existing logged error.
+   */
+  recordRecoveryAttempt(id: string, succeeded: boolean): void {
+    const entry = this.errors.find((e) => e.id === id);
+    if (!entry) return;
+    entry.recoveryAttempts = (entry.recoveryAttempts ?? 0) + 1;
+    if (succeeded) entry.recovered = true;
+    this.saveToStorage();
+  }
+
+  // ── Console output ───────────────────────────────────────────────────────────
+
+  private emitToConsole(entry: LoggedError, original: Error): void {
+    const prefix = `[ArenaX Error] [${entry.category}] [${entry.severity}]`;
+
+    if (entry.severity === ErrorSeverity.CRITICAL || entry.severity === ErrorSeverity.HIGH) {
+      console.error(prefix, original, entry.metadata);
+    } else if (entry.severity === ErrorSeverity.MEDIUM) {
+      console.warn(prefix, original, entry.metadata);
+    } else {
+      console.info(prefix, original, entry.metadata);
+    }
+  }
+
+  // ── Analytics integration ────────────────────────────────────────────────────
+
+  private trackAnalytics(entry: LoggedError): void {
+    if (typeof window === "undefined") return;
+
+    const isFatal =
+      entry.severity === ErrorSeverity.CRITICAL || entry.severity === ErrorSeverity.HIGH;
+
+    // Native gtag (Google Analytics / GA4)
+    const w = window as Window & { gtag?: (...args: unknown[]) => void };
+    if (typeof w.gtag === "function") {
+      w.gtag("event", "exception", {
+        description: `[${entry.category}] ${entry.message}`,
+        fatal: isFatal,
+        error_id: entry.id,
+        error_severity: entry.severity,
+      });
+    }
+
+    // Datadog RUM (if present on window via RumProvider)
+    const dd = window as Window & {
+      DD_RUM?: {
+        addError: (error: unknown, context?: Record<string, unknown>) => void;
+      };
+    };
+    if (dd.DD_RUM?.addError) {
+      dd.DD_RUM.addError(new Error(entry.message), {
+        errorId: entry.id,
+        category: entry.category,
+        severity: entry.severity,
+        ...entry.metadata,
       });
     }
   }
+
+  // ── Query helpers ─────────────────────────────────────────────────────────────
 
   getErrors(): LoggedError[] {
     return [...this.errors];
@@ -115,24 +191,76 @@ class ErrorLogger {
     return this.errors.filter((e) => e.severity === severity);
   }
 
-  clearErrors() {
+  /** Errors logged within the last `windowMs` milliseconds. */
+  getRecentErrors(windowMs = 60_000): LoggedError[] {
+    const cutoff = Date.now() - windowMs;
+    return this.errors.filter((e) => e.timestamp >= cutoff);
+  }
+
+  /**
+   * Basic analytics summary for the monitoring dashboard.
+   */
+  getSummary(): ErrorSummary {
+    const total = this.errors.length;
+    const byCategory = Object.values(ErrorCategory).reduce<Record<string, number>>(
+      (acc, cat) => {
+        acc[cat] = this.errors.filter((e) => e.category === cat).length;
+        return acc;
+      },
+      {},
+    );
+    const bySeverity = Object.values(ErrorSeverity).reduce<Record<string, number>>(
+      (acc, sev) => {
+        acc[sev] = this.errors.filter((e) => e.severity === sev).length;
+        return acc;
+      },
+      {},
+    );
+    const recoveredCount = this.errors.filter((e) => e.recovered).length;
+    const recent = this.getRecentErrors(60_000).length;
+
+    return { total, byCategory, bySeverity, recoveredCount, recentCount: recent };
+  }
+
+  clearErrors(): void {
     this.errors = [];
     this.saveToStorage();
   }
+
+  /** Replace the external sink callback (e.g. after analytics service initialises). */
+  setOnError(cb: (entry: LoggedError) => void): void {
+    this.onError = cb;
+  }
 }
 
-// Singleton instance
+// ─── Export types ─────────────────────────────────────────────────────────────
+
+export interface ErrorSummary {
+  total: number;
+  byCategory: Record<string, number>;
+  bySeverity: Record<string, number>;
+  recoveredCount: number;
+  recentCount: number;
+}
+
+// ─── Singleton ────────────────────────────────────────────────────────────────
+
 export const errorLogger = new ErrorLogger();
 
-// Convenience functions
-export function logError(error: Error, metadata?: Record<string, unknown>) {
+// ─── Convenience helpers ──────────────────────────────────────────────────────
+
+export function logError(error: Error, metadata?: Record<string, unknown>): LoggedError {
   return errorLogger.logError(error, metadata);
 }
 
-export function getLoggedErrors() {
+export function getLoggedErrors(): LoggedError[] {
   return errorLogger.getErrors();
 }
 
-export function clearLoggedErrors() {
+export function clearLoggedErrors(): void {
   errorLogger.clearErrors();
+}
+
+export function getErrorSummary(): ErrorSummary {
+  return errorLogger.getSummary();
 }

--- a/frontend/src/lib/errors.ts
+++ b/frontend/src/lib/errors.ts
@@ -1,4 +1,5 @@
-// Error Types
+// ─── Error Severity & Category ───────────────────────────────────────────────
+
 export enum ErrorSeverity {
   LOW = "low",
   MEDIUM = "medium",
@@ -15,6 +16,8 @@ export enum ErrorCategory {
   UNKNOWN = "unknown",
 }
 
+// ─── Logged Error Shape ───────────────────────────────────────────────────────
+
 export interface LoggedError {
   id: string;
   timestamp: number;
@@ -23,9 +26,18 @@ export interface LoggedError {
   category: ErrorCategory;
   severity: ErrorSeverity;
   metadata?: Record<string, unknown>;
+  /** How many times an automatic recovery was attempted */
+  recoveryAttempts?: number;
+  /** Whether an automatic recovery succeeded */
+  recovered?: boolean;
 }
 
-// Custom Error Class
+// ─── Custom Error Classes ─────────────────────────────────────────────────────
+
+/**
+ * Base application error.  All ArenaX-specific errors should extend this class
+ * so that error boundaries and the logger can extract structured metadata.
+ */
 export class ArenaXError extends Error {
   public category: ErrorCategory;
   public severity: ErrorSeverity;
@@ -35,7 +47,7 @@ export class ArenaXError extends Error {
     message: string,
     category: ErrorCategory = ErrorCategory.UNKNOWN,
     severity: ErrorSeverity = ErrorSeverity.MEDIUM,
-    metadata?: Record<string, unknown>
+    metadata?: Record<string, unknown>,
   ) {
     super(message);
     this.name = "ArenaXError";
@@ -43,58 +55,171 @@ export class ArenaXError extends Error {
     this.severity = severity;
     this.metadata = metadata;
 
-    // Maintain proper stack trace
-    if ((Error as any).captureStackTrace) {
-      (Error as any).captureStackTrace(this, ArenaXError);
+    if ((Error as { captureStackTrace?: (t: unknown, c: unknown) => void }).captureStackTrace) {
+      (Error as { captureStackTrace: (t: unknown, c: unknown) => void }).captureStackTrace(this, ArenaXError);
     }
   }
 }
 
-// Error Utility Functions
-export function determineErrorCategory(error: Error): ErrorCategory {
-  const message = error.message.toLowerCase();
-  
-  if (error instanceof ArenaXError) {
-    return error.category;
+/** Thrown when a network request fails or times out. */
+export class NetworkError extends ArenaXError {
+  constructor(message: string, metadata?: Record<string, unknown>) {
+    super(message, ErrorCategory.NETWORK, ErrorSeverity.HIGH, metadata);
+    this.name = "NetworkError";
   }
-  
-  if (message.includes("network") || message.includes("fetch") || message.includes("timeout")) {
+}
+
+/** Thrown when the user is not authenticated or a token has expired. */
+export class AuthenticationError extends ArenaXError {
+  constructor(message: string, metadata?: Record<string, unknown>) {
+    super(message, ErrorCategory.AUTHENTICATION, ErrorSeverity.HIGH, metadata);
+    this.name = "AuthenticationError";
+  }
+}
+
+/** Thrown when user-supplied data fails validation. */
+export class ValidationError extends ArenaXError {
+  public field?: string;
+
+  constructor(
+    message: string,
+    field?: string,
+    metadata?: Record<string, unknown>,
+  ) {
+    super(message, ErrorCategory.VALIDATION, ErrorSeverity.LOW, metadata);
+    this.name = "ValidationError";
+    this.field = field;
+  }
+}
+
+/** Thrown when an API endpoint returns an error response. */
+export class ApiError extends ArenaXError {
+  public statusCode?: number;
+
+  constructor(
+    message: string,
+    statusCode?: number,
+    metadata?: Record<string, unknown>,
+  ) {
+    const severity =
+      statusCode && statusCode >= 500 ? ErrorSeverity.HIGH : ErrorSeverity.MEDIUM;
+    super(message, ErrorCategory.API, severity, metadata);
+    this.name = "ApiError";
+    this.statusCode = statusCode;
+  }
+}
+
+// ─── Recovery strategies ──────────────────────────────────────────────────────
+
+/**
+ * Describes how the error recovery system should react to a given error.
+ */
+export interface RecoveryStrategy {
+  /** Maximum number of automatic retry attempts (default: 3). */
+  maxAttempts: number;
+  /** Base delay in milliseconds between retries (default: 1 000 ms). */
+  baseDelayMs: number;
+  /** Whether to apply exponential back-off between retries (default: true). */
+  exponentialBackoff: boolean;
+  /** Maximum delay cap in milliseconds (default: 30 000 ms). */
+  maxDelayMs: number;
+}
+
+export const DEFAULT_RECOVERY_STRATEGY: RecoveryStrategy = {
+  maxAttempts: 3,
+  baseDelayMs: 1_000,
+  exponentialBackoff: true,
+  maxDelayMs: 30_000,
+};
+
+/**
+ * Returns the recommended recovery strategy for a given error category.
+ * Network and API errors are retryable; auth/validation errors are not.
+ */
+export function getRecoveryStrategy(category: ErrorCategory): RecoveryStrategy | null {
+  switch (category) {
+    case ErrorCategory.NETWORK:
+      return { maxAttempts: 3, baseDelayMs: 1_000, exponentialBackoff: true, maxDelayMs: 15_000 };
+    case ErrorCategory.API:
+      return { maxAttempts: 2, baseDelayMs: 2_000, exponentialBackoff: true, maxDelayMs: 10_000 };
+    case ErrorCategory.RUNTIME:
+      return { maxAttempts: 1, baseDelayMs: 500, exponentialBackoff: false, maxDelayMs: 500 };
+    // Authentication and Validation errors should not be auto-retried
+    case ErrorCategory.AUTHENTICATION:
+    case ErrorCategory.VALIDATION:
+    case ErrorCategory.UNKNOWN:
+    default:
+      return null;
+  }
+}
+
+// ─── Utility Functions ────────────────────────────────────────────────────────
+
+export function determineErrorCategory(error: Error): ErrorCategory {
+  if (error instanceof ArenaXError) return error.category;
+
+  const msg = error.message.toLowerCase();
+
+  if (msg.includes("network") || msg.includes("fetch") || msg.includes("timeout")) {
     return ErrorCategory.NETWORK;
   }
-  
-  if (message.includes("unauthorized") || message.includes("forbidden") || message.includes("authentication")) {
+  if (
+    msg.includes("unauthorized") ||
+    msg.includes("forbidden") ||
+    msg.includes("authentication") ||
+    msg.includes("401") ||
+    msg.includes("403")
+  ) {
     return ErrorCategory.AUTHENTICATION;
   }
-  
-  if (message.includes("validation") || message.includes("invalid")) {
+  if (msg.includes("validation") || msg.includes("invalid")) {
     return ErrorCategory.VALIDATION;
   }
-  
-  if (message.includes("api") || message.includes("server")) {
+  if (msg.includes("api") || msg.includes("server") || msg.includes("500")) {
     return ErrorCategory.API;
   }
-  
+
   return ErrorCategory.UNKNOWN;
 }
 
 export function determineErrorSeverity(error: Error): ErrorSeverity {
-  if (error instanceof ArenaXError) {
-    return error.severity;
-  }
-  
-  const message = error.message.toLowerCase();
-  
-  if (message.includes("critical") || message.includes("fatal")) {
-    return ErrorSeverity.CRITICAL;
-  }
-  
-  if (message.includes("network") || message.includes("timeout")) {
-    return ErrorSeverity.HIGH;
-  }
-  
+  if (error instanceof ArenaXError) return error.severity;
+
+  const msg = error.message.toLowerCase();
+
+  if (msg.includes("critical") || msg.includes("fatal")) return ErrorSeverity.CRITICAL;
+  if (msg.includes("network") || msg.includes("timeout")) return ErrorSeverity.HIGH;
+
   return ErrorSeverity.MEDIUM;
 }
 
+/**
+ * Returns whether an error should be considered retryable based on its category.
+ */
+export function isRetryableError(error: Error): boolean {
+  const category = determineErrorCategory(error);
+  return getRecoveryStrategy(category) !== null;
+}
+
 export function generateErrorId(): string {
-  return `${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+  return `${Date.now()}-${Math.random().toString(36).substring(2, 11)}`;
+}
+
+/**
+ * Serialises an error into a plain object safe for JSON / logging.
+ */
+export function serializeError(error: Error): Record<string, unknown> {
+  const base: Record<string, unknown> = {
+    name: error.name,
+    message: error.message,
+    stack: error.stack,
+  };
+
+  if (error instanceof ArenaXError) {
+    base.category = error.category;
+    base.severity = error.severity;
+    base.metadata = error.metadata;
+  }
+
+  return base;
 }


### PR DESCRIPTION
# Pull Request — Issue #709: Comprehensive Error Handling & Resilience

## Summary

Closes #709

This PR delivers a complete overhaul of the frontend error handling system — adding structured error types, a unified logging pipeline, granular error boundaries, async retry/recovery, an analytics-connected monitoring dashboard, and thorough test coverage.

---

## What Changed

### New files

| File | Description |
|------|-------------|
| `src/hooks/useErrorRecovery.ts` | Async retry hook with exponential back-off, integrated with `errorLogger` |
| `src/components/common/SectionErrorBoundary.tsx` | Inline boundary for individual page sections/widgets |
| `src/components/common/ErrorMonitorDashboard.tsx` | Developer/admin dashboard for viewing logged errors |
| `src/__tests__/error-boundaries.test.tsx` | Component tests for all four boundary variants |
| `src/__tests__/error-recovery.test.tsx` | Hook tests covering retry, exhaustion, and non-retryable errors |
| `ERROR_HANDLING.md` | Architecture documentation |

### Modified files

| File | What changed |
|------|-------------|
| `src/lib/errors.ts` | Added `NetworkError`, `AuthenticationError`, `ValidationError`, `ApiError` subclasses; added `getRecoveryStrategy`, `isRetryableError`, `serializeError` |
| `src/lib/errorLogger.ts` | Datadog RUM integration, `recordRecoveryAttempt`, `getSummary`, `getRecentErrors`, `setOnError` callback, structured console output by severity |
| `src/components/ui/ErrorBoundary.tsx` | Uses shared `determineErrorCategory` instead of inline keyword-matching; integrates `logError` |
| `src/components/ui/MobileErrorBoundary.tsx` | Refactored to use `determineErrorCategory`; removed duplicated logic; uses `logError` |
| `src/components/common/ErrorBoundaryWithRetry.tsx` | Replaced raw Tailwind colour classes with design-system tokens; added `logError` integration |
| `src/components/providers/ErrorProvider.tsx` | Added `getByCategory`, `getBySeverity`, `summary`, `refreshSummary` to context |
| `src/components/providers/QueryProvider.tsx` | Added `QueryCache` + `MutationCache` global error handlers — all TanStack Query errors now auto-logged |
| `src/__tests__/error-handling.test.ts` | Extended to cover new subclasses, `getRecoveryStrategy`, `isRetryableError`, `serializeError`, `errorLogger` summary/recovery |

---

## Architecture

```
ErrorBoundary (full-page)
  └─ PageErrorBoundary (per-page)
       └─ SectionErrorBoundary (per-widget, inline)
            └─ useErrorRecovery (async retry / back-off)
                 └─ errorLogger (structured logging + analytics sinks)
                      ├─ gtag / Google Analytics
                      └─ Datadog RUM (DD_RUM)
```

QueryProvider's `QueryCache` / `MutationCache` feed into `errorLogger` automatically, so every TanStack Query failure is tracked with zero per-call boilerplate.

---

## New Error Classes

```ts
new NetworkError(message)           // NETWORK / HIGH
new AuthenticationError(message)    // AUTHENTICATION / HIGH
new ValidationError(message, field) // VALIDATION / LOW
new ApiError(message, statusCode)   // API / HIGH (5xx) or MEDIUM (4xx)
```

---

## Recovery Strategies

| Category | Retryable | maxAttempts | baseDelay | Back-off |
|----------|-----------|------------|-----------|----------|
| NETWORK | ✓ | 3 | 1 000 ms | Exponential (cap 15 s) |
| API | ✓ | 2 | 2 000 ms | Exponential (cap 10 s) |
| RUNTIME | ✓ | 1 | 500 ms | None |
| AUTHENTICATION | ✗ | — | — | — |
| VALIDATION | ✗ | — | — | — |

---

## useErrorRecovery Usage

```tsx
const { execute, status, error } = useErrorRecovery<Tournament[]>({
  onExhausted: (err) => toast.error(err.message),
});

const load = useCallback(() => execute(() => api.getTournaments()), [execute]);
```

Status values: `idle` → `retrying` → `succeeded` | `failed`

---

## SectionErrorBoundary Usage

```tsx
<SectionErrorBoundary label="Match Feed">
  <MatchFeedWidget />
</SectionErrorBoundary>
```

Renders a compact inline fallback — the rest of the page stays usable.  Up to 3 retries before showing a "contact support" link.

---

## ErrorMonitorDashboard

Drop-in developer/admin component — guard with a role check before exposing in production:

```tsx
import { ErrorMonitorDashboard } from "@/components/common/ErrorMonitorDashboard";

// inside an admin-only page
<ErrorMonitorDashboard />
```

Shows: summary counts, per-category breakdown, filterable error list with expandable stack traces and recovery status.

---

## Tests

| Test file | Cases |
|-----------|-------|
| `error-handling.test.ts` | 30+ — error classes, utilities, logger, recovery strategies |
| `error-boundaries.test.tsx` | 20+ — render, catch, retry, callbacks for all 4 boundary types |
| `error-recovery.test.tsx` | 10+ — hook: success, flaky retry, exhaustion, auth/validation non-retry, reset |

Run:
```bash
npm test -- --testPathPattern="error"
```

---

## Acceptance Criteria

| Criterion | Status |
|-----------|--------|
| Boundaries catch errors | ✅ All four boundary types tested and wired into the layout |
| Logging is comprehensive | ✅ Single `errorLogger` sink — global handlers, query cache, boundaries, hook |
| Recovery works | ✅ `useErrorRecovery` with exponential back-off; `SectionErrorBoundary` inline retries |
| Testing is thorough | ✅ 60+ test cases across three test files |
| Documentation is clear | ✅ `ERROR_HANDLING.md` with architecture diagram, API reference, decision log |
| Error analytics | ✅ gtag + Datadog RUM integration in `errorLogger`; `ErrorSummary` in context |
| Error monitoring | ✅ `ErrorMonitorDashboard` component |

---

## Reviewer Notes

- `PR-issue-709.md` (this file) is listed in `.gitignore` via the `PR-*.md` pattern — it won't appear in future diffs.
- `ERROR_HANDLING.md` at `frontend/` root is committed and intended as living documentation.
- The `ErrorMonitorDashboard` should be rendered only behind an admin/role guard in production.
