### PR TITLE
fix(monitoring): forward ErrorBoundary and QueryClient errors to Datadog RUM

### DIFF
--- a/frontend/src/components/providers/QueryProvider.tsx
+++ b/frontend/src/components/providers/QueryProvider.tsx
@@ -4,12 +4,13 @@ import { QueryClient, QueryClientProvider, MutationCache, QueryCache } from "@ta
 import { useState } from "react";
 import { logError } from "@/lib/errorLogger";
 import { ArenaXError, ErrorCategory, ErrorSeverity } from "@/lib/errors";
+import { datadogRum } from "@datadog/browser-rum";
 
 // ─── Query error handler ──────────────────────────────────────────────────────
 
 /**
  * Translates a TanStack Query error into an `ArenaXError` so it flows through
- * the structured logging / analytics pipeline.
+ * the structured logging / analytics pipeline, and forwards it to Datadog RUM.
  */
 function handleQueryError(error: unknown, context?: Record<string, unknown>): void {
   const err =
@@ -22,6 +23,13 @@ function handleQueryError(error: unknown, context?: Record<string, unknown>): vo
         );
 
   logError(err, { source: "QueryClient", ...context });
+
+  // Forward to Datadog RUM. Context only contains query/mutation keys —
+  // no tokens, passwords, or user PII.
+  datadogRum.addError(err, {
+    source: "QueryClient",
+    ...context,
+  });
 }
 
 // ─── Provider ─────────────────────────────────────────────────────────────────

--- a/frontend/src/components/ui/ErrorBoundary.tsx
+++ b/frontend/src/components/ui/ErrorBoundary.tsx
@@ -5,6 +5,7 @@ import { Button } from "./Button";
 import { AlertTriangle, RefreshCw, Home, Mail, Copy, Check } from "lucide-react";
 import { logError } from "@/lib/errorLogger";
 import { determineErrorCategory, ErrorCategory } from "@/lib/errors";
+import { datadogRum } from "@datadog/browser-rum";
 
 // ─── Error message catalogue ──────────────────────────────────────────────────
 
@@ -85,6 +86,15 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
       source: "ErrorBoundary",
       componentStack: errorInfo.componentStack,
     });
+
+    // Forward to Datadog RUM for production monitoring.
+    // Only include non-sensitive breadcrumbs — no tokens, passwords or PII.
+    datadogRum.addError(error, {
+      source: "ErrorBoundary",
+      componentStack: errorInfo.componentStack ?? undefined,
+      route: typeof window !== "undefined" ? window.location.pathname : undefined,
+    });
+
     this.props.onError?.(error, errorInfo);
   }
 


### PR DESCRIPTION
## Summary

React rendering errors caught by `ErrorBoundary` and all TanStack Query errors handled by `QueryProvider` are now forwarded to Datadog RUM via `datadogRum.addError()`. `@datadog/browser-rum` was already installed (v7.4.0) and initialised in `RumProvider`.

## Changes

### `frontend/src/components/ui/ErrorBoundary.tsx`
- Added `import { datadogRum } from '@datadog/browser-rum'`.
- In `componentDidCatch`, after the existing `logError` call, added:
  ```ts
  datadogRum.addError(error, {
    source: 'ErrorBoundary',
    componentStack: errorInfo.componentStack ?? undefined,
    route: window.location.pathname,
  });
  ```
- Context payload contains only the component stack and current route — no tokens, passwords, or PII.

### `frontend/src/components/providers/QueryProvider.tsx`
- Added `import { datadogRum } from '@datadog/browser-rum'`.
- In `handleQueryError`, after the existing `logError` call, added:
  ```ts
  datadogRum.addError(err, { source: 'QueryClient', ...context });
  ```
- Context contains only `queryKey` / `mutationKey` identifiers — no user data or secrets.

## Security

No PII, tokens, or passwords are included in any Datadog error payload. The component stack and route are the only breadcrumb data attached.

Closes #750