### PR TITLE
fix: attach auth headers to all API calls and use SPA navigation

### DIFF
--- a/frontend/src/app/[locale]/friends/page.tsx
+++ b/frontend/src/app/[locale]/friends/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState } from "react";
+import { useRouter } from "next/navigation";
 import { UserPlus, Users, Search, MessageSquare } from "lucide-react";
 import { FriendsList } from "@/components/social/FriendsList";
 import { FriendRequests } from "@/components/social/FriendRequests";
@@ -8,6 +9,7 @@ import { InviteFriends } from "@/components/social/InviteFriends";
 import { useFriendsList, usePendingFriendRequests } from "@/hooks/useSocial";
 
 export default function FriendsPage() {
+  const router = useRouter();
   const [activeTab, setActiveTab] = useState<"list" | "requests" | "invite">(
     "list",
   );
@@ -95,7 +97,7 @@ export default function FriendsPage() {
               friends={filteredFriends}
               isLoading={friendsLoading}
               onMessage={(friendId) => {
-                window.location.href = `/messages?friend=${friendId}`;
+                router.push(`/messages?friend=${friendId}`);
               }}
             />
           )}

--- a/frontend/src/app/[locale]/layout.tsx
+++ b/frontend/src/app/[locale]/layout.tsx
@@ -17,6 +17,7 @@ import { NotificationProvider } from "@/contexts/NotificationContext";
 import { WebVitalsInit } from "@/components/providers/WebVitalsInit";
 import { DragAndDropProvider } from "@/components/providers/DragAndDropProvider";
 import { RumProvider } from "@/components/providers/RumProvider";
+import { RouterInitializer } from "@/components/providers/RouterInitializer";
 
 
 export function generateStaticParams() {
@@ -90,6 +91,7 @@ export default function RootLayout({
                             <NotificationProvider>
                               <RumProvider>
                                 <DragAndDropProvider>
+                                  <RouterInitializer />
                                   <AppLayout>{children}</AppLayout>
                                 </DragAndDropProvider>
                               </RumProvider>

--- a/frontend/src/components/common/ErrorBoundaryWithRetry.tsx
+++ b/frontend/src/components/common/ErrorBoundaryWithRetry.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/Button";
 import { logError } from "@/lib/errorLogger";
 import { determineErrorCategory, ErrorCategory } from "@/lib/errors";
 import { cn } from "@/lib/utils";
+import { navigate } from "@/lib/routerUtils";
 
 // ─── Props / State ────────────────────────────────────────────────────────────
 
@@ -131,7 +132,7 @@ export class ErrorBoundaryWithRetry extends Component<
           <Button
             size="sm"
             variant="outline"
-            onClick={() => { window.location.href = "/login"; }}
+            onClick={() => { navigate("/login"); }}
           >
             Sign in again
           </Button>

--- a/frontend/src/components/common/SectionErrorBoundary.tsx
+++ b/frontend/src/components/common/SectionErrorBoundary.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/Button";
 import { logError } from "@/lib/errorLogger";
 import { determineErrorCategory, ErrorCategory } from "@/lib/errors";
 import { cn } from "@/lib/utils";
+import { navigate } from "@/lib/routerUtils";
 
 // ─── Props / State ────────────────────────────────────────────────────────────
 
@@ -113,7 +114,7 @@ export class SectionErrorBoundary extends Component<
           <Button
             size="sm"
             variant="outline"
-            onClick={() => { window.location.href = "/login"; }}
+            onClick={() => { navigate("/login"); }}
           >
             Sign in again
           </Button>

--- a/frontend/src/components/providers/RouterInitializer.tsx
+++ b/frontend/src/components/providers/RouterInitializer.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { setNavigate } from "@/lib/routerUtils";
+
+/**
+ * Mounts once at the top of the app tree and wires the Next.js App Router's
+ * `push` function into the imperative `navigate()` helper in `routerUtils.ts`.
+ *
+ * This allows class components (error boundaries, etc.) to call `navigate(url)`
+ * and get proper client-side routing instead of a full-page reload.
+ *
+ * Place this inside any client-side provider that wraps the whole app.
+ */
+export function RouterInitializer() {
+  const router = useRouter();
+
+  useEffect(() => {
+    setNavigate((url) => router.push(url));
+  }, [router]);
+
+  return null;
+}

--- a/frontend/src/components/ui/ErrorBoundary.tsx
+++ b/frontend/src/components/ui/ErrorBoundary.tsx
@@ -6,6 +6,7 @@ import { AlertTriangle, RefreshCw, Home, Mail, Copy, Check } from "lucide-react"
 import { logError } from "@/lib/errorLogger";
 import { determineErrorCategory, ErrorCategory } from "@/lib/errors";
 import { datadogRum } from "@datadog/browser-rum";
+import { navigate } from "@/lib/routerUtils";
 
 // ─── Error message catalogue ──────────────────────────────────────────────────
 
@@ -105,15 +106,15 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
   };
 
   handleGoHome = (): void => {
-    window.location.href = "/";
+    navigate("/");
   };
 
   handleGoToLogin = (): void => {
-    window.location.href = "/login";
+    navigate("/login");
   };
 
   handleReportIssue = (): void => {
-    window.location.href = "/contact?error=true";
+    navigate("/contact?error=true");
   };
 
   handleCopyErrorDetails = (): void => {

--- a/frontend/src/components/ui/MobileErrorBoundary.tsx
+++ b/frontend/src/components/ui/MobileErrorBoundary.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/Button";
 import { AlertTriangle, RefreshCw, Home, Mail } from "lucide-react";
 import { logError } from "@/lib/errorLogger";
 import { determineErrorCategory, ErrorCategory } from "@/lib/errors";
+import { navigate } from "@/lib/routerUtils";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -82,11 +83,11 @@ export class MobileErrorBoundary extends Component<
   };
 
   handleGoHome = (): void => {
-    window.location.href = "/";
+    navigate("/");
   };
 
   handleReportIssue = (): void => {
-    window.location.href = "/contact?error=true";
+    navigate("/contact?error=true");
   };
 
   getErrorType(): MobileErrorType {
@@ -146,7 +147,7 @@ export class MobileErrorBoundary extends Component<
           <div className="space-y-3">
             {errorType === "auth" ? (
               <Button
-                onClick={() => { window.location.href = "/login"; }}
+                onClick={() => { navigate("/login"); }}
                 className="w-full"
                 size="lg"
               >

--- a/frontend/src/hooks/useAchievements.ts
+++ b/frontend/src/hooks/useAchievements.ts
@@ -1,95 +1,55 @@
 import { useQuery, useMutation } from '@tanstack/react-query'
 import {
-    Achievement,
-    PlayerAchievementsResponse,
-    AchievementStats,
-    AchievementUnlockedEvent,
-    ShareAchievementResponse,
+  Achievement,
+  PlayerAchievementsResponse,
+  AchievementStats,
+  AchievementUnlockedEvent,
+  ShareAchievementResponse,
 } from '@/types/achievement'
-
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000/api/v1'
+import { api } from '@/lib/api'
 
 export const useAchievements = () => {
-    return useQuery({
-        queryKey: ['achievements'],
-        queryFn: async () => {
-            const res = await fetch(`${API_BASE}/achievements`)
-            if (!res.ok) throw new Error('Failed to fetch achievements')
-            const data = await res.json()
-            return data.data as Achievement[]
-        },
-    })
+  return useQuery({
+    queryKey: ['achievements'],
+    queryFn: () => api.getAchievements(),
+  })
 }
 
 export const usePlayerAchievements = (playerId: string) => {
-    return useQuery({
-        queryKey: ['playerAchievements', playerId],
-        queryFn: async () => {
-            const res = await fetch(`${API_BASE}/achievements/player/${playerId}`)
-            if (!res.ok) throw new Error('Failed to fetch player achievements')
-            const data = await res.json()
-            return data.data as PlayerAchievementsResponse
-        },
-    })
+  return useQuery({
+    queryKey: ['playerAchievements', playerId],
+    queryFn: () => api.getPlayerAchievements(playerId),
+  })
 }
 
 export const useAchievementStats = (achievementId: string) => {
-    return useQuery({
-        queryKey: ['achievementStats', achievementId],
-        queryFn: async () => {
-            const res = await fetch(`${API_BASE}/achievements/${achievementId}/stats`)
-            if (!res.ok) throw new Error('Failed to fetch achievement stats')
-            const data = await res.json()
-            return data.data as AchievementStats
-        },
-    })
+  return useQuery({
+    queryKey: ['achievementStats', achievementId],
+    queryFn: () => api.getAchievementStats(achievementId),
+  })
 }
 
 export const useUpdateAchievementProgress = () => {
-    return useMutation({
-        mutationFn: async ({ achievementId, progress }: { achievementId: string; progress: number }) => {
-            const res = await fetch(`${API_BASE}/achievements/${achievementId}/progress`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ progress }),
-            })
-            if (!res.ok) throw new Error('Failed to update achievement progress')
-            const data = await res.json()
-            return data.data as AchievementUnlockedEvent | null
-        },
-    })
+  return useMutation({
+    mutationFn: ({ achievementId, progress }: { achievementId: string; progress: number }) =>
+      api.updateAchievementProgress(achievementId, progress),
+  })
 }
 
 export const useShareAchievement = () => {
-    return useMutation({
-        mutationFn: async (achievementId: string) => {
-            const res = await fetch(`${API_BASE}/achievements/${achievementId}/share`, {
-                method: 'POST',
-            })
-            if (!res.ok) throw new Error('Failed to share achievement')
-            const data = await res.json()
-            return data.data as ShareAchievementResponse
-        },
-    })
+  return useMutation({
+    mutationFn: (achievementId: string) => api.shareAchievement(achievementId),
+  })
 }
 
 export const useCheckAchievements = () => {
-    return useMutation({
-        mutationFn: async ({
-            eventType,
-            eventData,
-        }: {
-            eventType: string
-            eventData: Record<string, any>
-        }) => {
-            const res = await fetch(`${API_BASE}/achievements/check`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ event_type: eventType, event_data: eventData }),
-            })
-            if (!res.ok) throw new Error('Failed to check achievements')
-            const data = await res.json()
-            return data.data.unlocked_achievements as AchievementUnlockedEvent[]
-        },
-    })
+  return useMutation({
+    mutationFn: ({
+      eventType,
+      eventData,
+    }: {
+      eventType: string
+      eventData: Record<string, unknown>
+    }) => api.checkAchievements(eventType, eventData),
+  })
 }

--- a/frontend/src/hooks/useLeaderboard.ts
+++ b/frontend/src/hooks/useLeaderboard.ts
@@ -1,100 +1,61 @@
 import { useQuery, useMutation } from '@tanstack/react-query'
 import {
-    LeaderboardResponse,
-    PlayerRankResponse,
-    RankHistory,
-    SeasonalLeaderboard,
-    LeaderboardStats,
+  LeaderboardResponse,
+  PlayerRankResponse,
+  RankHistory,
+  SeasonalLeaderboard,
+  LeaderboardStats,
 } from '@/types/leaderboard'
-
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000/api/v1'
+import { api } from '@/lib/api'
 
 export const useLeaderboard = (
-    category: string,
-    limit = 100,
-    offset = 0,
-    season?: string,
-    search?: string,
+  category: string,
+  limit = 100,
+  offset = 0,
+  season?: string,
+  search?: string,
 ) => {
-    return useQuery({
-        queryKey: ['leaderboard', category, limit, offset, season, search],
-        queryFn: async () => {
-            const params = new URLSearchParams({
-                limit: String(limit),
-                offset: String(offset),
-            })
-            if (season) params.set('season', season)
-            if (search) params.set('search', search)
-            const res = await fetch(
-                `${API_BASE}/leaderboards/${category}?${params}`
-            )
-            if (!res.ok) throw new Error('Failed to fetch leaderboard')
-            return res.json() as Promise<LeaderboardResponse>
-        },
-    })
+  return useQuery({
+    queryKey: ['leaderboard', category, limit, offset, season, search],
+    queryFn: () => api.getLeaderboard(category, limit, offset, season, search),
+  })
 }
 
 export const useSeasonalLeaderboard = (
-    category: string,
-    season: string,
-    limit = 100,
-    offset = 0
+  category: string,
+  season: string,
+  limit = 100,
+  offset = 0,
 ) => {
-    return useQuery({
-        queryKey: ['leaderboard', 'seasonal', category, season, limit, offset],
-        queryFn: async () => {
-            const res = await fetch(
-                `${API_BASE}/leaderboards/${category}/season/${season}?limit=${limit}&offset=${offset}`
-            )
-            if (!res.ok) throw new Error('Failed to fetch seasonal leaderboard')
-            return res.json() as Promise<SeasonalLeaderboard>
-        },
-    })
+  return useQuery({
+    queryKey: ['leaderboard', 'seasonal', category, season, limit, offset],
+    queryFn: () => api.getSeasonalLeaderboard(category, season, limit, offset),
+  })
 }
 
 export const usePlayerRank = (category: string, playerId: string) => {
-    return useQuery({
-        queryKey: ['playerRank', category, playerId],
-        queryFn: async () => {
-            const res = await fetch(`${API_BASE}/leaderboards/${category}/player/${playerId}`)
-            if (!res.ok) throw new Error('Failed to fetch player rank')
-            return res.json() as Promise<PlayerRankResponse>
-        },
-    })
+  return useQuery({
+    queryKey: ['playerRank', category, playerId],
+    queryFn: () => api.getPlayerRank(category, playerId),
+  })
 }
 
 export const useRankHistory = (category: string, playerId: string, days = 30) => {
-    return useQuery({
-        queryKey: ['rankHistory', category, playerId, days],
-        queryFn: async () => {
-            const res = await fetch(
-                `${API_BASE}/leaderboards/${category}/history/${playerId}?days=${days}`
-            )
-            if (!res.ok) throw new Error('Failed to fetch rank history')
-            return res.json() as Promise<RankHistory>
-        },
-    })
+  return useQuery({
+    queryKey: ['rankHistory', category, playerId, days],
+    queryFn: () => api.getRankHistory(category, playerId, days),
+  })
 }
 
 export const useLeaderboardStats = (category: string) => {
-    return useQuery({
-        queryKey: ['leaderboardStats', category],
-        queryFn: async () => {
-            const res = await fetch(`${API_BASE}/leaderboards/${category}/stats`)
-            if (!res.ok) throw new Error('Failed to fetch leaderboard stats')
-            return res.json() as Promise<LeaderboardStats>
-        },
-    })
+  return useQuery({
+    queryKey: ['leaderboardStats', category],
+    queryFn: () => api.getLeaderboardStats(category),
+  })
 }
 
 export const useRefreshLeaderboard = () => {
-    return useMutation({
-        mutationFn: async (category: string) => {
-            const res = await fetch(`${API_BASE}/leaderboards/${category}/refresh`, {
-                method: 'POST',
-            })
-            if (!res.ok) throw new Error('Failed to refresh leaderboard')
-            return res.json()
-        },
-    })
+  return useMutation({
+    mutationFn: (category: string) => api.refreshLeaderboard(category),
+  })
 }

--- a/frontend/src/hooks/useSocial.ts
+++ b/frontend/src/hooks/useSocial.ts
@@ -1,6 +1,5 @@
 import { useQuery, useMutation } from '@tanstack/react-query'
 import {
-  Friend,
   FriendRequest,
   Message,
   Conversation,
@@ -9,104 +8,58 @@ import {
   FriendsListResponse,
   SocialUser,
 } from '@/types/social'
-
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000/api/v1'
+import { api } from '@/lib/api'
 
 export const useFriendsList = () => {
   return useQuery({
     queryKey: ['friends'],
-    queryFn: async () => {
-      const res = await fetch(`${API_BASE}/friends`)
-      if (!res.ok) throw new Error('Failed to fetch friends list')
-      const data = await res.json()
-      return data.data as FriendsListResponse
-    },
+    queryFn: () => api.getFriendsList(),
   })
 }
 
 export const usePendingFriendRequests = () => {
   return useQuery({
     queryKey: ['friendRequests'],
-    queryFn: async () => {
-      const res = await fetch(`${API_BASE}/friends/requests`)
-      if (!res.ok) throw new Error('Failed to fetch friend requests')
-      const data = await res.json()
-      return data.data as FriendRequest[]
-    },
+    queryFn: () => api.getPendingFriendRequests(),
   })
 }
 
 export const useSuggestedUsers = () => {
   return useQuery({
     queryKey: ['suggestedUsers'],
-    queryFn: async () => {
-      const res = await fetch(`${API_BASE}/friends/suggestions`)
-      if (!res.ok) throw new Error('Failed to fetch suggested users')
-      const data = await res.json()
-      return data.data as SocialUser[]
-    },
+    queryFn: () => api.getSuggestedUsers(),
   })
 }
 
 export const useAddFriend = () => {
   return useMutation({
-    mutationFn: async (friendId: string) => {
-      const res = await fetch(`${API_BASE}/friends/add`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ friend_id: friendId }),
-      })
-      if (!res.ok) throw new Error('Failed to send friend request')
-      const data = await res.json()
-      return data.data as FriendRequest
-    },
+    mutationFn: (friendId: string) => api.addFriend(friendId),
   })
 }
 
 export const useAcceptFriendRequest = () => {
   return useMutation({
-    mutationFn: async (requestId: string) => {
-      const res = await fetch(`${API_BASE}/friends/requests/accept`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ request_id: requestId }),
-      })
-      if (!res.ok) throw new Error('Failed to accept friend request')
-      return res.json()
-    },
+    mutationFn: (requestId: string) => api.acceptFriendRequest(requestId),
   })
 }
 
 export const useSendMessage = () => {
   return useMutation({
-    mutationFn: async ({ toUserId, content }: { toUserId: string; content: string }) => {
-      const res = await fetch(`${API_BASE}/messages/send`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ to_user_id: toUserId, content }),
-      })
-      if (!res.ok) throw new Error('Failed to send message')
-      const data = await res.json()
-      return data.data as Message
-    },
+    mutationFn: ({ toUserId, content }: { toUserId: string; content: string }) =>
+      api.sendMessage(toUserId, content),
   })
 }
 
 export const useConversations = () => {
   return useQuery({
     queryKey: ['conversations'],
-    queryFn: async () => {
-      const res = await fetch(`${API_BASE}/messages/conversations`)
-      if (!res.ok) throw new Error('Failed to fetch conversations')
-      const data = await res.json()
-      return data.data as Conversation[]
-    },
+    queryFn: () => api.getConversations(),
   })
 }
 
 export const useCreateParty = () => {
   return useMutation({
-    mutationFn: async ({
+    mutationFn: ({
       name,
       description,
       maxMembers,
@@ -114,27 +67,13 @@ export const useCreateParty = () => {
       name: string
       description?: string
       maxMembers?: number
-    }) => {
-      const res = await fetch(`${API_BASE}/party/create`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name, description, max_members: maxMembers }),
-      })
-      if (!res.ok) throw new Error('Failed to create party')
-      const data = await res.json()
-      return data.data as Party
-    },
+    }) => api.createParty({ name, description, maxMembers }),
   })
 }
 
 export const useOnlineStatus = (userId: string) => {
   return useQuery({
     queryKey: ['onlineStatus', userId],
-    queryFn: async () => {
-      const res = await fetch(`${API_BASE}/status/${userId}`)
-      if (!res.ok) throw new Error('Failed to fetch online status')
-      const data = await res.json()
-      return data.data as OnlineStatus
-    },
+    queryFn: () => api.getOnlineStatus(userId),
   })
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -23,6 +23,30 @@ import {
   KycFilters,
   ProcessKycPayload,
 } from "../types/admin";
+import {
+  Achievement,
+  PlayerAchievementsResponse,
+  AchievementStats,
+  AchievementUnlockedEvent,
+  ShareAchievementResponse,
+} from "../types/achievement";
+import {
+  LeaderboardResponse,
+  PlayerRankResponse,
+  RankHistory,
+  SeasonalLeaderboard,
+  LeaderboardStats,
+} from "../types/leaderboard";
+import {
+  Friend,
+  FriendRequest,
+  Message,
+  Conversation,
+  Party,
+  OnlineStatus,
+  FriendsListResponse,
+  SocialUser,
+} from "../types/social";
 import { AuthApiError } from "./authErrors";
 
 const TOKEN_KEY = "auth_token";
@@ -476,6 +500,166 @@ class ApiClient {
       method: "POST",
       body: JSON.stringify(data),
     });
+  }
+
+  // ── Achievement endpoints ──────────────────────────────────────────────────
+
+  async getAchievements(): Promise<Achievement[]> {
+    return this.request<Achievement[]>("/achievements");
+  }
+
+  async getPlayerAchievements(playerId: string): Promise<PlayerAchievementsResponse> {
+    return this.request<PlayerAchievementsResponse>(
+      `/achievements/player/${playerId}`
+    );
+  }
+
+  async getAchievementStats(achievementId: string): Promise<AchievementStats> {
+    return this.request<AchievementStats>(
+      `/achievements/${achievementId}/stats`
+    );
+  }
+
+  async updateAchievementProgress(
+    achievementId: string,
+    progress: number,
+  ): Promise<AchievementUnlockedEvent | null> {
+    return this.request<AchievementUnlockedEvent | null>(
+      `/achievements/${achievementId}/progress`,
+      { method: "POST", body: JSON.stringify({ progress }) },
+    );
+  }
+
+  async shareAchievement(achievementId: string): Promise<ShareAchievementResponse> {
+    return this.request<ShareAchievementResponse>(
+      `/achievements/${achievementId}/share`,
+      { method: "POST" },
+    );
+  }
+
+  async checkAchievements(
+    eventType: string,
+    eventData: Record<string, unknown>,
+  ): Promise<AchievementUnlockedEvent[]> {
+    const result = await this.request<{ unlocked_achievements: AchievementUnlockedEvent[] }>(
+      "/achievements/check",
+      {
+        method: "POST",
+        body: JSON.stringify({ event_type: eventType, event_data: eventData }),
+      },
+    );
+    return result.unlocked_achievements;
+  }
+
+  // ── Leaderboard endpoints ─────────────────────────────────────────────────
+
+  async getLeaderboard(
+    category: string,
+    limit = 100,
+    offset = 0,
+    season?: string,
+    search?: string,
+  ): Promise<LeaderboardResponse> {
+    const params = new URLSearchParams({
+      limit: String(limit),
+      offset: String(offset),
+    });
+    if (season) params.set("season", season);
+    if (search) params.set("search", search);
+    return this.request<LeaderboardResponse>(`/leaderboards/${category}?${params}`);
+  }
+
+  async getSeasonalLeaderboard(
+    category: string,
+    season: string,
+    limit = 100,
+    offset = 0,
+  ): Promise<SeasonalLeaderboard> {
+    return this.request<SeasonalLeaderboard>(
+      `/leaderboards/${category}/season/${season}?limit=${limit}&offset=${offset}`,
+    );
+  }
+
+  async getPlayerRank(category: string, playerId: string): Promise<PlayerRankResponse> {
+    return this.request<PlayerRankResponse>(
+      `/leaderboards/${category}/player/${playerId}`,
+    );
+  }
+
+  async getRankHistory(
+    category: string,
+    playerId: string,
+    days = 30,
+  ): Promise<RankHistory> {
+    return this.request<RankHistory>(
+      `/leaderboards/${category}/history/${playerId}?days=${days}`,
+    );
+  }
+
+  async getLeaderboardStats(category: string): Promise<LeaderboardStats> {
+    return this.request<LeaderboardStats>(`/leaderboards/${category}/stats`);
+  }
+
+  async refreshLeaderboard(category: string): Promise<unknown> {
+    return this.request(`/leaderboards/${category}/refresh`, { method: "POST" });
+  }
+
+  // ── Social / Friends endpoints ────────────────────────────────────────────
+
+  async getFriendsList(): Promise<FriendsListResponse> {
+    return this.request<FriendsListResponse>("/friends");
+  }
+
+  async getPendingFriendRequests(): Promise<FriendRequest[]> {
+    return this.request<FriendRequest[]>("/friends/requests");
+  }
+
+  async getSuggestedUsers(): Promise<SocialUser[]> {
+    return this.request<SocialUser[]>("/friends/suggestions");
+  }
+
+  async addFriend(friendId: string): Promise<FriendRequest> {
+    return this.request<FriendRequest>("/friends/add", {
+      method: "POST",
+      body: JSON.stringify({ friend_id: friendId }),
+    });
+  }
+
+  async acceptFriendRequest(requestId: string): Promise<unknown> {
+    return this.request("/friends/requests/accept", {
+      method: "POST",
+      body: JSON.stringify({ request_id: requestId }),
+    });
+  }
+
+  async sendMessage(toUserId: string, content: string): Promise<Message> {
+    return this.request<Message>("/messages/send", {
+      method: "POST",
+      body: JSON.stringify({ to_user_id: toUserId, content }),
+    });
+  }
+
+  async getConversations(): Promise<Conversation[]> {
+    return this.request<Conversation[]>("/messages/conversations");
+  }
+
+  async createParty(params: {
+    name: string;
+    description?: string;
+    maxMembers?: number;
+  }): Promise<Party> {
+    return this.request<Party>("/party/create", {
+      method: "POST",
+      body: JSON.stringify({
+        name: params.name,
+        description: params.description,
+        max_members: params.maxMembers,
+      }),
+    });
+  }
+
+  async getOnlineStatus(userId: string): Promise<OnlineStatus> {
+    return this.request<OnlineStatus>(`/status/${userId}`);
   }
 }
 

--- a/frontend/src/lib/routerUtils.ts
+++ b/frontend/src/lib/routerUtils.ts
@@ -1,0 +1,39 @@
+/**
+ * Imperative navigation helper for use in class components and other contexts
+ * where React hooks are unavailable.
+ *
+ * `navigate` is wired up once at app startup by `RouterInitializer`. Until it
+ * is wired, calls fall back to `window.location.assign` so there is always a
+ * working implementation (e.g. during SSR safety checks or test environments).
+ *
+ * Usage in a class component:
+ *
+ *   import { navigate } from "@/lib/routerUtils";
+ *   // ...
+ *   navigate("/login");
+ */
+
+type NavigateFn = (url: string) => void;
+
+let _navigate: NavigateFn = (url: string) => {
+  if (typeof window !== "undefined") {
+    window.location.assign(url);
+  }
+};
+
+/**
+ * Called once by `RouterInitializer` to inject the Next.js App Router's
+ * `push` function so all subsequent `navigate()` calls use client-side
+ * routing instead of a hard page reload.
+ */
+export function setNavigate(fn: NavigateFn): void {
+  _navigate = fn;
+}
+
+/**
+ * Navigate to `url` using the Next.js router (client-side, no full reload).
+ * Falls back to `window.location.assign` if the router has not been wired yet.
+ */
+export function navigate(url: string): void {
+  _navigate(url);
+}


### PR DESCRIPTION
Closes #719 
Closes #730 

- Extend ApiClient with social, leaderboard, and achievement endpoints so all requests flow through the central request() method which injects Authorization: Bearer and handles silent 401 token refresh
- Migrate useSocial.ts, useAchievements.ts, useLeaderboard.ts off raw fetch() calls to api.* methods; remove local API_BASE constants
- Add routerUtils.ts imperative navigate() helper and RouterInitializer client component so class-based error boundaries can do SPA routing
- Replace window.location.href assignments in ErrorBoundary.tsx, MobileErrorBoundary.tsx, ErrorBoundaryWithRetry.tsx, SectionErrorBoundary.tsx with navigate() from routerUtils
- Replace window.location.href in friends/page.tsx with useRouter().push()