### PR TITLE
fix(frontend): authenticate notification WebSocket via first message …

### DIFF
--- a/frontend/src/__tests__/notification-websocket-auth.test.tsx
+++ b/frontend/src/__tests__/notification-websocket-auth.test.tsx
@@ -1,0 +1,148 @@
+import React from "react";
+import { act, render } from "@testing-library/react";
+import { NotificationProvider } from "@/contexts/NotificationContext";
+
+jest.mock("@/hooks/useAuth", () => ({
+  useAuth: () => ({ user: { id: "user-1" } }),
+}));
+
+jest.mock("@/lib/api", () => ({
+  api: {
+    getNotifications: jest.fn().mockResolvedValue([]),
+    markNotificationRead: jest.fn().mockResolvedValue(undefined),
+    markAllNotificationsRead: jest.fn().mockResolvedValue(undefined),
+    deleteNotification: jest.fn().mockResolvedValue(undefined),
+    createNotification: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+
+  url: string;
+  sent: string[] = [];
+  closed = false;
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onclose: ((event: { code: number }) => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  constructor(url: string) {
+    this.url = url;
+    MockWebSocket.instances.push(this);
+  }
+
+  send(data: string) {
+    this.sent.push(data);
+  }
+
+  // Does not fire onclose synchronously — tests dispatch close events
+  // themselves, mirroring the async close of a real WebSocket.
+  close() {
+    this.closed = true;
+  }
+}
+
+const renderProvider = async () => {
+  render(
+    <NotificationProvider>
+      <div />
+    </NotificationProvider>
+  );
+  // Flush the initial refreshNotifications() call
+  await act(async () => {});
+  return MockWebSocket.instances[0];
+};
+
+describe("NotificationContext WebSocket auth", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    MockWebSocket.instances = [];
+    (global as unknown as { WebSocket: typeof MockWebSocket }).WebSocket =
+      MockWebSocket;
+    localStorage.clear();
+    sessionStorage.clear();
+    localStorage.setItem("auth_token", "test-jwt-token");
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("connects without the token in the URL", async () => {
+    const socket = await renderProvider();
+
+    expect(socket).toBeDefined();
+    expect(socket.url).toContain("/ws/notifications");
+    expect(socket.url).not.toContain("token");
+    expect(socket.url).not.toContain("test-jwt-token");
+  });
+
+  it("sends an auth message as the first message after the socket opens", async () => {
+    const socket = await renderProvider();
+
+    act(() => {
+      socket.onopen?.();
+    });
+
+    expect(socket.sent.length).toBeGreaterThan(0);
+    expect(JSON.parse(socket.sent[0])).toEqual({
+      type: "auth",
+      token: "test-jwt-token",
+    });
+  });
+
+  it("closes the socket and stops reconnecting when auth is rejected", async () => {
+    const socket = await renderProvider();
+
+    act(() => {
+      socket.onopen?.();
+      socket.onmessage?.({ data: JSON.stringify({ type: "auth_error" }) });
+    });
+
+    expect(socket.closed).toBe(true);
+
+    act(() => {
+      socket.onclose?.({ code: 1000 });
+      jest.advanceTimersByTime(30_000);
+    });
+
+    expect(MockWebSocket.instances).toHaveLength(1);
+  });
+
+  it("does not reconnect after an auth-failure close code", async () => {
+    const socket = await renderProvider();
+
+    act(() => {
+      socket.onclose?.({ code: 4401 });
+      jest.advanceTimersByTime(30_000);
+    });
+
+    expect(MockWebSocket.instances).toHaveLength(1);
+  });
+
+  it("still reconnects after a normal connection drop", async () => {
+    const socket = await renderProvider();
+
+    act(() => {
+      socket.onclose?.({ code: 1006 });
+      jest.advanceTimersByTime(5_000);
+    });
+
+    expect(MockWebSocket.instances.length).toBeGreaterThan(1);
+  });
+
+  it("does not surface auth acknowledgements as notifications", async () => {
+    const socket = await renderProvider();
+
+    act(() => {
+      socket.onopen?.();
+      socket.onmessage?.({ data: JSON.stringify({ type: "auth_ok" }) });
+    });
+
+    const stored = JSON.parse(
+      localStorage.getItem("arenax_notifications") ?? "[]"
+    );
+    expect(stored).toEqual([]);
+  });
+});

--- a/frontend/src/contexts/NotificationContext.tsx
+++ b/frontend/src/contexts/NotificationContext.tsx
@@ -378,18 +378,24 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
     let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
     let retry = 0;
     let closed = false;
+    let authFailed = false;
+
+    // 1008 = policy violation, 4401/4403 = app-level auth failure codes
+    const AUTH_FAILURE_CLOSE_CODES = [1008, 4401, 4403];
+
+    const getAuthToken = () =>
+      localStorage.getItem("auth_token") ?? sessionStorage.getItem("auth_token");
 
     const buildWsUrl = () => {
       const protocol = window.location.protocol === "https:" ? "wss" : "ws";
-      const token =
-        localStorage.getItem("auth_token") ??
-        sessionStorage.getItem("auth_token");
-      const qs = token ? `?token=${encodeURIComponent(token)}` : "";
-      return `${protocol}://${window.location.host}/ws/notifications${qs}`;
+      // The token is deliberately NOT part of the URL: query strings end up
+      // in server access logs, browser history, and Referer headers. Auth is
+      // performed via the first message after the socket opens instead.
+      return `${protocol}://${window.location.host}/ws/notifications`;
     };
 
     const scheduleReconnect = () => {
-      if (closed) return;
+      if (closed || authFailed) return;
       const delay = Math.min(10000, 1000 * 2 ** retry);
       retry += 1;
       reconnectTimer = setTimeout(connect, delay);
@@ -428,6 +434,18 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
           ws?.send(JSON.stringify({ type: "pong" }));
           return;
         }
+        if (parsed?.type === "auth_ok" || parsed?.type === "auth_success") {
+          return;
+        }
+        if (
+          parsed?.type === "auth_error" ||
+          parsed?.type === "auth_failed" ||
+          parsed?.type === "unauthorized"
+        ) {
+          authFailed = true;
+          ws?.close();
+          return;
+        }
         const notification = normalizeNotification(parsed);
         if (notification) handleIncomingNotification(notification);
       } catch {
@@ -446,10 +464,18 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
 
       ws.onopen = () => {
         retry = 0;
+        const token = getAuthToken();
+        if (token) {
+          ws?.send(JSON.stringify({ type: "auth", token }));
+        }
       };
       ws.onmessage = (event) => handleMessage(event.data);
-      ws.onclose = () => {
+      ws.onclose = (event) => {
         if (closed) return;
+        if (AUTH_FAILURE_CLOSE_CODES.includes(event.code)) {
+          authFailed = true;
+          return;
+        }
         scheduleReconnect();
       };
       ws.onerror = () => {


### PR DESCRIPTION
## Summary
Fixes the notification WebSocket leaking the JWT through the connection URL. Tokens in query strings end up in server access logs, browser history, and Referer headers.

## Changes
- The WebSocket now connects to `/ws/notifications` with no `token` query parameter.
- Immediately after `onopen`, the client sends `{ "type": "auth", "token": "..." }` as the first message.
- If the server rejects auth, either with an `auth_error`, `auth_failed`, or `unauthorized` message or with close codes 1008/4401/4403, the client closes the socket and stops reconnecting, so rejected credentials are never retried.
- Normal connection drops keep the existing exponential backoff reconnect.
- Auth acknowledgement messages (`auth_ok`, `auth_success`) are ignored instead of being rendered as notifications.

## Tests
Added `src/__tests__/notification-websocket-auth.test.tsx` (6 tests): URL contains no token, auth is the first message sent, rejection closes without reconnect, auth-failure close codes stop reconnection, normal drops still reconnect, and auth acks do not surface as notifications. All pass locally; `next lint` is clean on the changed files.

## Note for reviewers
This is the client half. The `/ws/notifications` server handler must accept the first-message auth (and should reply or close with one of the codes above on failure) for end-to-end coverage of the acceptance criteria.

Closes #733