### PR TITLE
fix(frontend): surface offline state with banner and reconnect toast

### DIFF
--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -6,6 +6,7 @@ import { Navbar } from "@/components/layout/Navbar";
 import { MobileHeaderActions } from "@/components/layout/MobileHeaderActions";
 import { Logo } from "@/components/common/Logo";
 import { ToastContainer } from "@/components/notifications/Toast";
+import { OfflineBanner } from "@/components/layout/OfflineBanner";
 import { SkipLink } from "@/components/ui/SkipLink";
 import { BottomNav } from "@/components/ui/BottomNav";
 import { PageTransition } from "@/components/layout/PageTransition";
@@ -51,6 +52,7 @@ export function AppLayout({ children }: AppLayoutProps) {
 
   return (
     <div className="min-h-screen bg-background font-sans antialiased flex flex-col">
+      <OfflineBanner />
       <SkipLink targetId="main-content" />
       <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
         <div className="container flex h-14 items-center justify-between">

--- a/frontend/src/components/layout/OfflineBanner.tsx
+++ b/frontend/src/components/layout/OfflineBanner.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { usePathname } from "next/navigation";
+import { WifiOff, X } from "lucide-react";
+import { useNetworkStatus } from "@/hooks/useNetworkStatus";
+import { useNotifications } from "@/contexts/NotificationContext";
+
+/**
+ * `OfflineBanner` surfaces the browser's online/offline state in the UI.
+ *
+ * Previously `useNetworkStatus` tracked connectivity correctly but nothing
+ * consumed it, so users had no indication their connection had dropped —
+ * requests would silently fail with no explanation. This component:
+ *
+ * - Renders a dismissable, accessible banner at the top of the page while
+ *   the browser is offline.
+ * - Fires a "Back online" toast the moment connectivity is restored.
+ * - Stays hidden on the PWA offline fallback route (`/offline`,
+ *   `/[locale]/offline`), which already communicates the offline state.
+ *
+ * Rendered once in `AppLayout` so it applies uniformly across the app.
+ */
+export function OfflineBanner() {
+  const { isOnline } = useNetworkStatus();
+  const pathname = usePathname();
+  const { addToast } = useNotifications();
+  const [dismissed, setDismissed] = useState(false);
+  const wasOnlineRef = useRef(isOnline);
+
+  useEffect(() => {
+    const wasOnline = wasOnlineRef.current;
+
+    if (wasOnline && !isOnline) {
+      // Connection just dropped: reset dismissal so the banner reappears.
+      setDismissed(false);
+    } else if (!wasOnline && isOnline) {
+      // Connection just came back: let the user know.
+      addToast({
+        type: "success",
+        title: "Back online",
+        message: "Your connection has been restored.",
+      });
+    }
+
+    wasOnlineRef.current = isOnline;
+  }, [isOnline, addToast]);
+
+  // Don't shadow the dedicated PWA offline fallback page — it already
+  // communicates the offline state on its own.
+  const isOfflineFallbackRoute = Boolean(pathname?.endsWith("/offline"));
+
+  if (isOfflineFallbackRoute || isOnline || dismissed) {
+    return null;
+  }
+
+  // Rendered in normal document flow, as the very first element in
+  // AppLayout, so it sits above the sticky header without overlaying (and
+  // therefore hiding) it. `z-[60]` keeps it above the header's own
+  // `z-50` stacking context for the moment they're both on screen.
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="relative z-[60] flex w-full items-center justify-center gap-3 border-b border-amber-500/20 bg-amber-500 px-4 py-2 text-sm font-medium text-amber-950 shadow-md dark:bg-amber-600 dark:text-amber-50"
+    >
+      <WifiOff className="h-4 w-4 shrink-0" aria-hidden="true" />
+      <span>You are offline. Some features may not be available.</span>
+      <button
+        type="button"
+        onClick={() => setDismissed(true)}
+        aria-label="Dismiss offline notice"
+        className="ml-2 shrink-0 rounded-full p-1 opacity-80 transition-opacity hover:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-950 dark:focus-visible:ring-amber-50"
+      >
+        <X className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Problem

`useNetworkStatus` (`frontend/src/hooks/useNetworkStatus.ts`) already tracks `navigator.onLine` and listens to the `online`/`offline` window events correctly, but nothing in the UI consumed its output. When a user's connection dropped, the app gave no visual indication at all — API calls would simply fail silently, leaving users confused about why actions weren't working. There was also no confirmation when connectivity returned.

## Fix

Adds a new `OfflineBanner` client component (`frontend/src/components/layout/OfflineBanner.tsx`) and wires it into `AppLayout` (`frontend/src/components/layout/AppLayout.tsx`), which is the shared shell used by both the non-locale (`app/layout.tsx`) and locale (`app/[locale]/layout.tsx`) route trees — so the fix applies uniformly across the whole app with a single, minimal change (2 lines: one import, one render).

Behavior:
- While `isOnline` is `false`, a full-width banner renders at the very top of the page (before the header) with the text "You are offline. Some features may not be available."
- The banner is placed in normal document flow, ahead of the app's `sticky top-0 z-50` header, so it never overlays or hides header content — it simply pushes the header down while visible.
- The banner is dismissable via an "X" button. If the connection drops again after a dismissal, the dismissed state is reset so the banner reliably reappears on every new disconnect (tracked via a `false -> true` / `true -> false` transition check using a ref for the previous `isOnline` value).
- The moment connectivity returns (`isOnline` flips `false -> true`), a "Back online" success toast fires via `useNotifications().addToast(...)`, rendered by the existing `<ToastContainer />` already mounted in `AppLayout`.
- The banner does not render on the PWA offline fallback route (`/offline`, `/[locale]/offline`), detected via `usePathname()`, since that page already communicates the offline state on its own.

## Acceptance criteria (issue #753)

- [x] Banner appears within 2s of going offline — the banner is driven directly by `useNetworkStatus`'s `offline` event listener and React state, so it renders on the next paint after the event fires (effectively instant, well under 2s).
- [x] Dismissable — "X" button with `aria-label="Dismiss offline notice"` hides the banner; a fresh disconnect re-shows it.
- [x] "Back online" toast on reconnect — fired via `addToast({ type: "success", title: "Back online", message: "Your connection has been restored." })` on the offline -> online transition.
- [x] `role="status"` / `aria-live="polite"` — present on the banner's root container so assistive tech announces the state change.

## Scope notes

- `useNetworkStatus.ts` itself was not modified — it already worked correctly.
- Per task instructions, the test suite, `npm run build`, and `npm run lint` were intentionally not run/modified as part of this change; only a manual read-through of the new component was done to check for obvious TypeScript issues.

Closes #753