### PR TITLE
fix: remove mock social data from collaboration system

### DIFF
--- a/frontend/src/components/tournaments/TournamentCoView.tsx
+++ b/frontend/src/components/tournaments/TournamentCoView.tsx
@@ -6,6 +6,7 @@ import {
   MessageSquare,
   Send,
   Check,
+  UserPlus,
 } from "lucide-react";
 import {
   Card,
@@ -45,7 +46,10 @@ export function TournamentCoView({
     if (isInCoView) {
       setActiveChannel(null, null);
     } else {
-      setActiveChannel(`tournament-${tournamentId}`, CollaborationChannelType.TOURNAMENT_COVIEW);
+      setActiveChannel(
+        `tournament-${tournamentId}`,
+        CollaborationChannelType.TOURNAMENT_COVIEW
+      );
     }
   };
 
@@ -59,6 +63,12 @@ export function TournamentCoView({
     } as any);
     setMessageInput("");
   };
+
+  const peers = channel?.users ?? [];
+  const hasPeers = peers.length > 0;
+  const messageEvents = events.filter(
+    (e) => e.type === CollaborationEventType.MESSAGE
+  );
 
   return (
     <Card className={cn("w-full", className)}>
@@ -79,19 +89,63 @@ export function TournamentCoView({
       </CardHeader>
 
       <CardContent>
-        {!isInCoView ? (
+        {/* Not joined yet */}
+        {!isInCoView && (
           <div className="text-center py-6 text-muted-foreground">
             Join the viewing party to chat and see who else is watching!
           </div>
-        ) : (
+        )}
+
+        {/* Joined but no real peers connected yet */}
+        {isInCoView && !isConnected && (
+          <div className="flex flex-col items-center gap-3 py-8 text-center">
+            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted/40">
+              <UserPlus className="h-6 w-6 text-muted-foreground" />
+            </div>
+            <div className="space-y-1">
+              <p className="text-sm font-medium">Invite friends to watch together</p>
+              <p className="text-xs text-muted-foreground">
+                Nobody else has joined yet. Share this tournament link to watch
+                with friends.
+              </p>
+            </div>
+            <div className="flex items-center gap-2 text-xs text-muted-foreground mt-1">
+              <div className="h-2 w-2 rounded-full bg-muted-foreground" />
+              Connecting…
+            </div>
+          </div>
+        )}
+
+        {/* Joined and connected, but channel is empty (no peers) */}
+        {isInCoView && isConnected && !hasPeers && (
+          <div className="flex flex-col items-center gap-3 py-8 text-center">
+            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted/40">
+              <UserPlus className="h-6 w-6 text-muted-foreground" />
+            </div>
+            <div className="space-y-1">
+              <p className="text-sm font-medium">Invite friends to watch together</p>
+              <p className="text-xs text-muted-foreground">
+                You're the only one here right now. Share this tournament link so
+                friends can join your viewing party.
+              </p>
+            </div>
+            <div className="flex items-center gap-2 text-xs text-muted-foreground mt-1">
+              <div className="h-2 w-2 rounded-full bg-success" />
+              Connected — waiting for others
+            </div>
+          </div>
+        )}
+
+        {/* Joined, connected and at least one peer is present */}
+        {isInCoView && isConnected && hasPeers && (
           <div className="space-y-4">
             {/* Connected users */}
             <div className="space-y-2">
               <h4 className="text-sm font-medium text-muted-foreground">
-                {channel?.users.length || 0} watching
+                {peers.length} watching
               </h4>
               <div className="flex flex-wrap gap-2">
-                {channel?.users.map((user) => (
+                {peers.map((user) => (
                   <div
                     key={user.id}
                     className="flex items-center gap-2 bg-muted/30 px-3 py-1.5 rounded-full"
@@ -113,28 +167,30 @@ export function TournamentCoView({
             <div className="space-y-2">
               <div className="flex items-center gap-1.5">
                 <MessageSquare className="h-4 w-4 text-muted-foreground" />
-                <span className="text-sm font-medium text-muted-foreground">Chat</span>
+                <span className="text-sm font-medium text-muted-foreground">
+                  Chat
+                </span>
               </div>
               <div className="bg-muted/20 rounded-lg p-3 max-h-48 overflow-y-auto space-y-2">
-                {events
-                  .filter((e) => e.type === CollaborationEventType.MESSAGE)
-                  .map((event) => {
-                    const msgEvent = event as any;
-                    const user = channel?.users.find((u) => u.id === msgEvent.userId);
-                    return (
-                      <div
-                        key={msgEvent.messageId}
-                        className="flex items-start gap-2 text-sm"
-                      >
-                        <span className="font-medium text-primary">
-                          {user?.username || "Unknown"}:
-                        </span>
-                        <span className="text-foreground">{msgEvent.content}</span>
-                      </div>
-                    );
-                  })}
-                {events.filter((e) => e.type === CollaborationEventType.MESSAGE).length === 0 && (
-                  <p className="text-sm text-muted-foreground text-center">No messages yet</p>
+                {messageEvents.map((event) => {
+                  const msgEvent = event as any;
+                  const user = peers.find((u) => u.id === msgEvent.userId);
+                  return (
+                    <div
+                      key={msgEvent.messageId}
+                      className="flex items-start gap-2 text-sm"
+                    >
+                      <span className="font-medium text-primary">
+                        {user?.username ?? "Unknown"}:
+                      </span>
+                      <span className="text-foreground">{msgEvent.content}</span>
+                    </div>
+                  );
+                })}
+                {messageEvents.length === 0 && (
+                  <p className="text-sm text-muted-foreground text-center">
+                    No messages yet
+                  </p>
                 )}
               </div>
               <div className="flex gap-2">
@@ -145,7 +201,7 @@ export function TournamentCoView({
                   onKeyDown={(e) => {
                     if (e.key === "Enter") handleSendMessage();
                   }}
-                  placeholder="Type a message..."
+                  placeholder="Type a message…"
                   className="flex-1 px-3 py-2 bg-muted rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary"
                 />
                 <Button
@@ -161,13 +217,8 @@ export function TournamentCoView({
 
             {/* Connection status */}
             <div className="flex items-center gap-2 text-xs text-muted-foreground">
-              <div
-                className={cn(
-                  "h-2 w-2 rounded-full",
-                  isConnected ? "bg-success" : "bg-muted-foreground"
-                )}
-              />
-              {isConnected ? "Connected" : "Disconnected"}
+              <div className="h-2 w-2 rounded-full bg-success" />
+              Connected
             </div>
           </div>
         )}

--- a/frontend/src/hooks/useCollaborationWebSocket.ts
+++ b/frontend/src/hooks/useCollaborationWebSocket.ts
@@ -3,21 +3,17 @@
 import {
   useCallback,
   useEffect,
-  useMemo,
   useRef,
   useState,
 } from "react";
 import type {
   CollaborationChannel,
   CollaborationEvent,
-  CollaborationUser,
 } from "@/types/collaboration";
 import {
   CollaborationChannelType,
   CollaborationEventType,
 } from "@/types/collaboration";
-import { mockSocialUsers } from "@/data/social";
-import { currentUser } from "@/data/user";
 
 interface UseCollaborationWebSocketOptions {
   channelId?: string;
@@ -35,17 +31,6 @@ interface UseCollaborationWebSocketReturn {
   disconnect: () => void;
 }
 
-// Mock data for demonstration
-const mockChannelBase: CollaborationChannel = {
-  id: "collab-channel-1",
-  type: CollaborationChannelType.TOURNAMENT_COVIEW,
-  name: "Tournament #1 Viewing Party",
-  users: [],
-  createdAt: Date.now(),
-  createdBy: currentUser.id,
-  tournamentId: "tournament-1",
-};
-
 export function useCollaborationWebSocket({
   channelId,
   channelType,
@@ -59,126 +44,44 @@ export function useCollaborationWebSocket({
   const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const closedRef = useRef(false);
 
-  // Mock initial channel and users
-  const initialChannel = useMemo(() => {
-    if (!channelId || !channelType) return null;
+  const disconnect = useCallback(() => {
+    closedRef.current = true;
 
-    const users: CollaborationUser[] = [
-      {
-        id: currentUser.id,
-        username: currentUser.username,
-        avatar: currentUser.avatar,
-        status: "online",
-        isReady: true,
-      },
-    ];
-
-    // Add some mock users
-    const mockUsersToAdd = [mockSocialUsers[0], mockSocialUsers[2]];
-    mockUsersToAdd.forEach((user) => {
-      users.push({
-        id: user.id,
-        username: user.username,
-        avatar: user.avatar,
-        status: user.status,
-        isReady: Math.random() > 0.5,
-      });
-    });
-
-    return {
-      ...mockChannelBase,
-      id: channelId,
-      type: channelType,
-      users,
-    } as CollaborationChannel;
-  }, [channelId, channelType]);
-
-  // Helper to send mock events (for demo purposes)
-  const sendMockEvent = useCallback(() => {
-    if (!initialChannel) return;
-
-    const eventTypes = [
-      CollaborationEventType.USER_JOINED,
-      CollaborationEventType.MESSAGE,
-      CollaborationEventType.COVIEW_POSITION,
-    ];
-    const randomType = eventTypes[Math.floor(Math.random() * eventTypes.length)];
-    const randomUser = mockSocialUsers[Math.floor(Math.random() * mockSocialUsers.length)];
-
-    let newEvent: CollaborationEvent;
-
-    switch (randomType) {
-      case CollaborationEventType.USER_JOINED:
-        newEvent = {
-          type: CollaborationEventType.USER_JOINED,
-          channelId: initialChannel.id,
-          timestamp: Date.now(),
-          userId: randomUser.id,
-          user: {
-            id: randomUser.id,
-            username: randomUser.username,
-            avatar: randomUser.avatar,
-            status: randomUser.status,
-          },
-        };
-        break;
-      case CollaborationEventType.MESSAGE:
-        newEvent = {
-          type: CollaborationEventType.MESSAGE,
-          channelId: initialChannel.id,
-          timestamp: Date.now(),
-          userId: randomUser.id,
-          content: ["Let's go!", "GG!", "Nice shot!", "Wow!"][Math.floor(Math.random() * 4)],
-          messageId: `msg-${Date.now()}`,
-        };
-        break;
-      case CollaborationEventType.COVIEW_POSITION:
-        newEvent = {
-          type: CollaborationEventType.COVIEW_POSITION,
-          channelId: initialChannel.id,
-          timestamp: Date.now(),
-          userId: randomUser.id,
-          tournamentId: initialChannel.tournamentId || "",
-          matchId: Math.random() > 0.5 ? "match-1" : undefined,
-        };
-        break;
-      default:
-        return;
+    if (wsRef.current) {
+      wsRef.current.close();
+      wsRef.current = null;
     }
 
-    setEvents((prev) => [newEvent, ...prev].slice(0, 50));
-  }, [initialChannel]);
+    if (reconnectTimeoutRef.current) {
+      clearTimeout(reconnectTimeoutRef.current);
+      reconnectTimeoutRef.current = null;
+    }
+
+    setIsConnected(false);
+    setChannel(null);
+    setEvents([]);
+  }, []);
 
   const connect = useCallback(() => {
-    if (!enabled || !initialChannel) {
+    if (!enabled || !channelId || !channelType) {
       return;
     }
 
     closedRef.current = false;
 
-    // Mock WebSocket connection (for demo)
-    setTimeout(() => {
-      if (closedRef.current) return;
-
-      setIsConnected(true);
-      setChannel(initialChannel);
-      setConnectionError(null);
-    }, 800);
-
-    return () => {
-      // Cleanup
-    };
-  }, [enabled, initialChannel]);
-
-  const disconnect = useCallback(() => {
-    closedRef.current = true;
-    setIsConnected(false);
-    setChannel(null);
-    if (reconnectTimeoutRef.current) {
-      clearTimeout(reconnectTimeoutRef.current);
-      reconnectTimeoutRef.current = null;
-    }
-  }, []);
+    // TODO: Replace with real WebSocket URL once the collaboration backend is ready.
+    // const wsUrl = `${process.env.NEXT_PUBLIC_WS_BASE_URL}/collaboration/${channelId}`;
+    // const ws = new WebSocket(wsUrl);
+    // wsRef.current = ws;
+    //
+    // ws.onopen = () => { ... };
+    // ws.onmessage = (event) => { ... };
+    // ws.onclose = () => { ... };
+    // ws.onerror = () => { ... };
+    //
+    // Until the backend is available the hook stays in an idle (not connected) state
+    // so the UI shows the empty/invite state rather than fake activity.
+  }, [enabled, channelId, channelType]);
 
   const reconnect = useCallback(() => {
     disconnect();
@@ -187,42 +90,24 @@ export function useCollaborationWebSocket({
 
   const sendEvent = useCallback(
     (event: Omit<CollaborationEvent, "timestamp" | "userId">) => {
-      if (!initialChannel) return;
+      if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) return;
 
-      const fullEvent: CollaborationEvent = {
-        ...event,
-        timestamp: Date.now(),
-        userId: currentUser.id,
-      } as CollaborationEvent;
-
-      setEvents((prev) => [fullEvent, ...prev].slice(0, 50));
+      // Events are only dispatched over a real WebSocket connection.
+      // When the backend is wired up, serialise and send here:
+      // wsRef.current.send(JSON.stringify({ ...event, timestamp: Date.now() }));
     },
-    [initialChannel]
+    []
   );
 
   useEffect(() => {
-    if (enabled && initialChannel) {
-      const cleanup = connect();
+    if (enabled && channelId) {
+      connect();
       return () => {
-        cleanup?.();
         disconnect();
       };
     }
     disconnect();
-  }, [connect, disconnect, enabled, initialChannel]);
-
-  // Simulate random events for demo purposes
-  useEffect(() => {
-    if (!isConnected) return;
-
-    const interval = setInterval(() => {
-      if (Math.random() > 0.7) {
-        sendMockEvent();
-      }
-    }, 5000);
-
-    return () => clearInterval(interval);
-  }, [isConnected, sendMockEvent]);
+  }, [connect, disconnect, enabled, channelId]);
 
   return {
     isConnected,


### PR DESCRIPTION

closes #758 
fix: remove mock social data from collaboration system

- Strip mockSocialUsers / currentUser imports from useCollaborationWebSocket
- Remove fake user seeding (ShadowNinja, DragonSlayer, ProGamer99) from channel init
- Remove sendMockEvent and the setInterval that fired fake USER_JOINED/MESSAGE events
- Hook now stays idle until a real WebSocket backend is wired up
- Add TODO comments marking where real WS URL and handlers plug in
- TournamentCoView: add three explicit render states (not-joined, connecting,
  connected-no-peers, connected-with-peers)
- Empty state shows 'Invite friends to watch together' when no real peers present
- No mock/fixture user data shown in collaboration viewer UI in production
- @/data/social no longer imported in any production component or hook
