### PR TITLE
fix(admin): add confirmation dialogs, error states and toasts to AdminPanel

### DIFF
--- a/frontend/src/app/[locale]/admin/disputes/page.tsx
+++ b/frontend/src/app/[locale]/admin/disputes/page.tsx
@@ -14,6 +14,8 @@ import {
 } from "@/components/ui/Card";
 import { Button } from "@/components/ui/Button";
 import { Input } from "@/components/ui/Input";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
+import { ToastContainer, toast } from "@/components/ui/Toast";
 import type { Dispute, ResolveDisputePayload } from "@/types/admin";
 import { PageHeaderSkeleton, ListItemSkeleton } from "@/components/common/PageSkeleton";
 import { PageError } from "@/components/common/PageError";
@@ -26,6 +28,16 @@ import {
   Clock,
   Gamepad2,
 } from "lucide-react";
+
+// ─── Client-side audit logger ─────────────────────────────────────────────────
+
+function auditLog(action: string, details: Record<string, unknown>) {
+  console.info("[AUDIT]", {
+    action,
+    ...details,
+    timestamp: new Date().toISOString(),
+  });
+}
 
 // ─── Status badge ────────────────────────────────────────────────────────────
 
@@ -93,22 +105,7 @@ interface ResolveFormProps {
 function ResolveForm({ dispute, onResolve, isPending }: ResolveFormProps) {
   const [winner, setWinner] = useState<"A" | "B" | "void" | null>(null);
   const [note, setNote] = useState("");
-
-  const handleSubmit = () => {
-    if (!winner) return;
-    const payload: ResolveDisputePayload =
-      winner === "void"
-        ? { status: "VOIDED", resolution: note || "Match voided by admin" }
-        : {
-            status: "RESOLVED",
-            resolution: note || `Admin declared winner`,
-            winnerOverrideId:
-              winner === "A"
-                ? dispute.match.playerAId
-                : dispute.match.playerBId,
-          };
-    onResolve(dispute.id, payload);
-  };
+  const [confirmOpen, setConfirmOpen] = useState(false);
 
   const playerALabel =
     dispute.match.playerAUsername ?? `Player A (${dispute.match.playerAId.slice(0, 8)}…)`;
@@ -142,58 +139,132 @@ function ResolveForm({ dispute, onResolve, isPending }: ResolveFormProps) {
     },
   ];
 
-  return (
-    <div className="space-y-4 pt-4 border-t border-border mt-4">
-      <h4 className="text-sm font-bold text-muted-foreground uppercase tracking-widest">
-        Resolution
-      </h4>
+  const resolvedStatus = winner === "void" ? "VOIDED" : "RESOLVED";
+  const winnerLabel =
+    winner === "A"
+      ? playerALabel
+      : winner === "B"
+      ? playerBLabel
+      : "N/A (match voided)";
 
-      {/* Winner / Void selection */}
-      <div
-        role="radiogroup"
-        aria-label="Select outcome"
-        className="grid sm:grid-cols-3 gap-2"
-      >
-        {options.map((opt) => (
-          <button
-            key={opt.value}
-            role="radio"
-            aria-checked={winner === opt.value}
-            onClick={() => setWinner(opt.value)}
-            className={`text-sm font-medium py-2 px-3 rounded-lg border-2 transition-colors text-left ${opt.colour}`}
-          >
-            {opt.label}
-          </button>
-        ))}
-      </div>
-
-      {/* Resolution note */}
-      <div>
-        <label
-          htmlFor={`note-${dispute.id}`}
-          className="block text-sm font-medium mb-1"
+  const confirmDescription = (
+    <div className="space-y-1">
+      <p>
+        <strong>Dispute:</strong>{" "}
+        <span className="font-mono">{dispute.id.slice(0, 10)}…</span>
+      </p>
+      <p>
+        <strong>Outcome:</strong>{" "}
+        <span
+          className={
+            resolvedStatus === "VOIDED" ? "text-destructive font-semibold" : "font-semibold"
+          }
         >
-          Resolution note{" "}
-          <span className="text-muted-foreground font-normal">(optional)</span>
-        </label>
-        <Input
-          id={`note-${dispute.id}`}
-          placeholder="Describe your decision…"
-          value={note}
-          onChange={(e) => setNote(e.target.value)}
-        />
+          {resolvedStatus}
+        </span>
+      </p>
+      <p>
+        <strong>Winner:</strong> {winnerLabel}
+      </p>
+      {note && (
+        <p>
+          <strong>Note:</strong> {note}
+        </p>
+      )}
+      <p className="pt-1 text-xs text-muted-foreground">
+        This action cannot be undone.
+      </p>
+    </div>
+  );
+
+  const handleConfirmClick = () => {
+    if (!winner) return;
+    setConfirmOpen(true);
+  };
+
+  const handleConfirmed = () => {
+    if (!winner) return;
+    setConfirmOpen(false);
+    const payload: ResolveDisputePayload =
+      winner === "void"
+        ? { status: "VOIDED", resolution: note || "Match voided by admin" }
+        : {
+            status: "RESOLVED",
+            resolution: note || `Admin declared winner`,
+            winnerOverrideId:
+              winner === "A"
+                ? dispute.match.playerAId
+                : dispute.match.playerBId,
+          };
+    onResolve(dispute.id, payload);
+  };
+
+  return (
+    <>
+      <div className="space-y-4 pt-4 border-t border-border mt-4">
+        <h4 className="text-sm font-bold text-muted-foreground uppercase tracking-widest">
+          Resolution
+        </h4>
+
+        {/* Winner / Void selection */}
+        <div
+          role="radiogroup"
+          aria-label="Select outcome"
+          className="grid sm:grid-cols-3 gap-2"
+        >
+          {options.map((opt) => (
+            <button
+              key={opt.value}
+              role="radio"
+              aria-checked={winner === opt.value}
+              onClick={() => setWinner(opt.value)}
+              className={`text-sm font-medium py-2 px-3 rounded-lg border-2 transition-colors text-left ${opt.colour}`}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+
+        {/* Resolution note */}
+        <div>
+          <label
+            htmlFor={`note-${dispute.id}`}
+            className="block text-sm font-medium mb-1"
+          >
+            Resolution note{" "}
+            <span className="text-muted-foreground font-normal">(optional)</span>
+          </label>
+          <Input
+            id={`note-${dispute.id}`}
+            placeholder="Describe your decision…"
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+          />
+        </div>
+
+        <Button
+          variant="primary"
+          onClick={handleConfirmClick}
+          disabled={!winner || isPending}
+          className="w-full sm:w-auto"
+        >
+          Confirm resolution
+        </Button>
       </div>
 
-      <Button
-        variant="primary"
-        onClick={handleSubmit}
-        disabled={!winner || isPending}
-        className="w-full sm:w-auto"
-        aria-busy={isPending}
-      >
-        {isPending ? "Saving…" : "Confirm resolution"}
-      </Button>
-    </div>
+      {/* Confirmation dialog */}
+      <ConfirmDialog
+        isOpen={confirmOpen}
+        onConfirm={handleConfirmed}
+        onCancel={() => setConfirmOpen(false)}
+        title="Confirm dispute resolution"
+        description={confirmDescription}
+        confirmLabel="Yes, resolve"
+        cancelLabel="Cancel"
+        variant={winner === "void" ? "danger" : "warning"}
+        isPending={isPending}
+      />
+    </>
   );
 }
 
@@ -214,10 +285,8 @@ function DisputeRow({ dispute, onResolve, resolvingId }: DisputeRowProps) {
     ? new Date(dispute.createdAt).toLocaleString()
     : "—";
 
-  const playerALabel =
-    dispute.match.playerAUsername ?? `Player A`;
-  const playerBLabel =
-    dispute.match.playerBUsername ?? `Player B`;
+  const playerALabel = dispute.match.playerAUsername ?? `Player A`;
+  const playerBLabel = dispute.match.playerBUsername ?? `Player B`;
 
   const alreadyClosed = ["RESOLVED", "DISMISSED", "VOIDED"].includes(
     dispute.status
@@ -436,11 +505,20 @@ export default function DisputeDashboard() {
       setResolvingId(id);
       return api.resolveDispute(id, payload);
     },
-    onSuccess: () => {
+    onSuccess: (_data, { id, payload }) => {
       queryClient.invalidateQueries({ queryKey: ["admin", "disputes"] });
+      toast.success("Dispute resolved successfully.");
+      auditLog("resolve_dispute", {
+        disputeId: id,
+        status: payload.status,
+        winnerOverrideId: payload.winnerOverrideId ?? null,
+      });
     },
-    onError: (err) => {
-      alert("Failed to resolve dispute: " + (err as Error).message);
+    onError: (err, { id }) => {
+      const message = (err as Error).message ?? "Unknown error";
+      const code = message.match(/\d{3}/)?.[0];
+      toast.error(`Failed to resolve dispute: ${message}`, code);
+      auditLog("resolve_dispute_failed", { disputeId: id, error: message });
     },
     onSettled: () => {
       setResolvingId(null);
@@ -530,6 +608,9 @@ export default function DisputeDashboard() {
           )}
         </div>
       </div>
+
+      {/* Toast notifications */}
+      <ToastContainer />
     </ProtectedPage>
   );
 }

--- a/frontend/src/app/[locale]/admin/kyc/page.tsx
+++ b/frontend/src/app/[locale]/admin/kyc/page.tsx
@@ -6,12 +6,32 @@ import { api } from "@/lib/api";
 import { ProtectedPage } from "@/components/navigation/ProtectedPage";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/Card";
 import { Button } from "@/components/ui/Button";
-import { Input } from "@/components/ui/Input";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
+import { ToastContainer, toast } from "@/components/ui/Toast";
 import type { KycDocument, KycReview, KycStatus } from "@/types/admin";
 import { PageHeaderSkeleton, ListItemSkeleton, Skeleton } from "@/components/common/PageSkeleton";
 import { PageError } from "@/components/common/PageError";
 import { EmptyState } from "@/components/common/EmptyState";
 import { FileText } from "lucide-react";
+
+// ─── Client-side audit logger ─────────────────────────────────────────────────
+
+function auditLog(action: string, details: Record<string, unknown>) {
+  console.info("[AUDIT]", {
+    action,
+    ...details,
+    timestamp: new Date().toISOString(),
+  });
+}
+
+// ─── Pending action state ─────────────────────────────────────────────────────
+
+interface PendingAction {
+  reviewId: string;
+  username: string;
+  status: KycStatus;
+  notes: string;
+}
 
 export default function KycDashboard() {
   const [reviews, setReviews] = useState<KycReview[]>([]);
@@ -21,6 +41,9 @@ export default function KycDashboard() {
   const [selectedReview, setSelectedReview] = useState<KycReview | null>(null);
   const [decisionNotes, setDecisionNotes] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // Confirmation dialog state
+  const [pendingAction, setPendingAction] = useState<PendingAction | null>(null);
 
   const fetchReviews = useCallback(async () => {
     setLoading(true);
@@ -41,31 +64,97 @@ export default function KycDashboard() {
     fetchReviews();
   }, [fetchReviews]);
 
-  const handleProcess = async (id: string, status: KycStatus) => {
+  // ── Request confirmation before processing ─────────────────────────────────
+
+  const requestProcess = (status: KycStatus) => {
+    if (!selectedReview) return;
+
     if (status === "REJECTED" && !decisionNotes) {
-      alert("Please provide a reason for rejection.");
+      toast.warning("Please provide a reason for rejection.");
       return;
     }
 
+    setPendingAction({
+      reviewId: selectedReview.id,
+      username: selectedReview.user.username,
+      status,
+      notes: decisionNotes,
+    });
+  };
+
+  // ── Execute after confirmation ─────────────────────────────────────────────
+
+  const handleConfirmedProcess = async () => {
+    if (!pendingAction) return;
+    const { reviewId, username, status, notes } = pendingAction;
+    setPendingAction(null);
+
     setIsSubmitting(true);
     const previousReviews = [...reviews];
-    setReviews(reviews.map((r: KycReview) => r.id === id ? { ...r, status } : r));
-    if (selectedReview?.id === id) {
-      setSelectedReview({ ...selectedReview, status });
+    setReviews(reviews.map((r: KycReview) => r.id === reviewId ? { ...r, status } : r));
+    if (selectedReview?.id === reviewId) {
+      setSelectedReview({ ...selectedReview!, status });
     }
 
     try {
-      await api.processKycReview(id, { status, notes: decisionNotes });
+      await api.processKycReview(reviewId, { status, notes });
       setDecisionNotes("");
       setSelectedReview(null);
+      toast.success(`KYC review processed: ${status}`);
+      auditLog("process_kyc", { reviewId, username, status });
       fetchReviews();
     } catch (err) {
       setReviews(previousReviews);
-      alert("Failed to process KYC review: " + (err as Error).message);
+      if (selectedReview?.id === reviewId) {
+        setSelectedReview(selectedReview);
+      }
+      const message = (err as Error).message ?? "Unknown error";
+      const code = message.match(/\d{3}/)?.[0];
+      toast.error(`Failed to process KYC review: ${message}`, code);
+      auditLog("process_kyc_failed", { reviewId, username, status, error: message });
     } finally {
       setIsSubmitting(false);
     }
   };
+
+  // ── Build confirmation dialog description ──────────────────────────────────
+
+  const confirmDescription = pendingAction ? (
+    <div className="space-y-1">
+      <p>
+        <strong>Action:</strong>{" "}
+        <span
+          className={
+            pendingAction.status === "REJECTED"
+              ? "text-destructive font-semibold"
+              : pendingAction.status === "APPROVED"
+              ? "text-green-600 font-semibold"
+              : "font-semibold"
+          }
+        >
+          {pendingAction.status}
+        </span>
+      </p>
+      <p>
+        <strong>User:</strong> {pendingAction.username}
+      </p>
+      {pendingAction.notes && (
+        <p>
+          <strong>Notes:</strong> {pendingAction.notes}
+        </p>
+      )}
+      <p className="pt-1 text-xs text-muted-foreground">
+        This action will be recorded in the audit log.
+      </p>
+    </div>
+  ) : null;
+
+  const confirmVariant =
+    pendingAction?.status === "REJECTED"
+      ? "danger"
+      : pendingAction?.status === "APPROVED"
+      ? "default"
+      : "warning";
 
   // ── Loading skeleton ──────────────────────────────────────────────────────
   if (loading && reviews.length === 0) {
@@ -124,185 +213,264 @@ export default function KycDashboard() {
   return (
     <ProtectedPage requiredRole="admin">
       <div className="container mx-auto p-6 space-y-8">
-      <header className="flex flex-col md:flex-row md:items-center justify-between gap-4">
-        <div>
-          <h1 className="text-4xl font-extrabold tracking-tight lg:text-5xl text-foreground dark:text-foreground">
-            KYC Review Queue
-          </h1>
-          <p className="text-xl text-muted-foreground">
-            Verify user identities and manage account risk.
-          </p>
-        </div>
-        <div className="flex items-center gap-2">
-          <label htmlFor="status-filter" className="text-sm font-medium">Status:</label>
-          <select 
-            id="status-filter"
-            className="bg-background border border-input h-10 px-3 py-2 rounded-md text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-            value={filterStatus}
-            onChange={(e: React.ChangeEvent<HTMLSelectElement>) => setFilterStatus(e.target.value as any)}
-          >
-            <option value="ALL">All Reviews</option>
-            <option value="PENDING">Pending</option>
-            <option value="APPROVED">Approved</option>
-            <option value="REJECTED">Rejected</option>
-            <option value="ESCALATED">Escalated</option>
-          </select>
-        </div>
-      </header>
+        <header className="flex flex-col md:flex-row md:items-center justify-between gap-4">
+          <div>
+            <h1 className="text-4xl font-extrabold tracking-tight lg:text-5xl text-foreground dark:text-foreground">
+              KYC Review Queue
+            </h1>
+            <p className="text-xl text-muted-foreground">
+              Verify user identities and manage account risk.
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <label htmlFor="status-filter" className="text-sm font-medium">Status:</label>
+            <select
+              id="status-filter"
+              className="bg-background border border-input h-10 px-3 py-2 rounded-md text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              value={filterStatus}
+              onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+                setFilterStatus(e.target.value as any)
+              }
+            >
+              <option value="ALL">All Reviews</option>
+              <option value="PENDING">Pending</option>
+              <option value="APPROVED">Approved</option>
+              <option value="REJECTED">Rejected</option>
+              <option value="ESCALATED">Escalated</option>
+            </select>
+          </div>
+        </header>
 
-      <div className="grid lg:grid-cols-3 gap-8">
-        {/* Review List */}
-        <div className="lg:col-span-1 space-y-4 max-h-[calc(100vh-250px)] overflow-y-auto pr-2">
-          {reviews.length === 0 ? (
-            <EmptyState
-              icon={FileText}
-              title="No reviews found"
-              description={filterStatus === "ALL" ? "There are no KYC reviews in the queue." : `No reviews with status "${filterStatus}".`}
-              size="sm"
-            />
-          ) : (
-            reviews.map((review: KycReview) => (
-              <Card 
-                key={review.id} 
-                className={`cursor-pointer transition-all duration-200 border-2 ${selectedReview?.id === review.id ? 'border-primary ring-2 ring-primary/20' : 'hover:border-primary/50'}`}
-                onClick={() => setSelectedReview(review)}
-              >
-                <CardHeader className="p-4 space-y-1">
-                  <div className="flex justify-between items-start">
-                    <CardTitle className="text-lg truncate">{review.user.username}</CardTitle>
-                    <span className={`px-2 py-0.5 rounded text-[10px] font-bold uppercase ${
-                      review.status === 'PENDING' ? 'bg-yellow-100 text-yellow-800' :
-                      review.status === 'APPROVED' ? 'bg-success-muted text-green-800' :
-                      review.status === 'REJECTED' ? 'bg-destructive/10 text-red-800' : 'bg-muted text-gray-800'
-                    }`}>
-                      {review.status}
-                    </span>
-                  </div>
-                  <CardDescription className="text-xs truncate">{new Date(review.createdAt).toLocaleDateString()}</CardDescription>
-                </CardHeader>
-              </Card>
-            ))
-          )}
-        </div>
-
-        {/* Detail Pane */}
-        <div className="lg:col-span-2">
-          {selectedReview ? (
-            <Card className="shadow-xl sticky top-6 border-2">
-              <CardHeader className="bg-muted/30 border-b">
-                <div className="flex items-center justify-between">
-                  <div>
-                    <CardTitle className="text-3xl font-bold">{selectedReview.user.username}</CardTitle>
-                    <CardDescription className="text-base">{selectedReview.user.email}</CardDescription>
-                  </div>
-                  <div className="text-right">
-                    <p className="text-xs font-bold text-muted-foreground uppercase tracking-widest">Review ID</p>
-                    <p className="font-mono text-sm">{selectedReview.id.substring(0, 8)}...</p>
-                  </div>
-                </div>
-              </CardHeader>
-              <CardContent className="p-8 space-y-8">
-                <section>
-                  <h3 className="text-lg font-bold mb-4 flex items-center gap-2">
-                    <span className="w-1.5 h-6 bg-primary rounded-full"></span>
-                    Identity Documents
-                  </h3>
-                  <div className="grid sm:grid-cols-2 gap-4">
-                    {Array.isArray(selectedReview.documents) && selectedReview.documents.length > 0 ? (
-                      selectedReview.documents.map((doc: KycDocument, i: number) => (
-                        <div key={i} className="group relative aspect-video bg-muted rounded-xl overflow-hidden border-2 border-transparent hover:border-primary transition-all">
-                          <Image 
-                            src={doc.url} 
-                            alt={`Document ${i + 1}`} 
-                            fill
-                            className="object-cover"
-                          />
-                          <div className="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 flex items-center justify-center transition-opacity">
-                            <Button variant="secondary" className="scale-90" onClick={() => window.open(doc.url, '_blank')}>View Original</Button>
-                          </div>
-                        </div>
-                      ))
-                    ) : (
-                      <div className="col-span-2 p-12 bg-muted/30 rounded-xl border-2 border-dashed flex flex-col items-center justify-center text-muted-foreground">
-                        <p>No documents uploaded for this review.</p>
-                      </div>
-                    )}
-                  </div>
-                </section>
-
-                <section className="bg-muted/20 p-6 rounded-2xl border">
-                  <h3 className="text-lg font-bold mb-4">Final Decision</h3>
-                  <div className="space-y-4">
-                    <div>
-                      <label htmlFor="notes" className="text-sm font-medium mb-1.5 block">Reviewer Notes / Reason</label>
-                      <textarea
-                        id="notes"
-                        rows={3}
-                        className="w-full bg-background border border-input rounded-xl px-4 py-3 text-sm focus:ring-2 focus:ring-primary/20 focus:outline-none transition-all"
-                        placeholder="Provide reasoning for your decision (required for rejections)..."
-                        value={decisionNotes}
-                        onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setDecisionNotes(e.target.value)}
-                        disabled={isSubmitting || selectedReview.status !== 'PENDING'}
-                      />
+        <div className="grid lg:grid-cols-3 gap-8">
+          {/* Review List */}
+          <div className="lg:col-span-1 space-y-4 max-h-[calc(100vh-250px)] overflow-y-auto pr-2">
+            {reviews.length === 0 ? (
+              <EmptyState
+                icon={FileText}
+                title="No reviews found"
+                description={
+                  filterStatus === "ALL"
+                    ? "There are no KYC reviews in the queue."
+                    : `No reviews with status "${filterStatus}".`
+                }
+                size="sm"
+              />
+            ) : (
+              reviews.map((review: KycReview) => (
+                <Card
+                  key={review.id}
+                  className={`cursor-pointer transition-all duration-200 border-2 ${
+                    selectedReview?.id === review.id
+                      ? "border-primary ring-2 ring-primary/20"
+                      : "hover:border-primary/50"
+                  }`}
+                  onClick={() => setSelectedReview(review)}
+                >
+                  <CardHeader className="p-4 space-y-1">
+                    <div className="flex justify-between items-start">
+                      <CardTitle className="text-lg truncate">{review.user.username}</CardTitle>
+                      <span
+                        className={`px-2 py-0.5 rounded text-[10px] font-bold uppercase ${
+                          review.status === "PENDING"
+                            ? "bg-yellow-100 text-yellow-800"
+                            : review.status === "APPROVED"
+                            ? "bg-success-muted text-green-800"
+                            : review.status === "REJECTED"
+                            ? "bg-destructive/10 text-red-800"
+                            : "bg-muted text-gray-800"
+                        }`}
+                      >
+                        {review.status}
+                      </span>
                     </div>
-                    
-                    {selectedReview.status === 'PENDING' ? (
-                      <div className="flex flex-wrap gap-3 pt-2">
-                        <Button 
-                          variant="primary" 
-                          className="flex-1 min-w-[140px] bg-success/90 hover:bg-green-700 text-white font-bold"
-                          onClick={() => handleProcess(selectedReview.id, "APPROVED")}
-                          disabled={isSubmitting}
-                        >
-                          Approve Identity
-                        </Button>
-                        <Button 
-                          variant="primary" 
-                          className="flex-1 min-w-[140px] bg-red-600 hover:bg-red-700 text-white font-bold"
-                          onClick={() => handleProcess(selectedReview.id, "REJECTED")}
-                          disabled={isSubmitting}
-                        >
-                          Reject Submission
-                        </Button>
-                        <Button 
-                          variant="secondary" 
-                          className="font-bold"
-                          onClick={() => handleProcess(selectedReview.id, "ESCALATED")}
-                          disabled={isSubmitting}
-                        >
-                          Escalate to Risk
-                        </Button>
-                      </div>
-                    ) : (
-                      <div className={`p-4 rounded-xl border flex items-center justify-between ${
-                        selectedReview.status === 'APPROVED' ? 'bg-success-muted border-success/30 text-green-800' :
-                        selectedReview.status === 'REJECTED' ? 'bg-destructive/5 border-red-200 text-red-800' :
-                        'bg-muted border-gray-200 text-gray-800'
-                      }`}>
-                        <div className="flex items-center gap-3">
-                          <span className="font-bold uppercase tracking-wider text-xs">Final State: {selectedReview.status}</span>
-                        </div>
-                        {selectedReview.notes && <p className="text-sm italic">&quot;{selectedReview.notes}&quot;</p>}
-                      </div>
-                    )}
+                    <CardDescription className="text-xs truncate">
+                      {new Date(review.createdAt).toLocaleDateString()}
+                    </CardDescription>
+                  </CardHeader>
+                </Card>
+              ))
+            )}
+          </div>
+
+          {/* Detail Pane */}
+          <div className="lg:col-span-2">
+            {selectedReview ? (
+              <Card className="shadow-xl sticky top-6 border-2">
+                <CardHeader className="bg-muted/30 border-b">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <CardTitle className="text-3xl font-bold">
+                        {selectedReview.user.username}
+                      </CardTitle>
+                      <CardDescription className="text-base">
+                        {selectedReview.user.email}
+                      </CardDescription>
+                    </div>
+                    <div className="text-right">
+                      <p className="text-xs font-bold text-muted-foreground uppercase tracking-widest">
+                        Review ID
+                      </p>
+                      <p className="font-mono text-sm">{selectedReview.id.substring(0, 8)}...</p>
+                    </div>
                   </div>
-                </section>
-              </CardContent>
-            </Card>
-          ) : (
-            <div className="h-full flex flex-col items-center justify-center p-12 bg-muted/20 border-2 border-dashed rounded-3xl text-muted-foreground animate-in fade-in duration-500">
-              <div className="w-20 h-20 rounded-full bg-muted flex items-center justify-center mb-6">
-                <svg className="w-10 h-10" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-                </svg>
+                </CardHeader>
+                <CardContent className="p-8 space-y-8">
+                  <section>
+                    <h3 className="text-lg font-bold mb-4 flex items-center gap-2">
+                      <span className="w-1.5 h-6 bg-primary rounded-full"></span>
+                      Identity Documents
+                    </h3>
+                    <div className="grid sm:grid-cols-2 gap-4">
+                      {Array.isArray(selectedReview.documents) &&
+                      selectedReview.documents.length > 0 ? (
+                        selectedReview.documents.map((doc: KycDocument, i: number) => (
+                          <div
+                            key={i}
+                            className="group relative aspect-video bg-muted rounded-xl overflow-hidden border-2 border-transparent hover:border-primary transition-all"
+                          >
+                            <Image
+                              src={doc.url}
+                              alt={`Document ${i + 1}`}
+                              fill
+                              className="object-cover"
+                            />
+                            <div className="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 flex items-center justify-center transition-opacity">
+                              <Button
+                                variant="secondary"
+                                className="scale-90"
+                                onClick={() => window.open(doc.url, "_blank")}
+                              >
+                                View Original
+                              </Button>
+                            </div>
+                          </div>
+                        ))
+                      ) : (
+                        <div className="col-span-2 p-12 bg-muted/30 rounded-xl border-2 border-dashed flex flex-col items-center justify-center text-muted-foreground">
+                          <p>No documents uploaded for this review.</p>
+                        </div>
+                      )}
+                    </div>
+                  </section>
+
+                  <section className="bg-muted/20 p-6 rounded-2xl border">
+                    <h3 className="text-lg font-bold mb-4">Final Decision</h3>
+                    <div className="space-y-4">
+                      <div>
+                        <label
+                          htmlFor="notes"
+                          className="text-sm font-medium mb-1.5 block"
+                        >
+                          Reviewer Notes / Reason
+                        </label>
+                        <textarea
+                          id="notes"
+                          rows={3}
+                          className="w-full bg-background border border-input rounded-xl px-4 py-3 text-sm focus:ring-2 focus:ring-primary/20 focus:outline-none transition-all"
+                          placeholder="Provide reasoning for your decision (required for rejections)..."
+                          value={decisionNotes}
+                          onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                            setDecisionNotes(e.target.value)
+                          }
+                          disabled={
+                            isSubmitting || selectedReview.status !== "PENDING"
+                          }
+                        />
+                      </div>
+
+                      {selectedReview.status === "PENDING" ? (
+                        <div className="flex flex-wrap gap-3 pt-2">
+                          <Button
+                            variant="primary"
+                            className="flex-1 min-w-[140px] bg-success/90 hover:bg-green-700 text-white font-bold"
+                            onClick={() => requestProcess("APPROVED")}
+                            disabled={isSubmitting}
+                          >
+                            Approve Identity
+                          </Button>
+                          <Button
+                            variant="primary"
+                            className="flex-1 min-w-[140px] bg-red-600 hover:bg-red-700 text-white font-bold"
+                            onClick={() => requestProcess("REJECTED")}
+                            disabled={isSubmitting}
+                          >
+                            Reject Submission
+                          </Button>
+                          <Button
+                            variant="secondary"
+                            className="font-bold"
+                            onClick={() => requestProcess("ESCALATED")}
+                            disabled={isSubmitting}
+                          >
+                            Escalate to Risk
+                          </Button>
+                        </div>
+                      ) : (
+                        <div
+                          className={`p-4 rounded-xl border flex items-center justify-between ${
+                            selectedReview.status === "APPROVED"
+                              ? "bg-success-muted border-success/30 text-green-800"
+                              : selectedReview.status === "REJECTED"
+                              ? "bg-destructive/5 border-red-200 text-red-800"
+                              : "bg-muted border-gray-200 text-gray-800"
+                          }`}
+                        >
+                          <div className="flex items-center gap-3">
+                            <span className="font-bold uppercase tracking-wider text-xs">
+                              Final State: {selectedReview.status}
+                            </span>
+                          </div>
+                          {selectedReview.notes && (
+                            <p className="text-sm italic">&quot;{selectedReview.notes}&quot;</p>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  </section>
+                </CardContent>
+              </Card>
+            ) : (
+              <div className="h-full flex flex-col items-center justify-center p-12 bg-muted/20 border-2 border-dashed rounded-3xl text-muted-foreground animate-in fade-in duration-500">
+                <div className="w-20 h-20 rounded-full bg-muted flex items-center justify-center mb-6">
+                  <svg
+                    className="w-10 h-10"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={1.5}
+                      d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+                    />
+                  </svg>
+                </div>
+                <h2 className="text-2xl font-bold mb-2">No Review Selected</h2>
+                <p>Select a user from the queue on the left to start the verification process.</p>
               </div>
-              <h2 className="text-2xl font-bold mb-2">No Review Selected</h2>
-              <p>Select a user from the queue on the left to start the verification process.</p>
-            </div>
-          )}
+            )}
+          </div>
         </div>
       </div>
-      </div>
+
+      {/* Confirmation dialog */}
+      {pendingAction && (
+        <ConfirmDialog
+          isOpen={!!pendingAction}
+          onConfirm={handleConfirmedProcess}
+          onCancel={() => setPendingAction(null)}
+          title={`Confirm: ${pendingAction.status} KYC review`}
+          description={confirmDescription!}
+          confirmLabel={`Yes, ${pendingAction.status.toLowerCase()}`}
+          cancelLabel="Cancel"
+          variant={confirmVariant}
+          isPending={isSubmitting}
+        />
+      )}
+
+      {/* Toast notifications */}
+      <ToastContainer />
     </ProtectedPage>
   );
 }

--- a/frontend/src/components/ui/ConfirmDialog.tsx
+++ b/frontend/src/components/ui/ConfirmDialog.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { AlertTriangle, AlertCircle, Info } from "lucide-react";
+import { Modal } from "./Modal";
+import { Button } from "./Button";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type ConfirmDialogVariant = "danger" | "warning" | "default";
+
+export interface ConfirmDialogProps {
+  isOpen: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+  title: string;
+  /** Summary shown inside the dialog body */
+  description: React.ReactNode;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  variant?: ConfirmDialogVariant;
+  /** Disable the confirm button while an async action is in flight */
+  isPending?: boolean;
+}
+
+// ─── Variant config ───────────────────────────────────────────────────────────
+
+const VARIANT_CONFIG: Record<
+  ConfirmDialogVariant,
+  {
+    icon: React.ReactNode;
+    iconBg: string;
+    confirmClass: string;
+  }
+> = {
+  danger: {
+    icon: <AlertTriangle className="h-6 w-6 text-destructive" aria-hidden="true" />,
+    iconBg: "bg-destructive/10",
+    confirmClass:
+      "bg-destructive text-destructive-foreground hover:bg-destructive/90 focus-visible:ring-destructive",
+  },
+  warning: {
+    icon: <AlertCircle className="h-6 w-6 text-yellow-600" aria-hidden="true" />,
+    iconBg: "bg-yellow-100 dark:bg-yellow-900/30",
+    confirmClass:
+      "bg-yellow-600 text-white hover:bg-yellow-700 focus-visible:ring-yellow-600",
+  },
+  default: {
+    icon: <Info className="h-6 w-6 text-primary" aria-hidden="true" />,
+    iconBg: "bg-primary/10",
+    confirmClass: "",
+  },
+};
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+/**
+ * Accessible confirmation dialog.
+ *
+ * - Pressing Escape or clicking the overlay cancels without confirming.
+ * - The confirm button is styled destructively for the 'danger' variant.
+ * - Focus is trapped inside the dialog while it is open (via Modal).
+ */
+export function ConfirmDialog({
+  isOpen,
+  onConfirm,
+  onCancel,
+  title,
+  description,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  variant = "default",
+  isPending = false,
+}: ConfirmDialogProps) {
+  const { icon, iconBg, confirmClass } = VARIANT_CONFIG[variant];
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onCancel}
+      title={title}
+      size="sm"
+      closeOnOverlayClick={true}
+      closeOnEscape={true}
+      showCloseButton={false}
+    >
+      <div className="space-y-4">
+        {/* Icon + description */}
+        <div className="flex gap-4 items-start">
+          <div
+            className={`shrink-0 w-10 h-10 rounded-full flex items-center justify-center ${iconBg}`}
+          >
+            {icon}
+          </div>
+          <div className="text-sm text-muted-foreground leading-relaxed pt-1.5">
+            {description}
+          </div>
+        </div>
+
+        {/* Action buttons */}
+        <div className="flex justify-end gap-3 pt-2">
+          <Button
+            variant="outline"
+            onClick={onCancel}
+            disabled={isPending}
+          >
+            {cancelLabel}
+          </Button>
+          <Button
+            className={confirmClass || undefined}
+            onClick={onConfirm}
+            disabled={isPending}
+            aria-busy={isPending}
+          >
+            {isPending ? "Processing…" : confirmLabel}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/components/ui/Toast.tsx
+++ b/frontend/src/components/ui/Toast.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { useState, useCallback, useEffect, useRef } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { CheckCircle2, XCircle, AlertTriangle, Info, X } from "lucide-react";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type ToastVariant = "success" | "error" | "warning" | "info";
+
+export interface ToastItem {
+  id: string;
+  variant: ToastVariant;
+  message: string;
+  /** Optional error code shown below the message for error toasts */
+  code?: string;
+  duration?: number;
+}
+
+// ─── Singleton event bus ──────────────────────────────────────────────────────
+
+type ToastListener = (toast: ToastItem) => void;
+
+const addListeners: Set<ToastListener> = new Set();
+
+function emitAdd(toast: ToastItem) {
+  addListeners.forEach((fn) => fn(toast));
+}
+
+let counter = 0;
+
+// ─── Public toast API ─────────────────────────────────────────────────────────
+
+/**
+ * Imperative toast helper — can be called outside React components.
+ *
+ * @example
+ * toast.success("Action completed");
+ * toast.error("Something went wrong", "ERR_403");
+ */
+export const toast = {
+  success(message: string, duration = 4000) {
+    emitAdd({ id: `t-${++counter}`, variant: "success", message, duration });
+  },
+  error(message: string, code?: string, duration = 6000) {
+    emitAdd({ id: `t-${++counter}`, variant: "error", message, code, duration });
+  },
+  warning(message: string, duration = 4000) {
+    emitAdd({ id: `t-${++counter}`, variant: "warning", message, duration });
+  },
+  info(message: string, duration = 4000) {
+    emitAdd({ id: `t-${++counter}`, variant: "info", message, duration });
+  },
+};
+
+/** Returns the same imperative toast API. */
+export function useToast() {
+  return toast;
+}
+
+// ─── Variant styles ───────────────────────────────────────────────────────────
+
+const VARIANT_CONFIG: Record<
+  ToastVariant,
+  { icon: React.ReactNode; border: string }
+> = {
+  success: {
+    icon: <CheckCircle2 className="h-5 w-5 shrink-0 text-green-500" aria-hidden="true" />,
+    border: "border-green-500/40",
+  },
+  error: {
+    icon: <XCircle className="h-5 w-5 shrink-0 text-destructive" aria-hidden="true" />,
+    border: "border-destructive/40",
+  },
+  warning: {
+    icon: <AlertTriangle className="h-5 w-5 shrink-0 text-yellow-500" aria-hidden="true" />,
+    border: "border-yellow-500/40",
+  },
+  info: {
+    icon: <Info className="h-5 w-5 shrink-0 text-blue-500" aria-hidden="true" />,
+    border: "border-blue-500/40",
+  },
+};
+
+// ─── Single toast item ────────────────────────────────────────────────────────
+
+function ToastItemComponent({
+  item,
+  onDismiss,
+}: {
+  item: ToastItem;
+  onDismiss: (id: string) => void;
+}) {
+  const { icon, border } = VARIANT_CONFIG[item.variant];
+  const timerRef = useRef<ReturnType<typeof setTimeout>>();
+
+  useEffect(() => {
+    timerRef.current = setTimeout(() => onDismiss(item.id), item.duration ?? 4000);
+    return () => clearTimeout(timerRef.current);
+  }, [item.id, item.duration, onDismiss]);
+
+  return (
+    <motion.div
+      layout
+      initial={{ opacity: 0, y: 24, scale: 0.95 }}
+      animate={{ opacity: 1, y: 0, scale: 1 }}
+      exit={{ opacity: 0, y: 12, scale: 0.95 }}
+      transition={{ duration: 0.22, ease: "easeOut" }}
+      role="alert"
+      aria-live="polite"
+      className={`flex items-start gap-3 w-full max-w-sm rounded-lg border shadow-lg px-4 py-3 bg-background ${border}`}
+    >
+      {icon}
+      <div className="flex-1 min-w-0 text-foreground">
+        <p className="text-sm font-medium leading-snug">{item.message}</p>
+        {item.code && (
+          <p className="text-xs text-muted-foreground mt-0.5 font-mono">
+            Code: {item.code}
+          </p>
+        )}
+      </div>
+      <button
+        onClick={() => onDismiss(item.id)}
+        className="shrink-0 text-muted-foreground hover:text-foreground transition-colors -mr-1"
+        aria-label="Dismiss notification"
+      >
+        <X className="h-4 w-4" />
+      </button>
+    </motion.div>
+  );
+}
+
+// ─── ToastContainer ───────────────────────────────────────────────────────────
+
+/**
+ * Renders all active toasts in a fixed bottom-right stack.
+ * Mount once near the root of your app or on the page that needs toasts.
+ */
+export function ToastContainer() {
+  const [items, setItems] = useState<ToastItem[]>([]);
+
+  const handleAdd = useCallback((item: ToastItem) => {
+    setItems((prev) => [...prev, item]);
+  }, []);
+
+  const handleDismiss = useCallback((id: string) => {
+    setItems((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  useEffect(() => {
+    addListeners.add(handleAdd);
+    return () => {
+      addListeners.delete(handleAdd);
+    };
+  }, [handleAdd]);
+
+  return (
+    <div
+      aria-label="Notifications"
+      className="fixed bottom-4 right-4 z-[9999] flex flex-col gap-2 w-full max-w-sm pointer-events-none"
+    >
+      <AnimatePresence mode="sync">
+        {items.map((item) => (
+          <div key={item.id} className="pointer-events-auto">
+            <ToastItemComponent item={item} onDismiss={handleDismiss} />
+          </div>
+        ))}
+      </AnimatePresence>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Sensitive admin actions (dispute resolution, KYC processing) now require explicit confirmation before execution. Success and error feedback is delivered via non-blocking toasts, and all actions are logged to the client-side audit stream.

## Changes

### `frontend/src/components/ui/Toast.tsx` (new)
- Singleton event-bus toast system built on **framer-motion**.
- `toast.success()`, `toast.error(msg, code?)`, `toast.warning()`, `toast.info()` — callable anywhere.
- `ToastContainer` renders at bottom-right; auto-dismisses after 4 s / 6 s.
- Error toasts display an optional error code below the message.
- Accessible: `role="alert"`, `aria-live="polite"`.

### `frontend/src/components/ui/ConfirmDialog.tsx` (new)
- Wraps the existing `Modal` component (with full focus-trap + keyboard support).
- Props: `title`, `description` (ReactNode), `confirmLabel`, `cancelLabel`, `variant` (danger/warning/default), `isPending`.
- Destructive (`danger`) variant styles the confirm button red.
- Pressing Escape or clicking the overlay cancels without confirming — the action is never submitted.

### `frontend/src/app/[locale]/admin/disputes/page.tsx`
- `ResolveForm` now opens a `ConfirmDialog` listing dispute ID, outcome (RESOLVED/VOIDED), winner name, and note before calling `api.resolveDispute`.
- On **success**: `toast.success("Dispute resolved successfully.")`
- On **error**: `toast.error(message, errorCode)` — replaces previous `alert()`
- Client-side audit: `console.info('[AUDIT]', { action: 'resolve_dispute', disputeId, status, ... })`

### `frontend/src/app/[locale]/admin/kyc/page.tsx`
- Approve / Reject / Escalate buttons call `requestProcess(status)` which opens a `ConfirmDialog` summarising the action (username, status, notes) before any API call.
- Rejection without notes shows a `toast.warning()` instead of an `alert()`.
- On **success**: `toast.success("KYC review processed: ${status}")`
- On **error**: `toast.error(message, errorCode)` — replaces previous `alert()`
- Client-side audit: `console.info('[AUDIT]', { action: 'process_kyc', reviewId, username, status, ... })`

## Acceptance criteria

| Criterion | How addressed |
|---|---|
| Confirmation dialog before dispute resolution | `ConfirmDialog` in `ResolveForm` |
| Dismissing dialog does not submit action | Dialog cancelled → no API call |
| Success and error toasts after every action | `toast.success` / `toast.error` on mutation callbacks |
| Admin actions logged client-side | `auditLog()` helper via `console.info('[AUDIT]', ...)` |

Closes #751