### PR TITLE
fix(leaderboard): add missing Image import from next/image

### DIFF
--- a/frontend/src/app/[locale]/leaderboard/page.tsx
+++ b/frontend/src/app/[locale]/leaderboard/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useCallback, useMemo, Suspense } from "react";
+import Image from "next/image";
 import { useSearchParams, useRouter, usePathname } from "next/navigation";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/Card";
 import { Button } from "@/components/ui/Button";


### PR DESCRIPTION
## Summary

`leaderboard/page.tsx` was using the Next.js `<Image>` component on line 516 (inside the avatar render path) but was missing the corresponding import statement. This caused a `ReferenceError: Image is not defined` at runtime whenever a leaderboard entry had an `avatarUrl`.

## Changes

- Added `import Image from "next/image";` to the top of `src/app/[locale]/leaderboard/page.tsx`.

## Testing

- The import resolves the ReferenceError for any leaderboard row that renders a player avatar.
- Existing rows without an avatar are unaffected.

Closes #743