### PR TITLE
fix: silent token refresh, typed API layer, lobby page, notification UX

### DIFF
--- a/frontend/e2e/token-refresh.spec.ts
+++ b/frontend/e2e/token-refresh.spec.ts
@@ -1,0 +1,238 @@
+/**
+ * E2E tests: silent token refresh on 401
+ *
+ * These tests verify that:
+ * 1. A 401 on any API call triggers a silent token refresh and retries
+ *    the original request — the user never sees a broken page.
+ * 2. When the refresh itself fails (revoked/expired), the user is logged out
+ *    and redirected to /login?reason=session_expired with a toast.
+ * 3. Multiple concurrent 401s share a single refresh call (no duplicate refreshes).
+ */
+
+import { test, expect, type Page, type Route } from "@playwright/test";
+import { mockNotificationHandlers } from "./mocks/handlers";
+
+const LOCALE = "en";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const EXPIRED_ACCESS_TOKEN = "expired-access-token";
+const NEW_ACCESS_TOKEN = "fresh-access-token";
+const NEW_REFRESH_TOKEN = "fresh-refresh-token";
+const STORED_REFRESH_TOKEN = "stored-refresh-token";
+
+/** Seed the browser with an "expired" access token + a valid refresh token */
+async function seedExpiredSession(page: Page) {
+  await page.evaluate(
+    ({ accessToken, refreshToken }: { accessToken: string; refreshToken: string }) => {
+      localStorage.setItem("auth_token", accessToken);
+      localStorage.setItem("auth_refresh_token", refreshToken);
+      localStorage.setItem("arenax_remember_me", "true");
+      localStorage.setItem(
+        "arenax_auth_user",
+        JSON.stringify({
+          id: "user-1",
+          username: "testuser",
+          email: "test@example.com",
+          isVerified: true,
+          elo: 1200,
+          createdAt: new Date().toISOString(),
+          token: accessToken,
+          refreshToken,
+        }),
+      );
+    },
+    { accessToken: EXPIRED_ACCESS_TOKEN, refreshToken: STORED_REFRESH_TOKEN },
+  );
+}
+
+/** Mock a successful token refresh */
+async function mockSuccessfulRefresh(page: Page) {
+  await page.route("**/api/auth/refresh", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        access_token: NEW_ACCESS_TOKEN,
+        refresh_token: NEW_REFRESH_TOKEN,
+        expires_in: 900,
+        token_type: "Bearer",
+      }),
+    }),
+  );
+}
+
+/** Mock a failing token refresh (401 from /auth/refresh) */
+async function mockFailedRefresh(page: Page) {
+  await page.route("**/api/auth/refresh", (route) =>
+    route.fulfill({
+      status: 401,
+      contentType: "application/json",
+      body: JSON.stringify({ error: "refresh_token_expired", message: "Refresh token has expired" }),
+    }),
+  );
+}
+
+/** Mock a profile endpoint that returns 401 the first time, then 200 on retry */
+async function mockProfileWith401ThenSuccess(page: Page) {
+  let callCount = 0;
+  await page.route("**/api/users/me", (route) => {
+    callCount += 1;
+    if (callCount === 1) {
+      return route.fulfill({
+        status: 401,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "token_expired", message: "Token has expired" }),
+      });
+    }
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        id: "user-1",
+        username: "testuser",
+        email: "test@example.com",
+        is_verified: true,
+        created_at: new Date().toISOString(),
+        elo: 1200,
+      }),
+    });
+  });
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+test.describe("Silent token refresh", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockNotificationHandlers(page);
+  });
+
+  test("401 on profile fetch triggers silent refresh and user stays logged in", async ({
+    page,
+  }) => {
+    await mockSuccessfulRefresh(page);
+    await mockProfileWith401ThenSuccess(page);
+
+    // Seed expired session
+    await page.goto(`/${LOCALE}/login`);
+    await seedExpiredSession(page);
+
+    // Navigate to a protected page that calls /api/users/me
+    await page.goto(`/${LOCALE}/dashboard`);
+
+    // The user should NOT be redirected to login
+    await expect(page).not.toHaveURL(/login/, { timeout: 8_000 });
+
+    // The new tokens should be stored
+    const storedToken = await page.evaluate(() =>
+      localStorage.getItem("auth_token"),
+    );
+    expect(storedToken).toBe(NEW_ACCESS_TOKEN);
+
+    const storedRefresh = await page.evaluate(() =>
+      localStorage.getItem("auth_refresh_token"),
+    );
+    expect(storedRefresh).toBe(NEW_REFRESH_TOKEN);
+  });
+
+  test("failed refresh logs out user and redirects to /login?reason=session_expired", async ({
+    page,
+  }) => {
+    await mockFailedRefresh(page);
+
+    // Stub profile endpoint to always return 401 (expired token, no valid refresh)
+    await page.route("**/api/users/me", (route) =>
+      route.fulfill({
+        status: 401,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "token_expired", message: "Token has expired" }),
+      }),
+    );
+
+    await page.goto(`/${LOCALE}/login`);
+    await seedExpiredSession(page);
+
+    await page.goto(`/${LOCALE}/dashboard`);
+
+    // Should redirect to login with the session_expired reason
+    await expect(page).toHaveURL(/login.*reason=session_expired/, { timeout: 10_000 });
+  });
+
+  test("session_expired toast is visible on the login page after redirect", async ({
+    page,
+  }) => {
+    // Navigate directly to login with the reason param (simulates the redirect)
+    await page.goto(`/${LOCALE}/login?reason=session_expired`);
+
+    // Toast should appear
+    await expect(
+      page.locator('[role="alert"]').filter({ hasText: /session.*expired/i }),
+    ).toBeVisible({ timeout: 6_000 });
+  });
+
+  test("parallel 401 requests share a single refresh call", async ({ page }) => {
+    let refreshCount = 0;
+
+    await page.route("**/api/auth/refresh", (route) => {
+      refreshCount += 1;
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          access_token: NEW_ACCESS_TOKEN,
+          refresh_token: NEW_REFRESH_TOKEN,
+          expires_in: 900,
+          token_type: "Bearer",
+        }),
+      });
+    });
+
+    // Two endpoints both return 401 so both will attempt refresh simultaneously
+    let notifCount = 0;
+    await page.route("**/api/notifications**", (route) => {
+      notifCount += 1;
+      if (notifCount === 1) {
+        return route.fulfill({
+          status: 401,
+          contentType: "application/json",
+          body: JSON.stringify({ error: "token_expired", message: "Token has expired" }),
+        });
+      }
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ data: [] }),
+      });
+    });
+
+    await mockProfileWith401ThenSuccess(page);
+
+    await page.goto(`/${LOCALE}/login`);
+    await seedExpiredSession(page);
+    await page.goto(`/${LOCALE}/dashboard`);
+
+    // Give time for both requests + refresh to settle
+    await page.waitForTimeout(2_000);
+
+    // The refresh endpoint should have been called at most once despite two 401s
+    expect(refreshCount).toBeLessThanOrEqual(1);
+  });
+
+  test("after successful refresh, retried request succeeds without user noticing", async ({
+    page,
+  }) => {
+    await mockSuccessfulRefresh(page);
+    await mockProfileWith401ThenSuccess(page);
+
+    await page.goto(`/${LOCALE}/login`);
+    await seedExpiredSession(page);
+    await page.goto(`/${LOCALE}/dashboard`);
+
+    // No error toasts should appear
+    const errorToast = page.locator('[role="alert"]').filter({ hasText: /error|failed|expired/i });
+    await expect(errorToast).not.toBeVisible({ timeout: 5_000 });
+
+    // User stays on the dashboard (not redirected to login)
+    await expect(page).not.toHaveURL(/login/, { timeout: 5_000 });
+  });
+});

--- a/frontend/src/app/[locale]/login/page.tsx
+++ b/frontend/src/app/[locale]/login/page.tsx
@@ -28,6 +28,21 @@ export default function LoginPage() {
   const [rememberMe, setRememberMe] = useState(false);
   const [fieldErrors, setFieldErrors] = useState<Partial<Record<keyof LoginFormData, string>>>({});
 
+  // Show a toast if the user was redirected due to an expired session
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const params = new URLSearchParams(window.location.search);
+    if (params.get("reason") === "session_expired") {
+      addToast({
+        type: "warning",
+        title: "Session expired",
+        message: "Your session has expired. Please sign in again.",
+        duration: 8000,
+      });
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   // Error toast when auth error is set
   useEffect(() => {
     if (error) {

--- a/frontend/src/app/[locale]/notifications/page.tsx
+++ b/frontend/src/app/[locale]/notifications/page.tsx
@@ -27,23 +27,19 @@ function NotificationItem({
   const { markAsRead, removeNotification } = useNotifications();
   const isRead = notification.read;
 
-  const handleClick = () => {
+  const handleMarkRead = () => {
     if (!isRead) markAsRead(notification.id);
   };
 
-  const content = (
-    <div
-      className={cn(
-        "flex flex-col gap-1 p-4 rounded-lg transition-colors cursor-pointer",
-        !isRead && "bg-primary/5"
-      )}
-      onClick={handleClick}
-      role="button"
-      tabIndex={0}
-      onKeyDown={(e) => {
-        if (e.key === "Enter" || e.key === " ") handleClick();
-      }}
-    >
+  const handleDelete = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    removeNotification(notification.id);
+  };
+
+  // Inner content — the readable part of the notification
+  const innerContent = (
+    <div className="flex flex-col gap-1 pr-10">
       <div className="flex items-start justify-between gap-2">
         <p className={cn("font-medium text-sm", !isRead && "font-semibold")}>
           {notification.title}
@@ -65,28 +61,64 @@ function NotificationItem({
     </div>
   );
 
+  // Delete button — always rendered outside any <a> to avoid nested interactives.
+  // On pointer-fine devices (mouse) it fades in on hover; on touch devices it is
+  // always visible so users don't have to hover to find it.
+  const deleteButton = (
+    <Button
+      variant="ghost"
+      size="sm"
+      className={cn(
+        "absolute top-2 right-2 h-8 w-8 p-0 transition-opacity",
+        // Always visible on coarse-pointer (touch) devices; fade in on hover for mouse
+        "opacity-100 @pointer-coarse:opacity-100",
+        "sm:opacity-0 sm:group-hover:opacity-100",
+      )}
+      onClick={handleDelete}
+      aria-label="Remove notification"
+    >
+      <Trash2 className="h-4 w-4" />
+    </Button>
+  );
+
   return (
     <div className="group relative border-b border-border/50 last:border-0">
       {notification.link ? (
-        <Link href={notification.link} className="block">
-          {content}
-        </Link>
+        // Link wraps only the readable content — delete button is a sibling
+        <>
+          <Link
+            href={notification.link}
+            className={cn(
+              "block p-4 rounded-lg transition-colors",
+              !isRead && "bg-primary/5",
+            )}
+            onClick={handleMarkRead}
+          >
+            {innerContent}
+          </Link>
+          {deleteButton}
+        </>
       ) : (
-        content
+        // No link — whole row is a div button, delete button still sits outside
+        // interactive content via absolute positioning
+        <>
+          <div
+            className={cn(
+              "p-4 rounded-lg transition-colors cursor-pointer",
+              !isRead && "bg-primary/5",
+            )}
+            role="button"
+            tabIndex={0}
+            onClick={handleMarkRead}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") handleMarkRead();
+            }}
+          >
+            {innerContent}
+          </div>
+          {deleteButton}
+        </>
       )}
-      <Button
-        variant="ghost"
-        size="sm"
-        className="absolute top-2 right-2 h-8 w-8 p-0 opacity-0 group-hover:opacity-100 transition-opacity"
-        onClick={(e) => {
-          e.preventDefault();
-          e.stopPropagation();
-          removeNotification(notification.id);
-        }}
-        aria-label="Remove notification"
-      >
-        <Trash2 className="h-4 w-4" />
-      </Button>
     </div>
   );
 }

--- a/frontend/src/app/[locale]/play/lobby/page.tsx
+++ b/frontend/src/app/[locale]/play/lobby/page.tsx
@@ -1,67 +1,366 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import PartyManager from '@/components/game/PartyManager';
-import ChatPanel from '@/components/game/ChatPanel';
-import GameSettings from '@/components/game/GameSettings';
+import { useEffect, useState, useRef, useCallback } from 'react';
+import { useSearchParams, useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { CheckCircle, Circle, Wifi, WifiOff, Users, Swords, RefreshCw } from 'lucide-react';
 import CountdownTimer from '@/components/game/CountdownTimer';
-import type { PartyPlayer } from '@/types/player';
+import { api } from '@/lib/api';
+import { useAuth } from '@/hooks/useAuth';
+import { useNotifications } from '@/contexts/NotificationContext';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface LobbyPlayer {
+  id: string;
+  username: string;
+  elo_rating: number;
+  avatar_url?: string;
+  is_ready: boolean;
+}
+
+interface LobbySession {
+  session_id: string;
+  game_mode: string;
+  status: string;
+  players: LobbyPlayer[];
+  created_at: string;
+}
+
+type PageState = 'loading' | 'ready' | 'countdown' | 'error';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function buildWsUrl(sessionId: string): string {
+  const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
+  const token =
+    localStorage.getItem('auth_token') ?? sessionStorage.getItem('auth_token');
+  const qs = token ? `?token=${encodeURIComponent(token)}` : '';
+  return `${protocol}://${window.location.host}/ws/lobby/${sessionId}${qs}`;
+}
+
+const GAME_MODE_LABELS: Record<string, string> = {
+  '1v1': '1v1 Duel',
+  '2v2': '2v2 Team Battle',
+  'battle-royale': 'Battle Royale',
+  ranked: 'Ranked Match',
+  casual: 'Casual Play',
+  custom: 'Custom Game',
+};
+
+// ─── Component ────────────────────────────────────────────────────────────────
 
 export default function LobbyPage() {
-  const [sessionId, setSessionId] = useState<string>('');
-  const [players, setPlayers] = useState<PartyPlayer[]>([]);
-  const [countdown, setCountdown] = useState<number | null>(null);
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const { user } = useAuth();
+  const { addToast } = useNotifications();
+
+  const sessionId = searchParams.get('session') ?? '';
+
+  const [pageState, setPageState] = useState<PageState>('loading');
+  const [session, setSession] = useState<LobbySession | null>(null);
+  const [errorMessage, setErrorMessage] = useState('');
+  const [isReady, setIsReady] = useState(false);
+  const [readyingUp, setReadyingUp] = useState(false);
+  const [wsConnected, setWsConnected] = useState(false);
+
+  const wsRef = useRef<WebSocket | null>(null);
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const retryRef = useRef(0);
+  const closedRef = useRef(false);
+
+  // ── Fetch initial session data ──────────────────────────────────────────────
+
+  const fetchSession = useCallback(async () => {
+    if (!sessionId) {
+      setErrorMessage('No session ID provided. Please start matchmaking again.');
+      setPageState('error');
+      return;
+    }
+
+    try {
+      const data = await api.getMatchSession(sessionId);
+      setSession(data);
+      setPageState('ready');
+
+      // Sync own ready state from server
+      if (user?.id) {
+        const self = data.players.find((p) => p.id === user.id);
+        if (self) setIsReady(self.is_ready);
+      }
+    } catch {
+      setErrorMessage(
+        'This session is invalid or has already expired. Start a new match to try again.',
+      );
+      setPageState('error');
+    }
+  }, [sessionId, user?.id]);
 
   useEffect(() => {
-    const params = new URLSearchParams(window.location.search);
-    const session = params.get('session');
-    if (session) {
-      setSessionId(session);
-      // Mock players - replace with actual API call
-      setPlayers([
-        { id: '1', username: 'Player1', isReady: true, isHost: true },
-        { id: '2', username: 'Player2', isReady: false, isHost: false },
-      ]);
-    }
-  }, []);
+    fetchSession();
+  }, [fetchSession]);
 
-  const handleStartGame = () => {
-    setCountdown(5);
+  // ── WebSocket connection ────────────────────────────────────────────────────
+
+  const connectWs = useCallback(() => {
+    if (!sessionId || closedRef.current) return;
+
+    try {
+      const ws = new WebSocket(buildWsUrl(sessionId));
+      wsRef.current = ws;
+
+      ws.onopen = () => {
+        setWsConnected(true);
+        retryRef.current = 0;
+      };
+
+      ws.onmessage = (event) => {
+        try {
+          const msg = JSON.parse(event.data as string) as {
+            type: string;
+            players?: LobbyPlayer[];
+            player_id?: string;
+            is_ready?: boolean;
+          };
+
+          if (msg.type === 'ping') {
+            ws.send(JSON.stringify({ type: 'pong' }));
+            return;
+          }
+
+          if (msg.type === 'lobby_update' && msg.players) {
+            setSession((prev) =>
+              prev ? { ...prev, players: msg.players! } : prev,
+            );
+            // Sync own ready flag
+            if (user?.id) {
+              const self = msg.players.find((p) => p.id === user.id);
+              if (self) setIsReady(self.is_ready);
+            }
+          }
+
+          if (msg.type === 'player_ready' && msg.player_id) {
+            setSession((prev) => {
+              if (!prev) return prev;
+              return {
+                ...prev,
+                players: prev.players.map((p) =>
+                  p.id === msg.player_id ? { ...p, is_ready: msg.is_ready ?? true } : p,
+                ),
+              };
+            });
+          }
+
+          if (msg.type === 'game_starting') {
+            setPageState('countdown');
+          }
+        } catch {
+          // Ignore malformed messages
+        }
+      };
+
+      ws.onclose = () => {
+        setWsConnected(false);
+        if (!closedRef.current) {
+          const delay = Math.min(10_000, 1_000 * 2 ** retryRef.current);
+          retryRef.current += 1;
+          reconnectTimerRef.current = setTimeout(connectWs, delay);
+        }
+      };
+
+      ws.onerror = () => ws.close();
+    } catch {
+      // WebSocket constructor can throw in some environments
+    }
+  }, [sessionId, user?.id]);
+
+  useEffect(() => {
+    if (pageState !== 'ready') return;
+
+    closedRef.current = false;
+    connectWs();
+
+    return () => {
+      closedRef.current = true;
+      if (reconnectTimerRef.current) clearTimeout(reconnectTimerRef.current);
+      wsRef.current?.close();
+    };
+    // connectWs is stable because its deps (sessionId, user.id) don't change
+    // while the lobby is mounted
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pageState]);
+
+  // ── Ready-up ────────────────────────────────────────────────────────────────
+
+  const handleReadyUp = async () => {
+    if (readyingUp) return;
+    setReadyingUp(true);
+    try {
+      await api.readyUp(sessionId);
+      setIsReady(true);
+      // Optimistically update own player card
+      if (user?.id) {
+        setSession((prev) => {
+          if (!prev) return prev;
+          return {
+            ...prev,
+            players: prev.players.map((p) =>
+              p.id === user.id ? { ...p, is_ready: true } : p,
+            ),
+          };
+        });
+      }
+    } catch {
+      addToast({
+        type: 'error',
+        title: 'Ready-up failed',
+        message: 'Could not mark you as ready. Please try again.',
+        duration: 4000,
+      });
+    } finally {
+      setReadyingUp(false);
+    }
   };
+
+  // ── Countdown completion ────────────────────────────────────────────────────
 
   const handleCountdownComplete = () => {
-    // Navigate to game session
-    window.location.href = `/game/${sessionId}`;
+    router.push(`/game/${sessionId}`);
   };
+
+  // ── Renders ─────────────────────────────────────────────────────────────────
+
+  if (pageState === 'countdown') {
+    return <CountdownTimer seconds={5} onComplete={handleCountdownComplete} />;
+  }
+
+  if (pageState === 'loading') {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-gray-900 via-purple-900 to-gray-900 flex items-center justify-center">
+        <div className="text-center">
+          <div className="w-16 h-16 mx-auto rounded-full border-4 border-purple-500 border-t-transparent animate-spin mb-4" />
+          <p className="text-foreground/80">Loading lobby…</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (pageState === 'error') {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-gray-900 via-purple-900 to-gray-900 flex items-center justify-center">
+        <div className="bg-white/10 backdrop-blur-lg rounded-2xl p-10 border border-white/20 max-w-md w-full mx-4 text-center">
+          <Swords className="w-14 h-14 mx-auto text-red-400 mb-4" />
+          <h2 className="text-2xl font-bold text-white mb-3">Session Not Found</h2>
+          <p className="text-foreground/70 mb-8">{errorMessage}</p>
+          <Link
+            href="/play"
+            className="inline-flex items-center gap-2 px-6 py-3 bg-purple-600 hover:bg-purple-700 text-white rounded-xl font-semibold transition-colors"
+          >
+            <RefreshCw className="w-4 h-4" />
+            Find New Match
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const allReady = session!.players.length > 0 && session!.players.every((p) => p.is_ready);
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-gray-900 via-purple-900 to-gray-900">
-      <div className="container mx-auto px-4 py-8">
+      <div className="container mx-auto px-4 py-8 max-w-3xl">
+
+        {/* Header */}
         <div className="text-center mb-8">
-          <h1 className="text-4xl font-bold text-white mb-2">Game Lobby</h1>
-          <p className="text-foreground/80">Session: {sessionId}</p>
+          <h1 className="text-4xl font-bold text-white mb-1">Game Lobby</h1>
+          <p className="text-foreground/60 text-sm">
+            {GAME_MODE_LABELS[session!.game_mode] ?? session!.game_mode}
+          </p>
+          <div className="flex items-center justify-center gap-2 mt-2">
+            {wsConnected ? (
+              <Wifi className="w-4 h-4 text-emerald-400" />
+            ) : (
+              <WifiOff className="w-4 h-4 text-amber-400 animate-pulse" />
+            )}
+            <span className={`text-xs ${wsConnected ? 'text-emerald-400' : 'text-amber-400'}`}>
+              {wsConnected ? 'Live' : 'Reconnecting…'}
+            </span>
+          </div>
         </div>
 
-        {countdown ? (
-          <CountdownTimer
-            seconds={countdown}
-            onComplete={handleCountdownComplete}
-          />
-        ) : (
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-            <div className="lg:col-span-2">
-              <PartyManager
-                players={players}
-                maxPlayers={4}
-                onStartGame={handleStartGame}
-              />
-            </div>
-            <div className="space-y-6">
-              <GameSettings />
-              <ChatPanel roomId={sessionId} />
-            </div>
+        {/* Players */}
+        <div className="bg-white/5 backdrop-blur-lg rounded-2xl border border-white/10 p-6 mb-6">
+          <div className="flex items-center gap-2 mb-5">
+            <Users className="w-5 h-5 text-purple-400" />
+            <h2 className="text-lg font-semibold text-white">
+              Players ({session!.players.length})
+            </h2>
           </div>
-        )}
+
+          <div className="space-y-3">
+            {session!.players.map((player) => (
+              <div
+                key={player.id}
+                className="flex items-center justify-between bg-white/5 rounded-xl px-4 py-3 border border-white/5"
+              >
+                <div className="flex items-center gap-3">
+                  <div className="w-9 h-9 rounded-full bg-gradient-to-br from-purple-500 to-pink-500 flex items-center justify-center text-white font-bold text-sm">
+                    {player.username[0]?.toUpperCase()}
+                  </div>
+                  <div>
+                    <p className="text-white font-medium text-sm">
+                      {player.username}
+                      {player.id === user?.id && (
+                        <span className="ml-2 text-xs text-purple-400">(you)</span>
+                      )}
+                    </p>
+                    <p className="text-foreground/50 text-xs">ELO {player.elo_rating}</p>
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  {player.is_ready ? (
+                    <>
+                      <CheckCircle className="w-5 h-5 text-emerald-400" />
+                      <span className="text-emerald-400 text-sm font-medium">Ready</span>
+                    </>
+                  ) : (
+                    <>
+                      <Circle className="w-5 h-5 text-foreground/30" />
+                      <span className="text-foreground/40 text-sm">Waiting…</span>
+                    </>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Actions */}
+        <div className="flex flex-col sm:flex-row gap-3">
+          {!isReady ? (
+            <button
+              onClick={handleReadyUp}
+              disabled={readyingUp}
+              className="flex-1 px-6 py-4 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 text-white rounded-xl font-bold text-lg transition-colors"
+            >
+              {readyingUp ? 'Marking ready…' : '✓ Ready Up'}
+            </button>
+          ) : (
+            <div className="flex-1 px-6 py-4 bg-emerald-600/20 border border-emerald-500/30 text-emerald-400 rounded-xl font-bold text-lg text-center">
+              ✓ You are ready
+              {allReady ? ' — starting soon!' : ' — waiting for others…'}
+            </div>
+          )}
+
+          <Link
+            href="/play"
+            className="px-6 py-4 bg-white/5 hover:bg-white/10 border border-white/10 text-foreground/70 rounded-xl font-semibold text-center transition-colors"
+          >
+            Leave
+          </Link>
+        </div>
+
       </div>
     </div>
   );

--- a/frontend/src/hooks/useAuth.tsx
+++ b/frontend/src/hooks/useAuth.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, createContext, useContext, useCallback } from "react";
+import { useState, createContext, useContext, useCallback, useEffect, useRef } from "react";
+import { useRouter } from "next/navigation";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { AuthUser, LoginRequest, RegisterRequest } from "@/types";
 import { api } from "@/lib/api";
@@ -16,6 +17,10 @@ interface AuthContextType {
   clearError: () => void;
   verifyEmail: (token: string) => Promise<void>;
   resendVerificationEmail: (email: string) => Promise<void>;
+  /** Exposed so components can manually trigger a token refresh if needed. */
+  refreshAccessToken: () => Promise<string>;
+  /** True while a token refresh is in flight. */
+  isRefreshing: boolean;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -90,10 +95,14 @@ export const useAuth = () => {
 };
 
 export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
+  const router = useRouter();
   const queryClient = useQueryClient();
   const [hasToken, setHasToken] = useState(() => !!getStoredToken());
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  // Track isRefreshing via a ref so the stable callback can read it
+  const isRefreshingRef = useRef(false);
 
   const clearError = useCallback(() => setError(null), []);
 
@@ -241,9 +250,29 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     queryClient.removeQueries({ queryKey: AUTH_PROFILE_QUERY_KEY });
   }, [queryClient]);
 
+  const refreshAccessToken = useCallback(async (): Promise<string> => {
+    isRefreshingRef.current = true;
+    setIsRefreshing(true);
+    try {
+      return await api.refreshAccessToken();
+    } finally {
+      isRefreshingRef.current = false;
+      setIsRefreshing(false);
+    }
+  }, []);
+
+  // Register the auth-failure handler with ApiClient once on mount so it can
+  // trigger logout + redirect when a refresh attempt fails inside request().
+  useEffect(() => {
+    api.setOnAuthFailure(() => {
+      logout();
+      router.push("/login?reason=session_expired");
+    });
+  }, [logout, router]);
+
   return (
     <AuthContext.Provider
-      value={{ user, login, register, logout, loading, error, clearError, verifyEmail, resendVerificationEmail }}
+      value={{ user, login, register, logout, loading, error, clearError, verifyEmail, resendVerificationEmail, refreshAccessToken, isRefreshing }}
     >
       {children}
     </AuthContext.Provider>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,22 +1,122 @@
 import { ApiResponse, ApiError } from "../types";
+import {
+  Tournament,
+  CreateTournamentRequest,
+  TournamentFilters,
+} from "../types/tournament";
+import {
+  Match,
+  MatchFilters,
+  ReportScoreRequest,
+} from "../types/match";
+import {
+  Proposal,
+  CreateProposalDto,
+} from "../types/governance";
+import {
+  Dispute,
+  ResolveDisputePayload,
+  AuditLog,
+  AuditLogFilters,
+  PaginatedAuditLogs,
+  KycReview,
+  KycFilters,
+  ProcessKycPayload,
+} from "../types/admin";
 import { AuthApiError } from "./authErrors";
+
+const TOKEN_KEY = "auth_token";
+const REFRESH_TOKEN_KEY = "auth_refresh_token";
+
+function getStoredToken(): string | null {
+  if (typeof window === "undefined") return null;
+  return localStorage.getItem(TOKEN_KEY) ?? sessionStorage.getItem(TOKEN_KEY);
+}
+
+function getStoredRefreshToken(): string | null {
+  if (typeof window === "undefined") return null;
+  return (
+    localStorage.getItem(REFRESH_TOKEN_KEY) ??
+    sessionStorage.getItem(REFRESH_TOKEN_KEY)
+  );
+}
+
+function updateStoredTokens(accessToken: string, refreshToken: string): void {
+  if (typeof window === "undefined") return;
+  // Preserve the storage location (local vs session) the user originally chose
+  const inLocal = !!localStorage.getItem(TOKEN_KEY);
+  const storage = inLocal ? localStorage : sessionStorage;
+  storage.setItem(TOKEN_KEY, accessToken);
+  storage.setItem(REFRESH_TOKEN_KEY, refreshToken);
+}
 
 class ApiClient {
   private baseURL: string;
+
+  // Shared in-flight refresh promise so parallel requests all await the same call
+  private refreshPromise: Promise<string> | null = null;
+  public isRefreshing = false;
+
+  // Callback set by useAuth so the client can trigger logout + redirect
+  private onAuthFailure?: () => void;
 
   constructor(baseURL: string = "/api") {
     this.baseURL = baseURL;
   }
 
+  /** Called once by AuthProvider so the client knows how to log the user out. */
+  setOnAuthFailure(callback: () => void): void {
+    this.onAuthFailure = callback;
+  }
+
+  /**
+   * Refresh the access token using the stored refresh token.
+   * Multiple concurrent callers share the same promise so only one HTTP
+   * request is made regardless of how many 401s fire simultaneously.
+   */
+  async refreshAccessToken(): Promise<string> {
+    if (this.refreshPromise) return this.refreshPromise;
+
+    this.isRefreshing = true;
+    this.refreshPromise = (async () => {
+      const refreshToken = getStoredRefreshToken();
+      if (!refreshToken) throw new Error("No refresh token available");
+
+      const url = `${this.baseURL}/auth/refresh`;
+      const response = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ refresh_token: refreshToken }),
+      });
+
+      if (!response.ok) {
+        throw new Error("Refresh failed");
+      }
+
+      const data = await response.json() as {
+        access_token: string;
+        refresh_token: string;
+      };
+
+      updateStoredTokens(data.access_token, data.refresh_token);
+      return data.access_token;
+    })()
+      .finally(() => {
+        this.isRefreshing = false;
+        this.refreshPromise = null;
+      });
+
+    return this.refreshPromise;
+  }
+
   private async request<T>(
     endpoint: string,
     options: RequestInit = {},
+    _isRetry = false,
   ): Promise<T> {
     const url = `${this.baseURL}${endpoint}`;
 
-    // Add authorization header if token exists (localStorage or sessionStorage)
-    const token =
-      localStorage.getItem("auth_token") ?? sessionStorage.getItem("auth_token");
+    const token = getStoredToken();
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
       ...(options.headers as Record<string, string>),
@@ -26,10 +126,20 @@ class ApiClient {
       headers.Authorization = `Bearer ${token}`;
     }
 
-    const response = await fetch(url, {
-      ...options,
-      headers,
-    });
+    const response = await fetch(url, { ...options, headers });
+
+    // Intercept 401 — attempt a silent token refresh and retry once
+    if (response.status === 401 && !_isRetry) {
+      try {
+        await this.refreshAccessToken();
+      } catch {
+        // Refresh itself failed — session is unrecoverable
+        this.onAuthFailure?.();
+        throw new Error("SESSION_EXPIRED");
+      }
+      // Retry the original request with the new token
+      return this.request<T>(endpoint, options, true);
+    }
 
     if (!response.ok) {
       const errorData: ApiError = await response.json().catch(() => ({
@@ -45,7 +155,10 @@ class ApiClient {
   }
 
   // Auth endpoints — backend returns { user, tokens } directly (no .data wrapper)
-  private async authRequest<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
+  private async authRequest<T>(
+    endpoint: string,
+    options: RequestInit = {},
+  ): Promise<T> {
     const url = `${this.baseURL}${endpoint}`;
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
@@ -61,10 +174,34 @@ class ApiClient {
       const code =
         (json as { error?: { code?: string } })?.error?.code ??
         (json as { code?: string })?.code ??
-        'UNKNOWN';
+        "UNKNOWN";
       throw new AuthApiError(message, code);
     }
     return json as T;
+  }
+
+  /** Fetch the session detail used by the lobby page. */
+  async getMatchSession(sessionId: string): Promise<{
+    session_id: string;
+    game_mode: string;
+    status: string;
+    players: Array<{
+      id: string;
+      username: string;
+      elo_rating: number;
+      avatar_url?: string;
+      is_ready: boolean;
+    }>;
+    created_at: string;
+  }> {
+    return this.request(`/matchmaking/sessions/${sessionId}`);
+  }
+
+  /** Mark the current user as ready in a lobby session. */
+  async readyUp(sessionId: string): Promise<{ success: boolean }> {
+    return this.request(`/matchmaking/sessions/${sessionId}/ready`, {
+      method: "POST",
+    });
   }
 
   async login(credentials: { email: string; password: string }) {
@@ -111,40 +248,44 @@ class ApiClient {
   }
 
   // Tournament endpoints
-  async getTournaments(params?: Record<string, any>) {
-    const queryString = params ? "?" + new URLSearchParams(params) : "";
-    return this.request(`/tournaments${queryString}`);
+  async getTournaments(params?: TournamentFilters): Promise<Tournament[]> {
+    const queryString = params
+      ? "?" + new URLSearchParams(params as Record<string, string>)
+      : "";
+    return this.request<Tournament[]>(`/tournaments${queryString}`);
   }
 
-  async getTournament(id: string) {
-    return this.request(`/tournaments/${id}`);
+  async getTournament(id: string): Promise<Tournament> {
+    return this.request<Tournament>(`/tournaments/${id}`);
   }
 
-  async createTournament(tournament: any) {
-    return this.request("/tournaments", {
+  async createTournament(tournament: CreateTournamentRequest): Promise<Tournament> {
+    return this.request<Tournament>("/tournaments", {
       method: "POST",
       body: JSON.stringify(tournament),
     });
   }
 
-  async joinTournament(id: string) {
-    return this.request(`/tournaments/${id}/register`, {
+  async joinTournament(id: string): Promise<{ message: string }> {
+    return this.request<{ message: string }>(`/tournaments/${id}/register`, {
       method: "POST",
     });
   }
 
   // Match endpoints
-  async getMatches(params?: Record<string, any>) {
-    const queryString = params ? "?" + new URLSearchParams(params) : "";
-    return this.request(`/matches${queryString}`);
+  async getMatches(params?: MatchFilters): Promise<Match[]> {
+    const queryString = params
+      ? "?" + new URLSearchParams(params as Record<string, string>)
+      : "";
+    return this.request<Match[]>(`/matches${queryString}`);
   }
 
-  async getMatch(id: string) {
-    return this.request(`/matches/${id}`);
+  async getMatch(id: string): Promise<Match> {
+    return this.request<Match>(`/matches/${id}`);
   }
 
-  async reportMatchScore(id: string, result: any) {
-    return this.request(`/matches/${id}/report`, {
+  async reportMatchScore(id: string, result: ReportScoreRequest): Promise<{ message: string }> {
+    return this.request<{ message: string }>(`/matches/${id}/report`, {
       method: "POST",
       body: JSON.stringify(result),
     });
@@ -207,51 +348,51 @@ class ApiClient {
   }
 
   // Governance endpoints
-  async getProposals(): Promise<any[]> {
+  async getProposals(): Promise<Proposal[]> {
     try {
-      return await this.request<any[]>("/governance");
+      return await this.request<Proposal[]>("/governance");
     } catch {
       return [];
     }
   }
 
-  async getProposal(id: string): Promise<any> {
-    return this.request<any>(`/governance/${id}`);
+  async getProposal(id: string): Promise<Proposal> {
+    return this.request<Proposal>(`/governance/${id}`);
   }
 
-  async createProposal(data: any) {
-    return this.request("/governance", {
+  async createProposal(data: CreateProposalDto): Promise<Proposal> {
+    return this.request<Proposal>("/governance", {
       method: "POST",
       body: JSON.stringify(data),
     });
   }
 
-  async startVoting(id: string) {
-    return this.request(`/governance/${id}/start-voting`, {
+  async startVoting(id: string): Promise<{ message: string }> {
+    return this.request<{ message: string }>(`/governance/${id}/start-voting`, {
       method: "POST",
     });
   }
 
-  async voteOnProposal(id: string, signature?: string) {
-    return this.request(`/governance/${id}/vote`, {
+  async voteOnProposal(id: string, signature?: string): Promise<{ message: string }> {
+    return this.request<{ message: string }>(`/governance/${id}/vote`, {
       method: "POST",
       body: JSON.stringify({ signature }),
     });
   }
 
-  async executeProposal(id: string) {
-    return this.request(`/governance/${id}/execute`, {
+  async executeProposal(id: string): Promise<{ message: string }> {
+    return this.request<{ message: string }>(`/governance/${id}/execute`, {
       method: "POST",
     });
   }
 
   // Admin/Dispute endpoints
-  async getDisputes() {
-    return this.request("/admin/disputes");
+  async getDisputes(): Promise<Dispute[]> {
+    return this.request<Dispute[]>("/admin/disputes");
   }
 
-  async resolveDispute(id: string, data: { status: string; resolution: string; winnerOverrideId?: string }) {
-    return this.request(`/admin/disputes/${id}/resolve`, {
+  async resolveDispute(id: string, data: ResolveDisputePayload): Promise<{ message: string }> {
+    return this.request<{ message: string }>(`/admin/disputes/${id}/resolve`, {
       method: "POST",
       body: JSON.stringify(data),
     });
@@ -265,22 +406,26 @@ class ApiClient {
     }
   }
 
-  async getAuditLogs(params?: Record<string, any>) {
-    const queryString = params ? "?" + new URLSearchParams(params) : "";
-    return this.request(`/admin/audit-logs${queryString}`);
+  async getAuditLogs(params?: AuditLogFilters): Promise<PaginatedAuditLogs> {
+    const queryString = params
+      ? "?" + new URLSearchParams(params as Record<string, string>)
+      : "";
+    return this.request<PaginatedAuditLogs>(`/admin/audit-logs${queryString}`);
   }
 
-  async getKycReviews(params?: Record<string, any>) {
-    const queryString = params ? "?" + new URLSearchParams(params) : "";
-    return this.request(`/admin/kyc${queryString}`);
+  async getKycReviews(params?: KycFilters): Promise<KycReview[]> {
+    const queryString = params
+      ? "?" + new URLSearchParams(params as Record<string, string>)
+      : "";
+    return this.request<KycReview[]>(`/admin/kyc${queryString}`);
   }
 
-  async getKycReview(id: string) {
-    return this.request(`/admin/kyc/${id}`);
+  async getKycReview(id: string): Promise<KycReview> {
+    return this.request<KycReview>(`/admin/kyc/${id}`);
   }
 
-  async processKycReview(id: string, data: { status: string; notes?: string }) {
-    return this.request(`/admin/kyc/${id}/process`, {
+  async processKycReview(id: string, data: ProcessKycPayload): Promise<{ message: string }> {
+    return this.request<{ message: string }>(`/admin/kyc/${id}/process`, {
       method: "POST",
       body: JSON.stringify(data),
     });

--- a/frontend/src/types/admin.ts
+++ b/frontend/src/types/admin.ts
@@ -70,3 +70,48 @@ export interface GovernanceProposal {
   targetContract: string;
   _count: { votes: number };
 }
+
+// ─── Audit log ────────────────────────────────────────────────────────────────
+
+export interface AuditLog {
+  id: string;
+  adminId: string;
+  action: string;
+  targetType: string;
+  targetId: string;
+  details?: Record<string, unknown>;
+  ipAddress?: string;
+  requestId?: string;
+  createdAt: string;
+}
+
+export interface AuditLogFilters {
+  adminId?: string;
+  action?: string;
+  targetType?: string;
+  targetId?: string;
+  from?: string;
+  to?: string;
+  page?: number;
+  limit?: number;
+}
+
+export interface PaginatedAuditLogs {
+  data: AuditLog[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
+// ─── KYC process ─────────────────────────────────────────────────────────────
+
+export interface ProcessKycPayload {
+  status: KycStatus;
+  notes?: string;
+}
+
+export interface KycFilters {
+  status?: KycStatus;
+  page?: number;
+  limit?: number;
+}

--- a/frontend/src/types/match.ts
+++ b/frontend/src/types/match.ts
@@ -45,6 +45,13 @@ export interface MatchFilters {
   limit?: number;
 }
 
+export interface ReportScoreRequest {
+  score: number;
+  opponentScore: number;
+  proofUrl?: string;
+  telemetryData?: Record<string, unknown>;
+}
+
 // Enhanced types for detailed match view
 export interface MatchRound {
   roundNumber: number;


### PR DESCRIPTION
closes #718 
closes #726 
closes #728 
closes #738 
## Summary

### Silent token refresh (Closes #718)
- ApiClient.request() intercepts 401s, calls refreshAccessToken(), retries once
- Shared refreshPromise deduplicates concurrent 401s — one HTTP call regardless
- Failed refresh triggers onAuthFailure() → logout + redirect to /login?reason=session_expired
- useAuth exposes refreshAccessToken() and isRefreshing flag
- Login page shows warning toast on ?reason=session_expired
- Playwright E2E tests: silent retry, failed-refresh redirect, toast, parallel dedup

### Lobby page (Closes #726)
- /play/lobby was 404 after matchmaking — now a real page
- Reads ?session= via useSearchParams(), fetches GET /api/matchmaking/sessions/:id
- WebSocket /ws/lobby/:id for live ready-state updates with backoff reconnect
- Displays game mode, players with ELO, Ready Up button, countdown timer
- Invalid/expired session shows error state with Find New Match CTA

### Typed API layer (Closes #728)
- Zero any types remain in api.ts
- Added AuditLog, AuditLogFilters, PaginatedAuditLogs, ProcessKycPayload, KycFilters to types/admin.ts
- Added ReportScoreRequest to types/match.ts
- tsconfig.json already has "strict": true

### Notification delete button (Closes #728)
- Delete button is now a sibling of <Link>, not nested inside it
- Always visible on touch devices; fades in on hover for mouse
- Separate tab stops for keyboard navigation
