### PR TITLE
feat: paginate the notifications page with a Load more button

### DIFF
--- a/frontend/src/app/[locale]/notifications/page.tsx
+++ b/frontend/src/app/[locale]/notifications/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { useState } from "react";
 import { Bell, CheckCheck, Trash2, Settings, BellOff } from "lucide-react";
 import Link from "next/link";
 import { useNotifications } from "@/contexts/NotificationContext";
@@ -91,12 +91,36 @@ function NotificationItem({
   );
 }
 
+const PAGE_SIZE = 20;
+
 export default function NotificationsPage() {
   const {
     persistentNotifications,
     unreadCount,
     markAllAsRead,
+    hasMoreNotifications,
+    loadMoreNotifications,
   } = useNotifications();
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+
+  const visibleNotifications = persistentNotifications.slice(0, visibleCount);
+  const canLoadMore =
+    visibleCount < persistentNotifications.length || hasMoreNotifications;
+
+  const handleLoadMore = async () => {
+    if (visibleCount < persistentNotifications.length) {
+      setVisibleCount((prev) => prev + PAGE_SIZE);
+      return;
+    }
+    setIsLoadingMore(true);
+    try {
+      await loadMoreNotifications();
+      setVisibleCount((prev) => prev + PAGE_SIZE);
+    } finally {
+      setIsLoadingMore(false);
+    }
+  };
 
   return (
     <div className="min-h-screen">
@@ -147,12 +171,24 @@ export default function NotificationsPage() {
             </div>
           ) : (
             <div className="divide-y divide-border/50">
-              {persistentNotifications.map((n) => (
+              {visibleNotifications.map((n) => (
                 <NotificationItem
                   key={n.id}
                   notification={n}
                 />
               ))}
+            </div>
+          )}
+          {canLoadMore && (
+            <div className="flex justify-center p-4 border-t border-border/50">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleLoadMore}
+                disabled={isLoadingMore}
+              >
+                {isLoadingMore ? "Loading..." : "Load more"}
+              </Button>
             </div>
           )}
         </div>

--- a/frontend/src/contexts/NotificationContext.tsx
+++ b/frontend/src/contexts/NotificationContext.tsx
@@ -23,6 +23,7 @@ const PERSISTENT_STORAGE_KEY = "arenax_notifications";
 const PREFERENCES_STORAGE_KEY = "arenax_notification_preferences";
 const MAX_LOCAL_NOTIFICATIONS = 50;
 const MAX_TOASTS = 4;
+const NOTIFICATIONS_PAGE_SIZE = 20;
 
 const DEFAULT_PREFERENCES: NotificationPreferences = {
   info: true,
@@ -39,7 +40,13 @@ interface NotificationContextType {
   markAsRead: (id: string) => void;
   markAllAsRead: () => void;
   removeNotification: (id: string) => void;
-  refreshNotifications: () => Promise<void>;
+  refreshNotifications: (options?: {
+    offset?: number;
+    limit?: number;
+    append?: boolean;
+  }) => Promise<void>;
+  hasMoreNotifications: boolean;
+  loadMoreNotifications: () => Promise<void>;
 
   // Ephemeral toasts
   toasts: ToastNotification[];
@@ -136,36 +143,65 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
   );
   const toastTimeouts = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
   const preferencesRef = useRef(preferences);
+  const notificationsCountRef = useRef(persistentNotifications.length);
+  const [hasMoreNotifications, setHasMoreNotifications] = useState(true);
 
   useEffect(() => {
     preferencesRef.current = preferences;
   }, [preferences]);
 
+  useEffect(() => {
+    notificationsCountRef.current = persistentNotifications.length;
+  }, [persistentNotifications.length]);
+
   const unreadCount = persistentNotifications.filter((n) => !n.read).length;
 
-  const refreshNotifications = useCallback(async () => {
-    if (!user?.id) {
-      setPersistentNotifications(loadLocalNotifications());
-      return;
-    }
-    try {
-      const data = await api.getNotifications();
-      if (Array.isArray(data)) {
-        const mapped: PersistentNotification[] = data.map((n) => ({
-          ...n,
-          type: (n.type as PersistentNotification["type"]) ?? "info",
-        }));
-        setPersistentNotifications(mapped);
-        saveLocalNotifications(mapped);
+  const refreshNotifications = useCallback(
+    async (options?: { offset?: number; limit?: number; append?: boolean }) => {
+      const append = options?.append ?? false;
+      const offset = options?.offset ?? 0;
+      const limit =
+        options?.limit ?? Math.max(NOTIFICATIONS_PAGE_SIZE, notificationsCountRef.current);
+
+      if (!user?.id) {
+        setPersistentNotifications(loadLocalNotifications());
+        setHasMoreNotifications(false);
+        return;
       }
-    } catch {
-      setPersistentNotifications(loadLocalNotifications());
-    }
-  }, [user?.id]);
+      try {
+        const data = await api.getNotifications({ offset, limit });
+        if (Array.isArray(data)) {
+          const mapped: PersistentNotification[] = data.map((n) => ({
+            ...n,
+            type: (n.type as PersistentNotification["type"]) ?? "info",
+          }));
+          setHasMoreNotifications(mapped.length >= limit);
+          setPersistentNotifications((prev) => {
+            const next = append
+              ? [...prev, ...mapped.filter((n) => !prev.some((p) => p.id === n.id))]
+              : mapped;
+            saveLocalNotifications(next);
+            return next;
+          });
+        }
+      } catch {
+        if (!append) setPersistentNotifications(loadLocalNotifications());
+      }
+    },
+    [user?.id]
+  );
+
+  const loadMoreNotifications = useCallback(async () => {
+    await refreshNotifications({
+      offset: notificationsCountRef.current,
+      limit: NOTIFICATIONS_PAGE_SIZE,
+      append: true,
+    });
+  }, [refreshNotifications]);
 
   useEffect(() => {
     refreshNotifications();
-    const interval = setInterval(refreshNotifications, 60_000);
+    const interval = setInterval(() => refreshNotifications(), 60_000);
     return () => clearInterval(interval);
   }, [refreshNotifications]);
 
@@ -473,6 +509,8 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
     markAllAsRead,
     removeNotification,
     refreshNotifications,
+    hasMoreNotifications,
+    loadMoreNotifications,
     toasts,
     addToast,
     removeToast,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -156,7 +156,7 @@ class ApiClient {
   }
 
   // Notification endpoints (persistent, stored in DB)
-  async getNotifications(): Promise<
+  async getNotifications(params?: { offset?: number; limit?: number }): Promise<
     Array<{
       id: string;
       type: string;
@@ -169,7 +169,11 @@ class ApiClient {
     }>
   > {
     try {
-      return await this.request("/notifications");
+      const query = new URLSearchParams();
+      if (params?.offset !== undefined) query.set("offset", String(params.offset));
+      if (params?.limit !== undefined) query.set("limit", String(params.limit));
+      const qs = query.toString();
+      return await this.request(`/notifications${qs ? `?${qs}` : ""}`);
     } catch {
       return [];
     }


### PR DESCRIPTION
## Summary
- `NotificationsPage` rendered all `persistentNotifications` from context in a single list. The context caps local-storage notifications at 50, but the API can return far more, so a user with many notifications would see a long DOM and slow render with no pagination.
- The notifications page now shows at most 20 notifications initially and exposes a "Load more" button.
- `NotificationContext.refreshNotifications` now accepts an optional `{ offset, limit, append }` and merges (rather than replaces) results when appending; a new `loadMoreNotifications()` helper and `hasMoreNotifications` flag were added to the context.
- `api.getNotifications` now accepts an optional `{ offset, limit }` and forwards them as query params to `/notifications`.

## Changes
- `frontend/src/lib/api.ts`: `getNotifications` accepts `{ offset, limit }` and builds a query string.
- `frontend/src/contexts/NotificationContext.tsx`: `refreshNotifications` supports offset/limit/append; added `hasMoreNotifications` state and `loadMoreNotifications()`; the periodic 60s refresh keeps the currently-loaded page size instead of truncating back to the first page.
- `frontend/src/app/[locale]/notifications/page.tsx`: renders only the first `visibleCount` (starting at 20) notifications, with a "Load more" button that first pages through already-fetched items, then calls `loadMoreNotifications()` once those are exhausted.

## Test plan
- [x] `npx tsc --noEmit` shows no new errors in the changed files
- [x] `npx eslint` clean on the changed files
- [x] Confirmed `NotificationBell.tsx`'s existing no-arg `refreshNotifications()` call still type-checks (options are optional)
- [ ] Manual: seed 1000+ notifications and confirm smooth rendering via React DevTools profiler

Closes #745