### PR TITLE
feat(server): API gateway, distributed cache, GraphQL federation, and centralized logging infra

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -70,6 +70,10 @@ BACKEND_URL=http://localhost:3001
 # Leave unset to use in-memory cache (no Redis required)
 REDIS_URL="redis://localhost:6379"
 PROFILE_CACHE_TTL_SECONDS=300
+# Comma-separated "host:port" list. When set, the cache connects via Redis
+# Cluster mode (sharding + automatic failover) instead of REDIS_URL above.
+# See infra/redis-cluster/docker-compose.yml and docs/REDIS_CLUSTER.md.
+# REDIS_CLUSTER_NODES="localhost:7000,localhost:7001,localhost:7002,localhost:7003,localhost:7004,localhost:7005"
 
 # ── Rate Limiting ────────────────────────────────────────────
 # Comma-separated IPs that bypass rate limiting

--- a/server/docs/API_GATEWAY_KONG.md
+++ b/server/docs/API_GATEWAY_KONG.md
@@ -1,0 +1,94 @@
+# API Gateway — Kong
+
+Closes #653.
+
+Kong is deployed in front of `arenax-server` as the edge API gateway,
+handling the concerns that belong at the edge rather than in every route
+handler: routing, CORS, global rate limiting, request size limits,
+correlation-id propagation, and access logging.
+
+## Relationship to the existing app-level API gateway
+
+The app already has its own API-key management system
+(`src/routes/api-gateway.routes.ts`, `src/middleware/api-gateway.middleware.ts`,
+`src/services/api-gateway.service.ts`) — key issuance, rotation, per-key
+permissions, per-key usage analytics. **Kong does not replace this.** Kong
+handles gateway-level concerns that apply uniformly to *all* traffic
+(CORS, coarse rate limiting, request shaping, access logs); the app-level
+system continues to own fine-grained, per-customer API key authorization
+and billing/analytics data. This mirrors how most production setups split
+the two: a dedicated gateway for edge concerns, application code for
+business authorization.
+
+## Configuration: DB-less / declarative mode
+
+Kong runs in **DB-less mode** — `infra/kong/kong.yml` *is* the
+configuration, checked into version control, with no separate Postgres
+store to migrate, back up, or let drift from what's deployed. Changing
+routing, plugins, or rate limits means editing that file and restarting
+the container; there's no runtime Admin API mutation to reason about in
+this setup.
+
+If a future requirement needs dynamic, Admin-API-driven configuration
+changes (e.g. self-service route creation), switch `KONG_DATABASE` to
+`postgres`, add a Postgres service to the compose file, and run
+`kong migrations bootstrap` — `kong.yml` can be imported once via
+`deck sync` to seed the initial state.
+
+## What's configured
+
+See `infra/kong/kong.yml` for the full declarative config:
+
+- **Service + routes** — `arenax-server` on `host.docker.internal:3001`
+  (the TS server runs on the host via `npm run dev`, not in this compose
+  file), routed from `/api/*` and `/health`.
+- **`cors`** — single place browser access policy is defined, instead of
+  per-service CORS middleware.
+- **`rate-limiting`** — 300 req/min globally, protecting the service from
+  anonymous traffic spikes ahead of (and independent of) the app's
+  per-API-key limiter.
+- **`correlation-id`** — reuses the `X-Request-Id` header the app's
+  `correlation.middleware.ts` already reads, so a request traced at the
+  gateway stays traceable through structured application logs and, via
+  #660, through the ELK stack.
+- **`request-size-limiting`** — 10MB payload cap at the edge.
+- **`file-log`** — access logs to stdout, picked up by the same Docker
+  log pipeline as application logs.
+
+## Running locally
+
+```bash
+npm run dev                                            # arenax-server on :3001
+docker compose -f infra/kong/docker-compose.yml up -d  # Kong on :8000 (proxy) / :8001 (admin)
+
+curl http://localhost:8000/health
+curl -X POST http://localhost:8000/api/graphql \
+  -H 'content-type: application/json' \
+  -d '{"query":"{ _service { sdl } }"}'
+```
+
+From this point, `http://localhost:8000` is the entry point clients use
+instead of `http://localhost:3001` directly.
+
+## Verifying rate limiting
+
+```bash
+for i in $(seq 1 5); do curl -s -o /dev/null -w "%{http_code}\n" http://localhost:8000/health; done
+curl -sI http://localhost:8000/health | grep -i ratelimit
+```
+
+`X-RateLimit-*` response headers confirm the plugin is active; exceeding
+300 requests in a rolling minute returns `429`.
+
+## Production notes
+
+- The bundled compose file targets local development (`host.docker.internal`
+  routing to a host process). In production, `services[].url` should point
+  at the real internal service address (a Kubernetes Service DNS name, an
+  internal load balancer, etc.), and Kong itself should run as a
+  horizontally-scaled deployment behind its own load balancer — not as a
+  single container.
+- TLS termination, mTLS to upstreams, and the `key-auth`/`jwt`/`oauth2`
+  Kong plugins are natural next steps if/when gateway-level (rather than
+  app-level) authentication is required for specific routes; they're not
+  enabled here to avoid duplicating the app's existing API-key system.

--- a/server/docs/ELK_LOGGING.md
+++ b/server/docs/ELK_LOGGING.md
@@ -1,0 +1,123 @@
+# Centralized Logging — ELK Stack
+
+Closes #660.
+
+`arenax-server` already logs through winston in structured JSON
+(`src/services/logger.service.ts`) — every request carries a
+`correlation_id`, and logs are written both to the console and to
+rotated files under `LOG_DIR` (`server/logs/` by default) via
+`winston-daily-rotate-file`. This change adds the **centralized side**:
+shipping those logs to Elasticsearch and making them searchable and
+visualizable in Kibana, without changing how the app itself logs.
+
+## Architecture
+
+```
+winston (app process)
+  -> server/logs/application-*.log, error-*.log   (JSON lines, already existed)
+       -> Filebeat (tails the files)
+            -> Logstash (parses, enriches, tags log stream)
+                 -> Elasticsearch (arenax-server-logs-YYYY.MM.dd indices)
+                      -> Kibana (search, dashboards, alerts)
+```
+
+The app writes to disk and nothing else — it has **no runtime dependency
+on Logstash or Elasticsearch being up**. If the ELK stack is down, logs
+simply queue up on disk (subject to the existing `LOG_MAX_FILES`
+retention) and Filebeat catches up once it's back, resuming from its
+on-disk read offset. This was a deliberate choice over shipping logs
+directly from the winston process (e.g. via a TCP/HTTP transport): a log
+sink outage should never be able to slow down or block request handling.
+
+## Components
+
+All under `server/infra/elk/`:
+
+- **`docker-compose.yml`** — Elasticsearch, Logstash, Kibana, Filebeat.
+  Single-node, security-disabled — local development settings; see
+  Production notes below.
+- **`filebeat/filebeat.yml`** — tails `application-*.log` and
+  `error-*.log` from the bind-mounted `server/logs/` directory. Its
+  `ndjson` parser decodes each line's JSON in place, so structured fields
+  (`level`, `message`, `correlation_id`, `service`, `environment`, ...)
+  arrive at Logstash already parsed rather than as an opaque string.
+- **`logstash/pipeline/logstash.conf`** — promotes winston's `timestamp`
+  field to Elasticsearch's `@timestamp`, tags each record with which
+  rotated file it came from (`log_stream: application|error`), and writes
+  to a daily index `arenax-server-logs-YYYY.MM.dd`.
+- **`logstash/config/logstash.yml`** — minimal Logstash node config.
+
+## Running locally
+
+```bash
+docker compose -f server/infra/elk/docker-compose.yml up -d
+npm run dev   # generate some log traffic from server/
+open http://localhost:5601
+```
+
+In Kibana: **Stack Management → Index Patterns** (or **Data Views** on
+newer Kibana), create a pattern for `arenax-server-logs-*` using
+`@timestamp` as the time field. **Discover** then shows searchable,
+structured logs — filterable by `level`, `correlation_id`, `log_stream`,
+etc.
+
+## Log analysis & visualization
+
+With the index pattern in place:
+
+- **Discover** — free-text/KQL search, e.g. `level: error AND
+  correlation_id: "<id>"` to pull every log line for one request across
+  services.
+- **Dashboards** — build panels on `level` (error rate over time),
+  `log_stream`, or any field the app logs as metadata (e.g. `route`,
+  `userId` if a resolver/controller includes it).
+
+## Alerts
+
+Kibana Alerting (Stack Management → Rules) can watch the
+`arenax-server-logs-*` index directly — e.g. an Elasticsearch query rule
+firing when `level: error` count exceeds a threshold in a rolling
+window. This is configured in the Kibana UI/API rather than checked into
+this repo, since alert destinations (Slack/PagerDuty/email) are
+environment-specific credentials.
+
+## Retention
+
+Two independent retention layers exist:
+
+- **On disk**: `LOG_MAX_FILES` (default `14d`, see `.env.example`) — the
+  existing winston-daily-rotate-file setting, unchanged.
+- **In Elasticsearch**: not configured with a default ILM policy in the
+  bundled dev compose (a single-node dev cluster doesn't need one). For
+  a longer-lived environment, apply an Index Lifecycle Management policy,
+  e.g.:
+
+  ```bash
+  curl -X PUT "localhost:9200/_ilm/policy/arenax-server-logs-policy" \
+    -H 'content-type: application/json' -d '{
+      "policy": {
+        "phases": {
+          "hot":    { "actions": { "rollover": { "max_age": "1d" } } },
+          "delete": { "min_age": "14d", "actions": { "delete": {} } }
+        }
+      }
+    }'
+  ```
+
+  matched to whatever retention window compliance/ops actually requires.
+
+## Production notes
+
+The bundled compose file is for local development:
+
+- `xpack.security.enabled: "false"` — production Elasticsearch/Kibana
+  should run with security enabled (API keys / users, not open access).
+- Single-node Elasticsearch has no replica shards and no HA — production
+  needs a multi-node cluster or a managed service (Elastic Cloud, AWS
+  OpenSearch, etc.).
+- Filebeat here reads a bind-mounted host directory, which only works
+  because the app process and Filebeat share a filesystem. In a
+  containerized/Kubernetes deployment, use the Filebeat Kubernetes
+  DaemonSet with `autodiscover`, or have the app log to stdout and let
+  the container runtime's log driver forward it (both are standard
+  alternatives to the file-tailing setup used here for local dev).

--- a/server/docs/GRAPHQL_FEDERATION.md
+++ b/server/docs/GRAPHQL_FEDERATION.md
@@ -1,0 +1,102 @@
+# GraphQL Federation
+
+Closes #652.
+
+The `arenax-server` GraphQL layer (`src/graphql/`) is now a real **Apollo
+Federation v2 subgraph**, not just a standalone schema. This lets other
+services own their own GraphQL types and *extend* entities this service
+publishes (`User`, `Match`, `Tournament`) without a shared monolithic
+schema or a hard runtime dependency between services.
+
+## What changed
+
+- `src/graphql/schema.ts` — the SDL now opens with:
+
+  ```graphql
+  extend schema
+      @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@key", "@shareable"])
+  ```
+
+  and marks `User`, `Match`, and `Tournament` as federated entities via
+  `@key(fields: "id")`.
+
+- `src/graphql/resolvers.ts` — each entity type gets a `__resolveReference`
+  resolver. This is what the router/gateway calls when another subgraph
+  says "give me the rest of the fields for `{ __typename: "User", id }`".
+
+- `src/graphql/server.ts` — the schema handed to `graphql-yoga` is now built
+  with `@apollo/subgraph`'s `buildSubgraphSchema(...)` instead of a plain
+  `{ typeDefs, resolvers }` object. This automatically adds the federation
+  machinery (`_service { sdl }`, `_entities(representations: [_Any!]!)`)
+  that a gateway needs to compose this subgraph into a supergraph.
+
+Nothing about the public `/api/graphql` endpoint changes for existing
+clients — it's still a normal, directly-queryable GraphQL endpoint. The
+federation directives are additive.
+
+## Verifying subgraph compliance locally
+
+```bash
+npm run dev
+# in another shell
+curl -s -X POST http://localhost:<PORT>/api/graphql \
+  -H 'content-type: application/json' \
+  -d '{"query":"{ _service { sdl } }"}' | jq
+```
+
+A non-empty `sdl` string confirms the endpoint is a valid Federation v2
+subgraph.
+
+## Composing a supergraph
+
+This service does not run a gateway itself — federation is only useful once
+a *second* subgraph exists to compose against. When that lands, compose
+with the Apollo Rover CLI:
+
+```bash
+rover subgraph check my-supergraph@prod \
+  --schema ./schema.graphql --name arenax-server
+
+rover supergraph compose --config ./supergraph.yaml > supergraph.graphql
+```
+
+`supergraph.yaml` example:
+
+```yaml
+federation_version: 2
+subgraphs:
+  arenax-server:
+    routing_url: https://api.arenax.internal/api/graphql
+    schema:
+      subgraph_url: https://api.arenax.internal/api/graphql
+  # wallet-service, social-service, etc. added here as they adopt federation
+```
+
+The composed `supergraph.graphql` is then served by an `@apollo/gateway` or
+Apollo Router instance, which fans queries out to each subgraph and stitches
+the entity references together.
+
+## Extending an entity from another subgraph
+
+A future subgraph (e.g. a wallet service) can add fields to `User` without
+touching this codebase:
+
+```graphql
+type User @key(fields: "id") {
+  id: ID!
+  walletBalance: Int!
+}
+```
+
+When the gateway resolves a query that needs both `displayName` (owned
+here) and `walletBalance` (owned by the wallet subgraph), it calls this
+service's `_entities` resolver with `{ __typename: "User", id }` to fetch
+the base fields, then merges in the wallet subgraph's response.
+
+## Follow-up (tracked separately, out of scope for this change)
+
+- Stand up an actual Apollo Router / gateway once a second subgraph exists.
+- Add subgraph schema checks (`rover subgraph check`) to CI once there is a
+  registered graph to check against.
+- Field-level `@shareable`/`@override` usage once ownership of overlapping
+  fields needs to move between services.

--- a/server/docs/REDIS_CLUSTER.md
+++ b/server/docs/REDIS_CLUSTER.md
@@ -1,0 +1,97 @@
+# Redis Cluster
+
+Closes #655.
+
+`CacheService` (`src/services/cache.service.ts`) can now run against a
+**Redis Cluster** instead of a single Redis instance, giving the cache
+horizontal scalability (data sharded across masters) and automatic
+failover (a replica is promoted when its master goes down) — while
+keeping the existing single-instance and in-memory-fallback behavior
+unchanged for anyone who doesn't opt in.
+
+## How backend selection works
+
+`CacheService` picks a backend in this order, unchanged in spirit from
+before:
+
+1. **`REDIS_CLUSTER_NODES`** set → `RedisClusterBackend` (ioredis `Cluster`)
+2. else **`REDIS_URL`** set → `RedisBackend` (single ioredis instance, as before)
+3. else → in-memory `Map`-based backend
+
+Whichever Redis backend is selected, a connection error still falls back to
+the in-memory backend automatically (`cacheService.get/set` never throw on
+a Redis outage — see the existing `isAvailable()`/backend-selection logic).
+
+## Configuration
+
+```bash
+# .env
+REDIS_CLUSTER_NODES="localhost:7000,localhost:7001,localhost:7002,localhost:7003,localhost:7004,localhost:7005"
+```
+
+When `REDIS_CLUSTER_NODES` is set, `REDIS_URL` is ignored for the cache
+(other services that use Redis directly, e.g. rate limiting, are
+unaffected by this change and keep using `REDIS_URL`).
+
+## Sharding
+
+ioredis's `Cluster` client shards keys across masters using Redis's CRC16
+hash-slot algorithm and transparently follows `MOVED`/`ASK` redirects — no
+sharding logic lives in application code.
+
+## Automatic failover
+
+`clusterRetryStrategy` retries a command against the refreshed cluster
+topology (up to 3 times, backing off up to 2s) so a mid-flight request
+survives a master failing over to its replica. The underlying Redis
+Cluster itself performs the failover (a replica is promoted once it
+detects its master is unreachable); the app-level retry just rides out the
+brief window while that happens.
+
+## Monitoring
+
+- `redis_cluster_nodes_total` (gauge) — nodes configured (from
+  `REDIS_CLUSTER_NODES`).
+- `redis_cluster_nodes_ready` (gauge) — nodes currently reporting `ready`,
+  refreshed every 15s. `nodes_ready < nodes_total` for more than a
+  monitoring cycle means a node is down and should be investigated.
+
+Both are exposed at the existing `/metrics` Prometheus endpoint — see
+[`server/METRICS_DASHBOARD.md`](../METRICS_DASHBOARD.md) for how to wire
+alerts on custom gauges.
+
+The existing `/health` dependency probe (`buildRedisProbe` in
+`dependency-health.service.ts`) already calls `cacheService.isRedisConnected`
+under the hood, so cluster mode is covered by the existing health endpoint
+with no changes needed there.
+
+## Local development
+
+```bash
+docker compose -f server/infra/redis-cluster/docker-compose.yml up -d
+```
+
+This starts a 6-node cluster (3 masters + 3 replicas) on `localhost:7000-7005`
+using `grokzen/redis-cluster`, pre-bootstrapped — no manual
+`redis-cli --cluster create` step required. Set `REDIS_CLUSTER_NODES` as
+shown above and start the server normally.
+
+To exercise failover locally:
+
+```bash
+docker compose -f server/infra/redis-cluster/docker-compose.yml exec redis-cluster \
+  redis-cli -p 7000 shutdown nosave
+```
+
+Watch `redis_cluster_nodes_ready` drop and recover as the cluster promotes
+a replica.
+
+## Production
+
+The bundled compose file is for local development only. In production, run
+a real multi-host cluster — e.g. the Bitnami `redis-cluster` Helm chart on
+Kubernetes, or a managed cluster-mode service (AWS ElastiCache/MemoryDB,
+Azure Cache for Redis in cluster mode) — and point `REDIS_CLUSTER_NODES` at
+the real node endpoints. TLS and AUTH should be layered on via
+`redisOptions` in `RedisClusterBackend` when the target cluster requires
+them (not needed for the local dev cluster, which has neither enabled).

--- a/server/infra/elk/docker-compose.yml
+++ b/server/infra/elk/docker-compose.yml
@@ -1,0 +1,86 @@
+version: '3.8'
+
+# ELK stack (Elasticsearch, Logstash, Kibana) + Filebeat for #660.
+#
+# Log flow: winston (src/services/logger.service.ts) already writes
+# structured JSON logs to server/logs/*.log via winston-daily-rotate-file.
+# Filebeat tails those files and ships them to Logstash, which parses the
+# JSON and forwards to Elasticsearch; Kibana visualizes/searches it.
+#
+# The app process is never coupled to Logstash's availability — logs are
+# always written to disk first, so a down ELK stack never affects request
+# handling, only how quickly logs become searchable.
+#
+# Single-node, security-disabled settings below are for local development
+# only. See docs/ELK_LOGGING.md for production hardening notes.
+#
+# Usage:
+#   docker compose -f infra/elk/docker-compose.yml up -d
+#   open http://localhost:5601   # Kibana
+services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.15.0
+    environment:
+      discovery.type: single-node
+      xpack.security.enabled: "false"
+      ES_JAVA_OPTS: "-Xms512m -Xmx512m"
+    ports:
+      - "9200:9200"
+    volumes:
+      - elasticsearch_data:/usr/share/elasticsearch/data
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:9200/_cluster/health || exit 1"]
+      interval: 15s
+      timeout: 10s
+      retries: 10
+    networks:
+      - elk-network
+
+  logstash:
+    image: docker.elastic.co/logstash/logstash:8.15.0
+    volumes:
+      - ./logstash/pipeline:/usr/share/logstash/pipeline:ro
+      - ./logstash/config/logstash.yml:/usr/share/logstash/config/logstash.yml:ro
+    environment:
+      LS_JAVA_OPTS: "-Xms256m -Xmx256m"
+    ports:
+      - "5044:5044" # Beats input
+      - "9600:9600" # Logstash monitoring API
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    networks:
+      - elk-network
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:8.15.0
+    environment:
+      ELASTICSEARCH_HOSTS: http://elasticsearch:9200
+    ports:
+      - "5601:5601"
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    networks:
+      - elk-network
+
+  filebeat:
+    image: docker.elastic.co/beats/filebeat:8.15.0
+    user: root # required to read the bind-mounted log directory
+    command: ["--strict.perms=false", "-e"]
+    volumes:
+      - ./filebeat/filebeat.yml:/usr/share/filebeat/filebeat.yml:ro
+      # arenax-server's own log directory (LOG_DIR, defaults to server/logs).
+      - ../../logs:/var/log/arenax:ro
+    depends_on:
+      logstash:
+        condition: service_started
+    networks:
+      - elk-network
+
+networks:
+  elk-network:
+    driver: bridge
+
+volumes:
+  elasticsearch_data:

--- a/server/infra/elk/filebeat/filebeat.yml
+++ b/server/infra/elk/filebeat/filebeat.yml
@@ -1,0 +1,24 @@
+filebeat.inputs:
+  - type: filestream
+    id: arenax-server-logs
+    paths:
+      - /var/log/arenax/application-*.log
+      - /var/log/arenax/error-*.log
+    parsers:
+      # Each line is already a single JSON object emitted by winston
+      # (winston.format.json() in src/services/logger.service.ts) —
+      # decode it here so Filebeat forwards structured fields instead of
+      # a raw string for Logstash to re-parse.
+      - ndjson:
+          target: ""
+          overwrite_keys: true
+          add_error_key: true
+    fields:
+      service: arenax-server
+    fields_under_root: true
+
+output.logstash:
+  hosts: ["logstash:5044"]
+
+logging.level: info
+logging.to_stderr: true

--- a/server/infra/elk/logstash/config/logstash.yml
+++ b/server/infra/elk/logstash/config/logstash.yml
@@ -1,0 +1,2 @@
+http.host: "0.0.0.0"
+xpack.monitoring.enabled: false

--- a/server/infra/elk/logstash/pipeline/logstash.conf
+++ b/server/infra/elk/logstash/pipeline/logstash.conf
@@ -1,0 +1,34 @@
+input {
+  beats {
+    port => 5044
+  }
+}
+
+filter {
+  # Filebeat's ndjson parser already decoded each winston log line into
+  # top-level fields (level, message, timestamp, correlation_id, service,
+  # environment, ...). Just promote winston's `timestamp` to the
+  # canonical @timestamp Elasticsearch/Kibana expect.
+  if [timestamp] {
+    date {
+      match  => ["timestamp", "ISO8601"]
+      target => "@timestamp"
+    }
+  }
+
+  # error-%DATE%.log and application-%DATE%.log both land here; tag which
+  # rotated file a record came from so Kibana can filter by log stream.
+  if [log][file][path] {
+    grok {
+      match => { "[log][file][path]" => "%{GREEDYDATA}/(?<log_stream>application|error)-%{GREEDYDATA}\.log" }
+      tag_on_failure => ["_logstreamparsefailure"]
+    }
+  }
+}
+
+output {
+  elasticsearch {
+    hosts => ["http://elasticsearch:9200"]
+    index => "arenax-server-logs-%{+YYYY.MM.dd}"
+  }
+}

--- a/server/infra/kong/docker-compose.yml
+++ b/server/infra/kong/docker-compose.yml
@@ -1,0 +1,47 @@
+version: '3.8'
+
+# Kong API Gateway (DB-less / declarative mode) for #653.
+#
+# Usage:
+#   npm run dev                                              # start arenax-server on :3001
+#   docker compose -f infra/kong/docker-compose.yml up -d    # start Kong
+#   curl http://localhost:8000/health
+#   curl http://localhost:8000/api/graphql -X POST ...
+#
+# Admin API (http://localhost:8001) is read-only in DB-less mode — config
+# changes are made by editing kong.yml and restarting the container:
+#   docker compose -f infra/kong/docker-compose.yml restart kong
+services:
+  kong:
+    image: kong:3.6
+    environment:
+      KONG_DATABASE: "off"
+      KONG_DECLARATIVE_CONFIG: /kong/declarative/kong.yml
+      KONG_PROXY_LISTEN: "0.0.0.0:8000"
+      KONG_ADMIN_LISTEN: "0.0.0.0:8001"
+      KONG_PROXY_ACCESS_LOG: /dev/stdout
+      KONG_ADMIN_ACCESS_LOG: /dev/stdout
+      KONG_PROXY_ERROR_LOG: /dev/stderr
+      KONG_ADMIN_ERROR_LOG: /dev/stderr
+    volumes:
+      - ./kong.yml:/kong/declarative/kong.yml:ro
+    ports:
+      - "8000:8000" # Proxy — public traffic goes here instead of :3001 directly
+      - "8001:8001" # Admin API (read-only status/introspection in DB-less mode)
+    extra_hosts:
+      # Lets Kong reach the arenax-server process running on the Docker
+      # host (`npm run dev`) from inside the container. Docker Desktop
+      # (Mac/Windows) supports host.docker.internal natively; this entry
+      # makes it resolve on Linux too.
+      - "host.docker.internal:host-gateway"
+    healthcheck:
+      test: ["CMD", "kong", "health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - kong-network
+
+networks:
+  kong-network:
+    driver: bridge

--- a/server/infra/kong/kong.yml
+++ b/server/infra/kong/kong.yml
@@ -1,0 +1,95 @@
+_format_version: "3.0"
+_transform: true
+
+# Declarative (DB-less) Kong configuration for #653.
+#
+# Kong sits in front of arenax-server as the edge API gateway: centralized
+# routing, global rate limiting, CORS, and request/response shaping. It is
+# deliberately *not* where per-API-key business authorization happens —
+# that stays in the app's own key-management system
+# (src/middleware/api-gateway.middleware.ts, src/routes/api-gateway.routes.ts),
+# which already owns key issuance, rotation, and per-key permissions.
+# Kong's job is the concerns a gateway is actually good at: uniform
+# rate limiting/CORS/observability across every route without every
+# service reimplementing it.
+#
+# DB-less mode is used for reproducibility — this file *is* the config,
+# checked into git, with no separate Postgres/Cassandra store to migrate
+# or drift from. See docs/API_GATEWAY_KONG.md for how to switch to a
+# database-backed deployment for production if dynamic (Admin API-driven)
+# configuration is later required.
+
+services:
+  - name: arenax-server
+    # host.docker.internal resolves to the Docker host from inside the
+    # Kong container; the TypeScript server runs on the host via `npm run
+    # dev`, not in this compose file. See docker-compose.yml's extra_hosts
+    # for Linux compatibility.
+    url: http://host.docker.internal:3001
+    routes:
+      - name: arenax-api
+        paths:
+          - /api
+        strip_path: false
+        # GraphQL and websockets both need to reach the same upstream.
+        preserve_host: false
+
+      - name: arenax-health
+        paths:
+          - /health
+        strip_path: false
+
+plugins:
+  # Global CORS so the gateway — not every downstream service — is the
+  # single place browser access policy is defined.
+  - name: cors
+    config:
+      origins:
+        - http://localhost:3000
+      methods:
+        - GET
+        - POST
+        - PUT
+        - PATCH
+        - DELETE
+        - OPTIONS
+      headers:
+        - Accept
+        - Authorization
+        - Content-Type
+        - X-API-Key
+        - X-Request-Id
+      credentials: true
+      max_age: 3600
+
+  # Global request-level rate limiting at the edge, independent of and in
+  # addition to the app's own per-API-key limiter
+  # (apiKeyRateLimiter in api-gateway.middleware.ts). This one protects
+  # the whole service from anonymous/unauthenticated traffic spikes.
+  - name: rate-limiting
+    config:
+      minute: 300
+      policy: local
+      fault_tolerant: true
+      hide_client_headers: false
+
+  # Correlation id propagation: reuses the same header the app's own
+  # correlation.middleware.ts reads, so a request traced at the gateway is
+  # traceable through to the structured application/ELK logs.
+  - name: correlation-id
+    config:
+      header_name: X-Request-Id
+      generator: uuid
+      echo_downstream: true
+
+  # Basic request size guard at the edge.
+  - name: request-size-limiting
+    config:
+      allowed_payload_size: 10
+
+  # Structured access logs to stdout, consumed by the ELK stack's
+  # Filebeat/Docker log driver alongside application logs (#660).
+  - name: file-log
+    config:
+      path: /dev/stdout
+      reopen: false

--- a/server/infra/redis-cluster/docker-compose.yml
+++ b/server/infra/redis-cluster/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '3.8'
+
+# Local Redis Cluster for development/testing of the #655 cluster-mode
+# cache backend. Six nodes (3 masters + 3 replicas) sharing one container
+# via `grokzen/redis-cluster`, the standard image for local Redis Cluster
+# development — no manual `redis-cli --cluster create` bootstrap needed.
+#
+# Usage:
+#   docker compose -f infra/redis-cluster/docker-compose.yml up -d
+#   REDIS_CLUSTER_NODES=localhost:7000,localhost:7001,localhost:7002,localhost:7003,localhost:7004,localhost:7005 npm run dev
+#
+# For production, run an actual multi-host cluster (e.g. via the Bitnami
+# redis-cluster Helm chart or AWS ElastiCache/MemoryDB in cluster mode) and
+# point REDIS_CLUSTER_NODES at the real node addresses instead.
+services:
+  redis-cluster:
+    image: grokzen/redis-cluster:7.0.10
+    environment:
+      IP: "0.0.0.0"
+      INITIAL_PORT: 7000
+      MASTERS: 3
+      SLAVES_PER_MASTER: 1
+    ports:
+      - "7000-7005:7000-7005"
+    volumes:
+      - redis_cluster_data:/redis-data
+    healthcheck:
+      test: ["CMD", "redis-cli", "-p", "7000", "cluster", "info"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    networks:
+      - redis-cluster-network
+
+networks:
+  redis-cluster-network:
+    driver: bridge
+
+volumes:
+  redis_cluster_data:

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -8,6 +8,7 @@
             "name": "arenax-server",
             "version": "0.1.0",
             "dependencies": {
+                "@apollo/subgraph": "^2.9.3",
                 "@opentelemetry/api": "^1.9.0",
                 "@opentelemetry/auto-instrumentations-node": "^0.55.0",
                 "@opentelemetry/exporter-trace-otlp-http": "^0.57.0",
@@ -28,6 +29,8 @@
                 "dotenv": "^16.4.5",
                 "express": "^4.18.3",
                 "express-rate-limit": "^7.5.0",
+                "graphql": "^16.9.0",
+                "graphql-yoga": "^5.10.4",
                 "helmet": "^7.1.0",
                 "hpp": "^0.2.3",
                 "ioredis": "^5.3.2",
@@ -116,6 +119,49 @@
                 "openapi-types": ">=7"
             }
         },
+        "node_modules/@apollo/cache-control-types": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@apollo/cache-control-types/-/cache-control-types-1.0.3.tgz",
+            "integrity": "sha512-F17/vCp7QVwom9eG7ToauIKdAxpSoadsJnqIfyryLFSkLSOEqu+eC5Z3N8OXcUVStuOMcNHlyraRsA6rRICu4g==",
+            "license": "MIT",
+            "peerDependencies": {
+                "graphql": "14.x || 15.x || 16.x"
+            }
+        },
+        "node_modules/@apollo/federation-internals": {
+            "version": "2.14.3",
+            "resolved": "https://registry.npmjs.org/@apollo/federation-internals/-/federation-internals-2.14.3.tgz",
+            "integrity": "sha512-Qwtx6ayTkRP9U4I/LXYrBmX1WJ9qDVDrGuXT4PWfz4sI2EnKSxbgn/n+iG6+5S1VUdFAaNGpgLhMpFPak2Uirw==",
+            "license": "Elastic-2.0",
+            "dependencies": {
+                "@types/uuid": "^9.0.0",
+                "chalk": "^4.1.0",
+                "js-levenshtein": "^1.1.6",
+                "uuid": "^9.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "graphql": "^16.5.0"
+            }
+        },
+        "node_modules/@apollo/subgraph": {
+            "version": "2.14.3",
+            "resolved": "https://registry.npmjs.org/@apollo/subgraph/-/subgraph-2.14.3.tgz",
+            "integrity": "sha512-ElfvdJJFKUQn32d7zUkBaqWhco5nSknlZKp2u0Z1FdDb5PGWfXUxuVQRpCv9zfqXXwKfCWithN6uchkDzy+khQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@apollo/cache-control-types": "^1.0.2",
+                "@apollo/federation-internals": "2.14.3"
+            },
+            "engines": {
+                "node": ">=14.15.0"
+            },
+            "peerDependencies": {
+                "graphql": "^16.5.0"
+            }
+        },
         "node_modules/@budibase/handlebars-helpers": {
             "version": "0.13.1",
             "dev": true,
@@ -166,10 +212,231 @@
                 "kuler": "^2.0.0"
             }
         },
+        "node_modules/@envelop/core": {
+            "version": "5.5.1",
+            "resolved": "https://registry.npmjs.org/@envelop/core/-/core-5.5.1.tgz",
+            "integrity": "sha512-3DQg8sFskDo386TkL5j12jyRAdip/8yzK3x7YGbZBgobZ4aKXrvDU0GppU0SnmrpQnNaiTUsxBs9LKkwQ/eyvw==",
+            "license": "MIT",
+            "dependencies": {
+                "@envelop/instrumentation": "^1.0.0",
+                "@envelop/types": "^5.2.1",
+                "@whatwg-node/promise-helpers": "^1.2.4",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@envelop/instrumentation": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@envelop/instrumentation/-/instrumentation-1.0.0.tgz",
+            "integrity": "sha512-cxgkB66RQB95H3X27jlnxCRNTmPuSTgmBAq6/4n2Dtv4hsk4yz8FadA1ggmd0uZzvKqWD6CR+WFgTjhDqg7eyw==",
+            "license": "MIT",
+            "dependencies": {
+                "@whatwg-node/promise-helpers": "^1.2.1",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@envelop/types": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/@envelop/types/-/types-5.2.1.tgz",
+            "integrity": "sha512-CsFmA3u3c2QoLDTfEpGr4t25fjMU31nyvse7IzWTvb0ZycuPjMjb0fjlheh+PbhBYb9YLugnT2uY6Mwcg1o+Zg==",
+            "license": "MIT",
+            "dependencies": {
+                "@whatwg-node/promise-helpers": "^1.0.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
         "node_modules/@faker-js/faker": {
             "version": "5.5.3",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@fastify/busboy": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-3.2.0.tgz",
+            "integrity": "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==",
+            "license": "MIT"
+        },
+        "node_modules/@graphql-tools/executor": {
+            "version": "1.5.7",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/executor/-/executor-1.5.7.tgz",
+            "integrity": "sha512-UcXVClkBml+qyGEsQxfEaAkboqySVGFUd9ivn7pDc9jZSckgF6zL21cNxuRH5ZA2exneV3PTtcc0I0rDOdE0Tg==",
+            "license": "MIT",
+            "dependencies": {
+                "@graphql-tools/utils": "^11.2.2",
+                "@graphql-typed-document-node/core": "^3.2.0",
+                "@repeaterjs/repeater": "^3.1.0",
+                "@whatwg-node/disposablestack": "^0.0.6",
+                "@whatwg-node/promise-helpers": "^1.0.0",
+                "tslib": "^2.4.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/executor/node_modules/@graphql-tools/utils": {
+            "version": "11.2.2",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-11.2.2.tgz",
+            "integrity": "sha512-Do2A/t6ayqOma8m7PvpYMsCBswL+NB35BQSng4GWSBqafL2/BnfAZy/NSENPwV721Rm2fG0BHETFC0+FJJZmLw==",
+            "license": "MIT",
+            "dependencies": {
+                "@graphql-typed-document-node/core": "^3.1.1",
+                "@whatwg-node/promise-helpers": "^1.0.0",
+                "cross-inspect": "1.0.1",
+                "tslib": "^2.4.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/merge": {
+            "version": "9.2.2",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.2.2.tgz",
+            "integrity": "sha512-DSLLAztOIQId7QE3m8Ehk5lV+0pjxNSSRDHPzlYQ9E4KJ9AoUMBprC4C+eX3v4srh05S2ujm5/veqAr5yEWFSQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@graphql-tools/utils": "^11.2.2",
+                "tslib": "^2.4.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/merge/node_modules/@graphql-tools/utils": {
+            "version": "11.2.2",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-11.2.2.tgz",
+            "integrity": "sha512-Do2A/t6ayqOma8m7PvpYMsCBswL+NB35BQSng4GWSBqafL2/BnfAZy/NSENPwV721Rm2fG0BHETFC0+FJJZmLw==",
+            "license": "MIT",
+            "dependencies": {
+                "@graphql-typed-document-node/core": "^3.1.1",
+                "@whatwg-node/promise-helpers": "^1.0.0",
+                "cross-inspect": "1.0.1",
+                "tslib": "^2.4.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/schema": {
+            "version": "10.0.38",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.38.tgz",
+            "integrity": "sha512-Kckk2/vm+rELJ7ijvFaAn9ouWSVUTD0D4SJIvYF4rKeuQHAfCzE/jzMFonZVpTXleqJjPXLZjVbuaMorw7A5Og==",
+            "license": "MIT",
+            "dependencies": {
+                "@graphql-tools/merge": "^9.2.2",
+                "@graphql-tools/utils": "^11.2.2",
+                "tslib": "^2.4.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/schema/node_modules/@graphql-tools/utils": {
+            "version": "11.2.2",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-11.2.2.tgz",
+            "integrity": "sha512-Do2A/t6ayqOma8m7PvpYMsCBswL+NB35BQSng4GWSBqafL2/BnfAZy/NSENPwV721Rm2fG0BHETFC0+FJJZmLw==",
+            "license": "MIT",
+            "dependencies": {
+                "@graphql-typed-document-node/core": "^3.1.1",
+                "@whatwg-node/promise-helpers": "^1.0.0",
+                "cross-inspect": "1.0.1",
+                "tslib": "^2.4.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/utils": {
+            "version": "10.11.0",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.11.0.tgz",
+            "integrity": "sha512-iBFR9GXIs0gCD+yc3hoNswViL1O5josI33dUqiNStFI/MHLCEPduasceAcazRH77YONKNiviHBV8f7OgcT4o2Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@graphql-typed-document-node/core": "^3.1.1",
+                "@whatwg-node/promise-helpers": "^1.0.0",
+                "cross-inspect": "1.0.1",
+                "tslib": "^2.4.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+            }
+        },
+        "node_modules/@graphql-typed-document-node/core": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+            "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
+            "license": "MIT",
+            "peerDependencies": {
+                "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+            }
+        },
+        "node_modules/@graphql-yoga/logger": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@graphql-yoga/logger/-/logger-2.0.1.tgz",
+            "integrity": "sha512-Nv0BoDGLMg9QBKy9cIswQ3/6aKaKjlTh87x3GiBg2Z4RrjyrM48DvOOK0pJh1C1At+b0mUIM67cwZcFTDLN4sA==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.8.1"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@graphql-yoga/subscription": {
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/@graphql-yoga/subscription/-/subscription-5.0.5.tgz",
+            "integrity": "sha512-oCMWOqFs6QV96/NZRt/ZhTQvzjkGB4YohBOpKM4jH/lDT4qb7Lex/aGCxpi/JD9njw3zBBtMqxbaC22+tFHVvw==",
+            "license": "MIT",
+            "dependencies": {
+                "@graphql-yoga/typed-event-target": "^3.0.2",
+                "@repeaterjs/repeater": "^3.0.4",
+                "@whatwg-node/events": "^0.1.0",
+                "tslib": "^2.8.1"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@graphql-yoga/typed-event-target": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@graphql-yoga/typed-event-target/-/typed-event-target-3.0.2.tgz",
+            "integrity": "sha512-ZpJxMqB+Qfe3rp6uszCQoag4nSw42icURnBRfFYSOmTgEeOe4rD0vYlbA8spvCu2TlCesNTlEN9BLWtQqLxabA==",
+            "license": "MIT",
+            "dependencies": {
+                "@repeaterjs/repeater": "^3.0.4",
+                "tslib": "^2.8.1"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
         },
         "node_modules/@grpc/grpc-js": {
             "version": "1.14.4",
@@ -1673,6 +1940,12 @@
             "version": "1.1.2",
             "license": "BSD-3-Clause"
         },
+        "node_modules/@repeaterjs/repeater": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@repeaterjs/repeater/-/repeater-3.1.0.tgz",
+            "integrity": "sha512-TaoVksZRSx2KWYYpyLQtMQXXeS98VsgZImzW65xmiVgbYhXLk+aEsmzPLirqVuE4/XuUapH2iMtxUzaBNDzdSQ==",
+            "license": "MIT"
+        },
         "node_modules/@scarf/scarf": {
             "version": "1.4.0",
             "hasInstallScript": true,
@@ -2164,7 +2437,6 @@
         },
         "node_modules/@types/uuid": {
             "version": "9.0.8",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/ws": {
@@ -2172,6 +2444,87 @@
             "license": "MIT",
             "dependencies": {
                 "@types/node": "*"
+            }
+        },
+        "node_modules/@whatwg-node/disposablestack": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/@whatwg-node/disposablestack/-/disposablestack-0.0.6.tgz",
+            "integrity": "sha512-LOtTn+JgJvX8WfBVJtF08TGrdjuFzGJc4mkP8EdDI8ADbvO7kiexYep1o8dwnt0okb0jYclCDXF13xU7Ge4zSw==",
+            "license": "MIT",
+            "dependencies": {
+                "@whatwg-node/promise-helpers": "^1.0.0",
+                "tslib": "^2.6.3"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@whatwg-node/events": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/@whatwg-node/events/-/events-0.1.2.tgz",
+            "integrity": "sha512-ApcWxkrs1WmEMS2CaLLFUEem/49erT3sxIVjpzU5f6zmVcnijtDSrhoK2zVobOIikZJdH63jdAXOrvjf6eOUNQ==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.6.3"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@whatwg-node/fetch": {
+            "version": "0.10.13",
+            "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.10.13.tgz",
+            "integrity": "sha512-b4PhJ+zYj4357zwk4TTuF2nEe0vVtOrwdsrNo5hL+u1ojXNhh1FgJ6pg1jzDlwlT4oBdzfSwaBwMCtFCsIWg8Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@whatwg-node/node-fetch": "^0.8.3",
+                "urlpattern-polyfill": "^10.0.0"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@whatwg-node/node-fetch": {
+            "version": "0.8.6",
+            "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.8.6.tgz",
+            "integrity": "sha512-BDMdYFcerLQkwA2RTldxOqRCs6ZQD1S7UgP3pUdGUkcbgTrP/V5ko77ZkCww9DHmC4lpoYuwigGfQYj285gMvA==",
+            "license": "MIT",
+            "dependencies": {
+                "@fastify/busboy": "^3.1.1",
+                "@whatwg-node/disposablestack": "^0.0.6",
+                "@whatwg-node/promise-helpers": "^1.3.2",
+                "tslib": "^2.6.3"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@whatwg-node/promise-helpers": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@whatwg-node/promise-helpers/-/promise-helpers-1.3.2.tgz",
+            "integrity": "sha512-Nst5JdK47VIl9UcGwtv2Rcgyn5lWtZ0/mhRQ4G8NN2isxpq2TO30iqHzmwoJycjWuyUfg3GFXqP/gFHXeV57IA==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.6.3"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@whatwg-node/server": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/@whatwg-node/server/-/server-0.11.0.tgz",
+            "integrity": "sha512-VSdkwnJRr8Yv9UgB2aXB3VUPWwd6Oqnn0hycFwhg9pZgWxJXb7JmhsiXe9tmpMwjHFxli12PGcz9aI63YYloGQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@envelop/instrumentation": "^1.0.0",
+                "@whatwg-node/disposablestack": "^0.0.6",
+                "@whatwg-node/fetch": "^0.10.13",
+                "@whatwg-node/promise-helpers": "^1.3.2",
+                "tslib": "^2.6.3"
+            },
+            "engines": {
+                "node": ">=18.0.0"
             }
         },
         "node_modules/abbrev": {
@@ -2698,7 +3051,6 @@
         },
         "node_modules/chalk": {
             "version": "4.1.2",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-styles": "^4.1.0",
@@ -2975,6 +3327,18 @@
             "version": "1.1.1",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/cross-inspect": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/cross-inspect/-/cross-inspect-1.0.1.tgz",
+            "integrity": "sha512-Pcw1JTvZLSJH83iiGWt6fRcT+BjZlCDRVwYLbUcHzv/CRpB7r0MlSrGbIyQvVSNyGnbt7G4AXuyCiDR3POvZ1A==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.4.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
         },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
@@ -3811,6 +4175,47 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/graphql": {
+            "version": "16.14.2",
+            "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.2.tgz",
+            "integrity": "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==",
+            "license": "MIT",
+            "engines": {
+                "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+            }
+        },
+        "node_modules/graphql-yoga": {
+            "version": "5.21.2",
+            "resolved": "https://registry.npmjs.org/graphql-yoga/-/graphql-yoga-5.21.2.tgz",
+            "integrity": "sha512-IIRF/3xtjj2D6caAWL9177hQ8tV3mWB3hve1GRnz7njPhQ3iY1jFtSp98fNGv0yV9kaPh9kKQ8JWdJZnedVmDw==",
+            "license": "MIT",
+            "dependencies": {
+                "@envelop/core": "^5.5.1",
+                "@envelop/instrumentation": "^1.0.0",
+                "@graphql-tools/executor": "^1.5.0",
+                "@graphql-tools/schema": "^10.0.11",
+                "@graphql-tools/utils": "^10.11.0",
+                "@graphql-yoga/logger": "^2.0.1",
+                "@graphql-yoga/subscription": "^5.0.5",
+                "@whatwg-node/fetch": "^0.10.6",
+                "@whatwg-node/promise-helpers": "^1.3.2",
+                "@whatwg-node/server": "^0.11.0",
+                "lru-cache": "^10.0.0",
+                "tslib": "^2.8.1"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^15.2.0 || ^16.0.0"
+            }
+        },
+        "node_modules/graphql-yoga/node_modules/lru-cache": {
+            "version": "10.4.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+            "license": "ISC"
+        },
         "node_modules/handlebars": {
             "version": "4.7.7",
             "dev": true,
@@ -3894,7 +4299,6 @@
         },
         "node_modules/has-flag": {
             "version": "4.0.0",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -4354,6 +4758,15 @@
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/panva"
+            }
+        },
+        "node_modules/js-levenshtein": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+            "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/js-md4": {
@@ -6478,7 +6891,6 @@
         },
         "node_modules/supports-color": {
             "version": "7.2.0",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "has-flag": "^4.0.0"
@@ -6751,6 +7163,12 @@
                 "strip-json-comments": "^2.0.0"
             }
         },
+        "node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "license": "0BSD"
+        },
         "node_modules/tweetnacl": {
             "version": "1.0.3",
             "license": "Unlicense"
@@ -6873,6 +7291,12 @@
                 "querystringify": "^2.1.1",
                 "requires-port": "^1.0.0"
             }
+        },
+        "node_modules/urlpattern-polyfill": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.1.0.tgz",
+            "integrity": "sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw==",
+            "license": "MIT"
         },
         "node_modules/util-deprecate": {
             "version": "1.0.2",

--- a/server/package.json
+++ b/server/package.json
@@ -18,6 +18,7 @@
         "test:api:report": "node test/newman/run-all.js --reporter htmlextra"
     },
     "dependencies": {
+        "@apollo/subgraph": "^2.9.3",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/auto-instrumentations-node": "^0.55.0",
         "@opentelemetry/exporter-trace-otlp-http": "^0.57.0",
@@ -38,6 +39,8 @@
         "dotenv": "^16.4.5",
         "express": "^4.18.3",
         "express-rate-limit": "^7.5.0",
+        "graphql": "^16.9.0",
+        "graphql-yoga": "^5.10.4",
         "helmet": "^7.1.0",
         "hpp": "^0.2.3",
         "ioredis": "^5.3.2",

--- a/server/src/config/env.ts
+++ b/server/src/config/env.ts
@@ -84,6 +84,9 @@ const envSchema = z.object({
     // ── Redis / Cache ────────────────────────────────────────────────────────
     REDIS_URL: z.string().url().optional(),
     PROFILE_CACHE_TTL_SECONDS: intStr('300'),
+    /** Comma-separated `host:port` list. When set, the cache connects via
+     *  ioredis Cluster mode instead of a single REDIS_URL instance. */
+    REDIS_CLUSTER_NODES: z.string().optional(),
 
     // ── RabbitMQ ─────────────────────────────────────────────────────────────
     RABBITMQ_URL: z.string().url().optional(),

--- a/server/src/graphql/resolvers.ts
+++ b/server/src/graphql/resolvers.ts
@@ -183,6 +183,57 @@ export const resolvers = {
         recentMatches(parent: { id: string }, args: { limit?: number }) {
             return [];
         },
+
+        // Federation entity resolver: lets other subgraphs reference a
+        // `User` by `id` (e.g. `{ __typename: "User", id }`) and have this
+        // subgraph resolve the remaining fields it owns.
+        async __resolveReference(reference: { id: string }) {
+            const prisma = getDatabaseClient();
+            const user = await (prisma as any).user.findUnique({
+                where: { id: reference.id },
+                select: { id: true, username: true, createdAt: true },
+            });
+            if (!user) return null;
+            return {
+                id: user.id,
+                displayName: user.username,
+                rating: 1000,
+                createdAt: user.createdAt,
+            };
+        },
+    },
+
+    Match: {
+        async __resolveReference(reference: { id: string }) {
+            const prisma = getDatabaseClient();
+            const match = await (prisma as any).match.findUnique({ where: { id: reference.id } });
+            if (!match) return null;
+            return {
+                id: match.id,
+                gameMode: match.metadata?.gameMode || 'unknown',
+                teamA: [],
+                teamB: [],
+                startedAt: match.createdAt,
+            };
+        },
+    },
+
+    Tournament: {
+        async __resolveReference(reference: { id: string }) {
+            const prisma = getDatabaseClient();
+            const t = await (prisma as any).tournament.findUnique({
+                where: { id: reference.id },
+                select: { id: true, name: true, startDate: true, endDate: true, _count: { select: { participants: true } } },
+            });
+            if (!t) return null;
+            return {
+                id: t.id,
+                name: t.name,
+                startsAt: t.startDate,
+                endsAt: t.endDate,
+                participantCount: t._count.participants,
+            };
+        },
     },
 };
 

--- a/server/src/graphql/schema.ts
+++ b/server/src/graphql/schema.ts
@@ -1,10 +1,17 @@
 /**
- * GraphQL schema foundation for #467.
+ * GraphQL schema foundation for #467, promoted to an Apollo Federation v2
+ * subgraph for #652.
  *
  * Defined in raw SDL so the layer is independent of the executor
  * (Apollo, Yoga, …). The maintainer can pick the runtime later; this
  * file is the schema-as-source-of-truth for clients and for the
  * resolver registry in resolvers.ts.
+ *
+ * `User`, `Match` and `Tournament` are declared as federated entities
+ * (`@key(fields: "id")`) so other subgraphs (e.g. a future wallet or
+ * social service) can extend them with their own fields without this
+ * service knowing about it. See server/docs/GRAPHQL_FEDERATION.md for
+ * how to compose this subgraph into a supergraph.
  *
  * Only the entities that already exist on the REST surface are
  * included. Subscriptions and field-level authorisation are sketched
@@ -13,6 +20,9 @@
  * sub-items.
  */
 export const typeDefs = /* GraphQL */ `
+    extend schema
+        @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@key", "@shareable"])
+
     """
     Field-level authorisation directive. Resolvers gate on the role
     name supplied at the field; missing or insufficient roles map to
@@ -22,7 +32,7 @@ export const typeDefs = /* GraphQL */ `
 
     scalar DateTime
 
-    type User {
+    type User @key(fields: "id") {
         id: ID!
         displayName: String!
         rating: Int!
@@ -37,7 +47,7 @@ export const typeDefs = /* GraphQL */ `
         CANCELLED
     }
 
-    type Match {
+    type Match @key(fields: "id") {
         id: ID!
         gameMode: String!
         teamA: [User!]!
@@ -48,7 +58,7 @@ export const typeDefs = /* GraphQL */ `
         ratingDelta: Int
     }
 
-    type Tournament {
+    type Tournament @key(fields: "id") {
         id: ID!
         name: String!
         startsAt: DateTime!

--- a/server/src/graphql/server.ts
+++ b/server/src/graphql/server.ts
@@ -1,7 +1,16 @@
 import type { Express, RequestHandler } from 'express';
+import { parse } from 'graphql';
+import { buildSubgraphSchema } from '@apollo/subgraph';
 import { typeDefs } from './schema';
 import { resolvers } from './resolvers';
 import { buildGraphQLContext, type GraphQLContext } from './context';
+
+// Built once at module load: a real Apollo Federation v2 subgraph schema
+// (adds `_service { sdl }` and `_entities(representations: [_Any!]!)` on
+// top of the application schema). A future gateway/router composes this
+// together with other subgraphs into a supergraph — see
+// server/docs/GRAPHQL_FEDERATION.md.
+const federatedSchema = buildSubgraphSchema({ typeDefs: parse(typeDefs), resolvers: resolvers as any });
 
 export interface GraphQLRegistration {
     path: string
@@ -27,10 +36,9 @@ class YogaExecutor implements GraphQLExecutor {
                 this.yoga(req, res, next);
                 return;
             }
-            // @ts-expect-error - graphql-yoga is ESM-only; dynamic import works at runtime
             import('graphql-yoga').then(({ createYoga }: any) => {
                 this.yoga = createYoga({
-                    schema: { typeDefs, resolvers },
+                    schema: federatedSchema,
                     context: async ({ request }: { request: any }) =>
                         buildGraphQLContext(request as unknown as import('express').Request),
                     graphiql: process.env.NODE_ENV !== 'production',

--- a/server/src/services/cache.service.ts
+++ b/server/src/services/cache.service.ts
@@ -1,4 +1,4 @@
-import Redis from 'ioredis';
+import Redis, { Cluster } from 'ioredis';
 import { logger } from './logger.service';
 import { metricsService } from './metrics.service';
 
@@ -9,6 +9,19 @@ import { metricsService } from './metrics.service';
 interface InMemoryEntry {
   value: unknown;
   expiry: number;
+}
+
+/** Parse a `REDIS_CLUSTER_NODES` env value ("host1:port1,host2:port2") into ioredis node descriptors. */
+function parseClusterNodes(value?: string): Array<{ host: string; port: number }> {
+  if (!value) return [];
+  return value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .map((entry) => {
+      const [host, port] = entry.split(':');
+      return { host, port: Number(port) || 6379 };
+    });
 }
 
 // ---------------------------------------------------------------------------
@@ -24,7 +37,7 @@ interface ICacheBackend {
 }
 
 // ---------------------------------------------------------------------------
-// RedisBackend
+// RedisBackend — single-instance Redis
 // ---------------------------------------------------------------------------
 
 class RedisBackend implements ICacheBackend {
@@ -81,6 +94,82 @@ class RedisBackend implements ICacheBackend {
 }
 
 // ---------------------------------------------------------------------------
+// RedisClusterBackend — sharded, highly-available Redis Cluster (#655)
+//
+// Built on ioredis's native `Cluster` client, which:
+//   - shards keys across masters using CRC16 hash slots (no app-level
+//     sharding logic needed — `MOVED`/`ASK` redirects are handled for us)
+//   - fails over to a replica automatically when a master goes down
+//     (`CLUSTERDOWN` is retried against the new topology once the cluster
+//     itself completes failover)
+// ---------------------------------------------------------------------------
+
+class RedisClusterBackend implements ICacheBackend {
+  private client: Cluster;
+  private ready = false;
+  readonly nodeCount: number;
+
+  constructor(nodes: Array<{ host: string; port: number }>) {
+    this.nodeCount = nodes.length;
+    this.client = new Cluster(nodes, {
+      enableOfflineQueue: false,
+      // Retries a redirected/failed-over command against the refreshed
+      // cluster topology before giving up on the request.
+      clusterRetryStrategy: (times: number) => (times > 3 ? null : Math.min(times * 200, 2000)),
+      redisOptions: {
+        maxRetriesPerRequest: 1,
+      },
+    });
+
+    this.client.on('ready', () => {
+      this.ready = true;
+      logger.info('Redis Cluster connected', { nodes: this.nodeCount });
+    });
+
+    this.client.on('error', (err: Error) => {
+      this.ready = false;
+      logger.warn('Redis Cluster error — falling back to in-memory', { error: err.message });
+    });
+
+    this.client.on('close', () => {
+      this.ready = false;
+    });
+
+    this.client.on('node error', (err: Error, address: string) => {
+      logger.warn('Redis Cluster node unreachable', { address, error: err.message });
+    });
+  }
+
+  isAvailable(): boolean {
+    return this.ready;
+  }
+
+  /** Number of nodes currently reporting `ready` in the cluster topology. */
+  get readyNodeCount(): number {
+    return this.client.nodes('all').filter((n: Redis) => n.status === 'ready').length;
+  }
+
+  async get(key: string): Promise<string | null> {
+    return this.client.get(key);
+  }
+
+  async set(key: string, value: string, ttlSeconds: number): Promise<void> {
+    await this.client.set(key, value, 'EX', ttlSeconds);
+  }
+
+  async delete(key: string): Promise<void> {
+    await this.client.del(key);
+  }
+
+  async clear(): Promise<void> {
+    // FLUSHDB must be issued per-master; the cluster client has no single
+    // keyspace to flush in one call.
+    const masters = this.client.nodes('master');
+    await Promise.all(masters.map((node: Redis) => node.flushdb()));
+  }
+}
+
+// ---------------------------------------------------------------------------
 // InMemoryBackend
 // ---------------------------------------------------------------------------
 
@@ -131,16 +220,19 @@ class InMemoryBackend implements ICacheBackend {
 // ---------------------------------------------------------------------------
 
 export class CacheService {
-  private redis: RedisBackend | null = null;
+  private redis: RedisBackend | RedisClusterBackend | null = null;
   private memory: InMemoryBackend;
   /** Default TTL in seconds (overridable per call). */
   readonly defaultTTL: number;
 
-  constructor(redisUrl?: string, defaultTTL = 300) {
+  constructor(redisUrl?: string, defaultTTL = 300, clusterNodes?: string) {
     this.defaultTTL = defaultTTL;
     this.memory = new InMemoryBackend();
 
-    if (redisUrl) {
+    const parsedNodes = parseClusterNodes(clusterNodes);
+    if (parsedNodes.length > 0) {
+      this.redis = new RedisClusterBackend(parsedNodes);
+    } else if (redisUrl) {
       this.redis = new RedisBackend(redisUrl);
     } else {
       logger.info('REDIS_URL not set — using in-memory cache');
@@ -148,6 +240,15 @@ export class CacheService {
 
     // Evict stale in-memory entries every minute regardless of Redis status.
     setInterval(() => this.memory.evictExpired(), 60_000).unref();
+
+    // Surface cluster health on Prometheus every 15s so failovers/node
+    // outages are visible without scraping ioredis internals directly.
+    if (this.redis instanceof RedisClusterBackend) {
+      const cluster = this.redis;
+      setInterval(() => {
+        metricsService.setRedisClusterHealth(cluster.nodeCount, cluster.readyNodeCount);
+      }, 15_000).unref();
+    }
   }
 
   // -------------------------------------------------------------------------
@@ -242,9 +343,14 @@ export class CacheService {
     return value;
   }
 
-  /** Whether Redis is currently connected. */
+  /** Whether Redis (single-instance or cluster) is currently connected. */
   get isRedisConnected(): boolean {
     return this.redis?.isAvailable() ?? false;
+  }
+
+  /** Whether the cache is backed by a Redis Cluster (vs. a single instance). */
+  get isClusterMode(): boolean {
+    return this.redis instanceof RedisClusterBackend;
   }
 
   /** Number of entries in the in-memory fallback store. */
@@ -259,19 +365,24 @@ export class CacheService {
 
 import { getEnv } from '../config/env';
 
-const _resolveConfig = (): { redisUrl?: string; ttl: number } => {
+const _resolveConfig = (): { redisUrl?: string; ttl: number; clusterNodes?: string } => {
     try {
         const env = getEnv();
-        return { redisUrl: env.REDIS_URL, ttl: env.PROFILE_CACHE_TTL_SECONDS };
+        return {
+            redisUrl: env.REDIS_URL,
+            ttl: env.PROFILE_CACHE_TTL_SECONDS,
+            clusterNodes: env.REDIS_CLUSTER_NODES,
+        };
     } catch {
         // Fallback before initEnv() runs (e.g. unit tests importing this module directly).
         return {
             redisUrl: process.env.REDIS_URL,
             ttl: Number(process.env.PROFILE_CACHE_TTL_SECONDS ?? 300),
+            clusterNodes: process.env.REDIS_CLUSTER_NODES,
         };
     }
 };
 
-const { redisUrl, ttl } = _resolveConfig();
+const { redisUrl, ttl, clusterNodes } = _resolveConfig();
 
-export const cacheService = new CacheService(redisUrl, ttl);
+export const cacheService = new CacheService(redisUrl, ttl, clusterNodes);

--- a/server/src/services/metrics.service.ts
+++ b/server/src/services/metrics.service.ts
@@ -89,6 +89,17 @@ const cacheMissesTotal = getOrCreateCounter({
   labelNames: ['namespace'],
 });
 
+// Redis Cluster metrics (#655)
+const redisClusterNodesTotal = getOrCreateGauge({
+  name: 'redis_cluster_nodes_total',
+  help: 'Number of nodes configured in the Redis Cluster',
+});
+
+const redisClusterNodesReady = getOrCreateGauge({
+  name: 'redis_cluster_nodes_ready',
+  help: 'Number of Redis Cluster nodes currently reachable and ready',
+});
+
 // Compression metrics (issue #477)
 const compressionUncompressedBytes = getOrCreateCounter({
   name: 'http_response_uncompressed_bytes_total',
@@ -153,6 +164,12 @@ export class MetricsService {
     cacheMissesTotal.inc({ namespace });
   }
 
+  // Redis Cluster metrics (#655)
+  setRedisClusterHealth(nodesTotal: number, nodesReady: number) {
+    redisClusterNodesTotal.set(nodesTotal);
+    redisClusterNodesReady.set(nodesReady);
+  }
+
   // Compression metrics (issue #477)
   recordCompression(
     encoding: string,
@@ -193,6 +210,8 @@ export class MetricsService {
     responseSizeBytes.reset();
     cacheHitsTotal.reset();
     cacheMissesTotal.reset();
+    redisClusterNodesTotal.reset();
+    redisClusterNodesReady.reset();
     logger.info('Metrics reset');
   }
 


### PR DESCRIPTION
## Summary

Resolves four related server infrastructure/observability issues:

- **GraphQL Federation** — the GraphQL layer (`src/graphql/`) is now a real Apollo Federation v2 subgraph. `User`, `Match`, and `Tournament` are declared as `@key(fields: "id")` entities with `__resolveReference` resolvers, and the executor builds the schema via `@apollo/subgraph`'s `buildSubgraphSchema`, exposing `_service { sdl }` / `_entities(...)` for a future gateway to compose against. See `server/docs/GRAPHQL_FEDERATION.md`.
- **Redis Cluster** — `CacheService` gains a `RedisClusterBackend` (ioredis `Cluster`) selected via a new `REDIS_CLUSTER_NODES` env var, with automatic sharding/failover and Prometheus gauges (`redis_cluster_nodes_total`/`redis_cluster_nodes_ready`). Existing single-instance `REDIS_URL` and in-memory fallback behavior is unchanged when the var is unset. Local dev cluster via `server/infra/redis-cluster/docker-compose.yml`. See `server/docs/REDIS_CLUSTER.md`.
- **Kong API Gateway** — declarative (DB-less) Kong config (`server/infra/kong/kong.yml`) in front of the server for routing, CORS, global rate limiting, request size limits, and correlation-id propagation. This sits alongside — not in place of — the app's existing per-API-key auth/permissions system. See `server/docs/API_GATEWAY_KONG.md`.
- **ELK centralized logging** — Filebeat tails the existing structured winston JSON logs and ships them through Logstash into Elasticsearch/Kibana (`server/infra/elk/`). The app process stays fully decoupled from the logging pipeline's availability — it only ever writes to disk. See `server/docs/ELK_LOGGING.md`.

## Test plan

- [x] `npm run build` / `npm run lint` (`tsc --noEmit`) pass with no errors
- [x] `node --test test/graphql-schema.test.js test/graphql-resolvers.test.js test/graphql-executor.test.js` — all 12 existing GraphQL tests pass unchanged
- [x] `node --test test/game-session-cache.test.js` — existing cache tests pass (in-memory fallback path)
- [x] Manually executed `{ _service { sdl } }` and a `_entities(representations: [...])` query against the built federation schema (via `graphql-js` `execute`) — confirms valid Federation v2 subgraph behavior and entity resolution
- [x] `docker compose config` validated for all three new compose files (`infra/redis-cluster`, `infra/kong`, `infra/elk`)
- [ ] Full live smoke test of the Redis Cluster / Kong / ELK containers (image pulls were not completable in the sandbox this PR was prepared in — compose files follow standard, well-documented image configurations and are ready to run in CI/local dev with normal registry access)

Closes #652
Closes #655
Closes #653
Closes #660