### PR TITLE
feat(dashboard): add skeleton loaders and error fallbacks to all 6 widgets

### DIFF
--- a/frontend/src/components/dashboard/AchievementProgress.tsx
+++ b/frontend/src/components/dashboard/AchievementProgress.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/Card";
+import { Button } from "@/components/ui/Button";
+import { RefreshCw } from "lucide-react";
 
 interface Achievement {
   id: string;
@@ -20,19 +22,80 @@ const mockAchievements: Achievement[] = [
   { id: "a5", title: "Sharpshooter", description: "Reach 1500 ELO", icon: "🎯", progress: 1250, total: 1500, unlocked: false },
 ];
 
-export function AchievementProgress() {
-  const unlocked = mockAchievements.filter((a) => a.unlocked).length;
+interface AchievementProgressProps {
+  achievements?: Achievement[];
+  isLoading?: boolean;
+  isError?: boolean;
+  onRetry?: () => void;
+}
+
+function AchievementSkeleton() {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between">
+          <div className="h-4 w-28 bg-muted rounded animate-pulse" />
+          <div className="h-3 w-16 bg-muted rounded animate-pulse" />
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-3">
+            <div className="h-8 w-8 bg-muted rounded animate-pulse" />
+            <div className="flex-1 space-y-1.5">
+              <div className="flex items-center justify-between">
+                <div className="h-3 w-24 bg-muted rounded animate-pulse" />
+                <div className="h-3 w-10 bg-muted rounded animate-pulse" />
+              </div>
+              <div className="h-1.5 bg-muted rounded-full" />
+            </div>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}
+
+function AchievementError({ onRetry }: { onRetry?: () => void }) {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base font-semibold">Achievements</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col items-center justify-center gap-3 py-8 text-center">
+        <p className="text-sm text-muted-foreground">Could not load achievements — please try again.</p>
+        {onRetry && (
+          <Button variant="outline" size="sm" onClick={onRetry} className="gap-2">
+            <RefreshCw className="h-4 w-4" />
+            Retry
+          </Button>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function AchievementProgress({
+  achievements = mockAchievements,
+  isLoading = false,
+  isError = false,
+  onRetry,
+}: AchievementProgressProps) {
+  if (isLoading) return <AchievementSkeleton />;
+  if (isError) return <AchievementError onRetry={onRetry} />;
+
+  const unlocked = achievements.filter((a) => a.unlocked).length;
 
   return (
     <Card>
       <CardHeader className="pb-3">
         <div className="flex items-center justify-between">
           <CardTitle className="text-base font-semibold">Achievements</CardTitle>
-          <span className="text-xs text-muted-foreground">{unlocked}/{mockAchievements.length} unlocked</span>
+          <span className="text-xs text-muted-foreground">{unlocked}/{achievements.length} unlocked</span>
         </div>
       </CardHeader>
       <CardContent className="space-y-3">
-        {mockAchievements.map((a) => {
+        {achievements.map((a) => {
           const pct = Math.min(100, Math.round((a.progress / a.total) * 100));
           return (
             <div key={a.id} className={`flex items-center gap-3 ${a.unlocked ? "opacity-100" : "opacity-70"}`}>

--- a/frontend/src/components/dashboard/FriendsList.tsx
+++ b/frontend/src/components/dashboard/FriendsList.tsx
@@ -2,7 +2,7 @@
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/Card";
 import { Button } from "@/components/ui/Button";
-import { UserPlus } from "lucide-react";
+import { UserPlus, RefreshCw } from "lucide-react";
 
 interface Friend {
   id: string;
@@ -28,10 +28,70 @@ const statusConfig = {
 
 interface FriendsListProps {
   compact?: boolean;
+  friends?: Friend[];
+  isLoading?: boolean;
+  isError?: boolean;
+  onRetry?: () => void;
 }
 
-export function FriendsList({ compact = false }: FriendsListProps) {
-  const sorted = [...mockFriends].sort((a, b) => {
+function FriendsListSkeleton({ compact = false }: { compact?: boolean }) {
+  const count = compact ? 4 : 5;
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between">
+          <div className="h-4 w-32 bg-muted rounded animate-pulse" />
+          <div className="h-7 w-7 bg-muted rounded animate-pulse" />
+        </div>
+      </CardHeader>
+      <CardContent className="p-0">
+        <div className="divide-y">
+          {Array.from({ length: count }).map((_, i) => (
+            <div key={i} className="flex items-center gap-3 px-6 py-2.5">
+              <div className="h-8 w-8 rounded-full bg-muted animate-pulse shrink-0" />
+              <div className="flex-1 space-y-1.5">
+                <div className="h-3 w-24 bg-muted rounded animate-pulse" />
+                <div className="h-3 w-14 bg-muted rounded animate-pulse" />
+              </div>
+              <div className="h-3 w-10 bg-muted rounded animate-pulse" />
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function FriendsListError({ onRetry }: { onRetry?: () => void }) {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base font-semibold">Friends</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col items-center justify-center gap-3 py-8 text-center">
+        <p className="text-sm text-muted-foreground">Could not load friends — please try again.</p>
+        {onRetry && (
+          <Button variant="outline" size="sm" onClick={onRetry} className="gap-2">
+            <RefreshCw className="h-4 w-4" />
+            Retry
+          </Button>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function FriendsList({
+  compact = false,
+  friends = mockFriends,
+  isLoading = false,
+  isError = false,
+  onRetry,
+}: FriendsListProps) {
+  if (isLoading) return <FriendsListSkeleton compact={compact} />;
+  if (isError) return <FriendsListError onRetry={onRetry} />;
+
+  const sorted = [...friends].sort((a, b) => {
     const order = { online: 0, "in-game": 1, offline: 2 };
     return order[a.status] - order[b.status];
   });
@@ -41,7 +101,7 @@ export function FriendsList({ compact = false }: FriendsListProps) {
       <CardHeader className="pb-3">
         <div className="flex items-center justify-between">
           <CardTitle className="text-base font-semibold">
-            Friends <span className="text-muted-foreground font-normal text-sm">({mockFriends.filter(f => f.status !== "offline").length} online)</span>
+            Friends <span className="text-muted-foreground font-normal text-sm">({friends.filter(f => f.status !== "offline").length} online)</span>
           </CardTitle>
           <Button variant="ghost" size="sm" className="h-7 px-2">
             <UserPlus className="h-4 w-4" />

--- a/frontend/src/components/dashboard/LeaderboardPreview.tsx
+++ b/frontend/src/components/dashboard/LeaderboardPreview.tsx
@@ -2,6 +2,8 @@
 
 import Link from "next/link";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/Card";
+import { Button } from "@/components/ui/Button";
+import { RefreshCw } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 interface LeaderEntry {
@@ -22,7 +24,65 @@ const mockLeaders: LeaderEntry[] = [
 
 const rankMedal: Record<number, string> = { 1: "🥇", 2: "🥈", 3: "🥉" };
 
-export function LeaderboardPreview() {
+interface LeaderboardPreviewProps {
+  leaders?: LeaderEntry[];
+  isLoading?: boolean;
+  isError?: boolean;
+  onRetry?: () => void;
+}
+
+function LeaderboardPreviewSkeleton() {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between">
+          <div className="h-4 w-24 bg-muted rounded animate-pulse" />
+          <div className="h-3 w-16 bg-muted rounded animate-pulse" />
+        </div>
+      </CardHeader>
+      <CardContent className="p-0">
+        <div className="divide-y">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className="flex items-center gap-3 px-6 py-2.5">
+              <div className="h-5 w-6 bg-muted rounded animate-pulse" />
+              <div className="flex-1 h-3 bg-muted rounded animate-pulse" />
+              <div className="h-4 w-12 bg-muted rounded animate-pulse" />
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function LeaderboardPreviewError({ onRetry }: { onRetry?: () => void }) {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base font-semibold">Leaderboard</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col items-center justify-center gap-3 py-8 text-center">
+        <p className="text-sm text-muted-foreground">Could not load leaderboard — please try again.</p>
+        {onRetry && (
+          <Button variant="outline" size="sm" onClick={onRetry} className="gap-2">
+            <RefreshCw className="h-4 w-4" />
+            Retry
+          </Button>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function LeaderboardPreview({
+  leaders = mockLeaders,
+  isLoading = false,
+  isError = false,
+  onRetry,
+}: LeaderboardPreviewProps) {
+  if (isLoading) return <LeaderboardPreviewSkeleton />;
+  if (isError) return <LeaderboardPreviewError onRetry={onRetry} />;
+
   return (
     <Card>
       <CardHeader className="pb-3">
@@ -35,7 +95,7 @@ export function LeaderboardPreview() {
       </CardHeader>
       <CardContent className="p-0">
         <div className="divide-y">
-          {mockLeaders.map((entry, i) => (
+          {leaders.map((entry, i) => (
             <div key={entry.rank}>
               {i === 5 && (
                 <div className="px-6 py-1 text-center text-xs text-muted-foreground">• • •</div>

--- a/frontend/src/components/dashboard/NewsFeed.tsx
+++ b/frontend/src/components/dashboard/NewsFeed.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/Card";
 import { Button } from "@/components/ui/Button";
+import { RefreshCw } from "lucide-react";
 
 interface NewsItem {
   id: string;
@@ -29,10 +30,63 @@ const tagColors: Record<string, string> = {
 
 const PAGE_SIZE = 3;
 
-export function NewsFeed() {
+interface NewsFeedProps {
+  news?: NewsItem[];
+  isLoading?: boolean;
+  isError?: boolean;
+  onRetry?: () => void;
+}
+
+function NewsFeedSkeleton() {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="h-4 w-32 bg-muted rounded animate-pulse" />
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="space-y-1.5">
+            <div className="flex items-center gap-2">
+              <div className="h-4 w-16 bg-muted rounded-full animate-pulse" />
+              <div className="h-3 w-20 bg-muted rounded animate-pulse" />
+            </div>
+            <div className="h-4 w-3/4 bg-muted rounded animate-pulse" />
+            <div className="h-3 w-full bg-muted rounded animate-pulse" />
+            <div className="h-3 w-5/6 bg-muted rounded animate-pulse" />
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}
+
+function NewsFeedError({ onRetry }: { onRetry?: () => void }) {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base font-semibold">Platform News</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col items-center justify-center gap-3 py-8 text-center">
+        <p className="text-sm text-muted-foreground">Could not load news — please try again.</p>
+        {onRetry && (
+          <Button variant="outline" size="sm" onClick={onRetry} className="gap-2">
+            <RefreshCw className="h-4 w-4" />
+            Retry
+          </Button>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function NewsFeed({ news = mockNews, isLoading = false, isError = false, onRetry }: NewsFeedProps) {
   const [page, setPage] = useState(1);
-  const visible = mockNews.slice(0, page * PAGE_SIZE);
-  const hasMore = visible.length < mockNews.length;
+
+  if (isLoading) return <NewsFeedSkeleton />;
+  if (isError) return <NewsFeedError onRetry={onRetry} />;
+
+  const visible = news.slice(0, page * PAGE_SIZE);
+  const hasMore = visible.length < news.length;
 
   return (
     <Card>

--- a/frontend/src/components/dashboard/RecentGames.tsx
+++ b/frontend/src/components/dashboard/RecentGames.tsx
@@ -2,15 +2,69 @@
 
 import Link from "next/link";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/Card";
+import { Button } from "@/components/ui/Button";
+import { RefreshCw } from "lucide-react";
 import { MatchWithPlayers } from "@/types/match";
 import { cn } from "@/lib/utils";
 
 interface RecentGamesProps {
   matches: MatchWithPlayers[];
   currentUserId: string;
+  isLoading?: boolean;
+  isError?: boolean;
+  onRetry?: () => void;
 }
 
-export function RecentGames({ matches, currentUserId }: RecentGamesProps) {
+function RecentGamesSkeleton() {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between">
+          <div className="h-4 w-28 bg-muted rounded animate-pulse" />
+          <div className="h-3 w-12 bg-muted rounded animate-pulse" />
+        </div>
+      </CardHeader>
+      <CardContent className="p-0">
+        <div className="divide-y">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div key={i} className="flex items-center gap-4 px-6 py-3">
+              <div className="h-6 w-8 bg-muted rounded animate-pulse" />
+              <div className="flex-1 space-y-1.5">
+                <div className="h-3 w-32 bg-muted rounded animate-pulse" />
+                <div className="h-3 w-20 bg-muted rounded animate-pulse" />
+              </div>
+              <div className="h-4 w-12 bg-muted rounded animate-pulse" />
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function RecentGamesError({ onRetry }: { onRetry?: () => void }) {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base font-semibold">Recent Games</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col items-center justify-center gap-3 py-8 text-center">
+        <p className="text-sm text-muted-foreground">Could not load recent games — please try again.</p>
+        {onRetry && (
+          <Button variant="outline" size="sm" onClick={onRetry} className="gap-2">
+            <RefreshCw className="h-4 w-4" />
+            Retry
+          </Button>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function RecentGames({ matches, currentUserId, isLoading = false, isError = false, onRetry }: RecentGamesProps) {
+  if (isLoading) return <RecentGamesSkeleton />;
+  if (isError) return <RecentGamesError onRetry={onRetry} />;
+
   return (
     <Card>
       <CardHeader className="pb-3">

--- a/frontend/src/components/dashboard/StatsOverview.tsx
+++ b/frontend/src/components/dashboard/StatsOverview.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { Card, CardContent } from "@/components/ui/Card";
-import { TrendingUp, TrendingDown, Trophy, Swords, Target, Zap } from "lucide-react";
+import { TrendingUp, TrendingDown, Trophy, Swords, Target, Zap, RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/Button";
 
 interface Stat {
   label: string;
@@ -18,9 +19,73 @@ interface StatsOverviewProps {
   winRate: number;
   rank: number;
   streak: number;
+  isLoading?: boolean;
+  isError?: boolean;
+  onRetry?: () => void;
 }
 
-export function StatsOverview({ elo, wins, losses, winRate, rank, streak }: StatsOverviewProps) {
+function StatSkeleton() {
+  return (
+    <Card>
+      <CardContent className="p-5">
+        <div className="flex items-center justify-between mb-3">
+          <div className="h-3 w-20 bg-muted rounded animate-pulse" />
+          <div className="h-5 w-5 bg-muted rounded animate-pulse" />
+        </div>
+        <div className="h-8 w-24 bg-muted rounded animate-pulse mt-1" />
+        <div className="h-3 w-28 bg-muted rounded animate-pulse mt-2" />
+      </CardContent>
+    </Card>
+  );
+}
+
+function StatsErrorFallback({ onRetry }: { onRetry?: () => void }) {
+  return (
+    <div className="col-span-2 lg:col-span-4">
+      <Card>
+        <CardContent className="p-5 flex flex-col items-center justify-center gap-3 text-center">
+          <p className="text-sm text-muted-foreground">Could not load stats — please try again.</p>
+          {onRetry && (
+            <Button variant="outline" size="sm" onClick={onRetry} className="gap-2">
+              <RefreshCw className="h-4 w-4" />
+              Retry
+            </Button>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export function StatsOverview({
+  elo,
+  wins,
+  losses,
+  winRate,
+  rank,
+  streak,
+  isLoading = false,
+  isError = false,
+  onRetry,
+}: StatsOverviewProps) {
+  if (isLoading) {
+    return (
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <StatSkeleton key={i} />
+        ))}
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+        <StatsErrorFallback onRetry={onRetry} />
+      </div>
+    );
+  }
+
   const stats: Stat[] = [
     {
       label: "ELO Rating",


### PR DESCRIPTION
## Summary

All six dashboard widgets were fed mock/static data with no loading or error states. When connected to real APIs they would render empty or broken content silently.

## Changes

Each of the six widgets — `StatsOverview`, `RecentGames`, `AchievementProgress`, `FriendsList`, `LeaderboardPreview`, `NewsFeed` — received the following additions:

| Prop | Behaviour |
|------|-----------|
| `isLoading?: boolean` | Renders a layout-matched skeleton using `animate-pulse`. Skeletons mirror the exact card structure so there is no layout shift when data arrives. |
| `isError?: boolean` | Renders a compact error card with a Retry button. |
| `onRetry?: () => void` | Callback wired to the Retry button so callers can re-trigger a TanStack Query `refetch`. |

All new props default to `false` / `undefined`, so existing call-sites in `dashboard/page.tsx` remain fully backward-compatible without modification.

## Acceptance criteria

- Every widget shows a skeleton during `isLoading`
- Every widget shows a compact error state with a Retry button on `isError`
- No widget renders empty content silently
- Skeletons match the real layout — no layout shift

Closes #742
