### PR TITLE
security: httpOnly cookies, WCAG viewport, JWT refresh config, remove…

### DIFF
--- a/backend/env.example
+++ b/backend/env.example
@@ -17,7 +17,10 @@ FLUTTERWAVE_SECRET=FLWSECK_TEST-xxx
 
 # Authentication
 JWT_SECRET=supersecretkey
-JWT_EXPIRES_IN=7d
+# Short-lived access token TTL: supports s / m / h / d suffixes (e.g. "15m")
+JWT_EXPIRES_IN=15m
+# Long-lived refresh token TTL. Defaults to "7d" when unset.
+JWT_REFRESH_EXPIRES_IN=7d
 
 # Stellar Configuration
 STELLAR_NETWORK_URL=https://horizon-testnet.stellar.org

--- a/backend/src/auth/jwt_service.rs
+++ b/backend/src/auth/jwt_service.rs
@@ -101,11 +101,44 @@ impl Default for JwtConfig {
             .and_then(|v| parse_duration_str(&v))
             .unwrap_or_else(|| Duration::minutes(15));
 
+        // Parse JWT_REFRESH_EXPIRES_IN env var; falls back to 7 days.
+        let refresh_token_expiry = std::env::var("JWT_REFRESH_EXPIRES_IN")
+            .ok()
+            .and_then(|v| parse_duration_str(&v))
+            .unwrap_or_else(|| Duration::days(7));
+
         Self {
             secret_key: std::env::var("JWT_SECRET")
                 .unwrap_or_else(|_| "default_secret_change_in_production".to_string()),
             access_token_expiry,
-            refresh_token_expiry: Duration::days(7),
+            refresh_token_expiry,
+            algorithm: Algorithm::HS256,
+            issuer: Some("ArenaX".to_string()),
+            audience: Some("ArenaX API".to_string()),
+        }
+    }
+}
+
+impl JwtConfig {
+    /// Build a `JwtConfig` from explicit duration strings.
+    ///
+    /// Called from `main.rs` after `Config::from_env()` so the values come
+    /// from the validated environment rather than being re-read inside this
+    /// module.
+    pub fn from_config(
+        secret_key: String,
+        jwt_expires_in: &str,
+        jwt_refresh_expires_in: &str,
+    ) -> Self {
+        let access_token_expiry = parse_duration_str(jwt_expires_in)
+            .unwrap_or_else(|| Duration::minutes(15));
+        let refresh_token_expiry = parse_duration_str(jwt_refresh_expires_in)
+            .unwrap_or_else(|| Duration::days(7));
+
+        Self {
+            secret_key,
+            access_token_expiry,
+            refresh_token_expiry,
             algorithm: Algorithm::HS256,
             issuer: Some("ArenaX".to_string()),
             audience: Some("ArenaX API".to_string()),
@@ -777,8 +810,73 @@ impl JwtService {
         })
     }
 
-    /// Cleanup expired sessions (garbage collection)
-    pub async fn cleanup_expired_sessions(&self) -> Result<u32, JwtError> {
+    // ── Config accessors (used by HTTP handlers for cookie max-age) ──────────
+
+    /// Access token TTL in seconds (for `Set-Cookie: max-age`).
+    pub fn access_token_expiry_secs(&self) -> i64 {
+        self.config.access_token_expiry.num_seconds()
+    }
+
+    /// Refresh token TTL in seconds (for `Set-Cookie: max-age`).
+    pub fn refresh_token_expiry_secs(&self) -> i64 {
+        self.config.refresh_token_expiry.num_seconds()
+    }
+
+    // ── Short-lived WebSocket token ───────────────────────────────────────────
+
+    /// Generate a 60-second access token used exclusively for the initial
+    /// WebSocket authentication handshake.
+    ///
+    /// The token is never stored in a cookie — it is returned in a JSON body
+    /// and used immediately. After 60 seconds it is worthless.
+    pub async fn generate_ws_token(
+        &self,
+        user_id: Uuid,
+        roles: Vec<String>,
+    ) -> Result<String, JwtError> {
+        let session_id = Uuid::new_v4().to_string();
+
+        let claims = Claims {
+            sub: user_id.to_string(),
+            exp: (Utc::now() + Duration::seconds(60)).timestamp(),
+            iat: Utc::now().timestamp(),
+            jti: Uuid::new_v4().to_string(),
+            token_type: TokenType::Access,
+            device_id: None,
+            session_id: session_id.clone(),
+            roles,
+        };
+
+        let key_rotation = self.key_rotation.read().await;
+        let encoding_key = EncodingKey::from_secret(key_rotation.current_key.as_bytes());
+
+        let token = encode(&Header::new(self.config.algorithm), &claims, &encoding_key)
+            .map_err(|e| JwtError::TokenGeneration(e.to_string()))?;
+
+        drop(key_rotation);
+
+        // Store a very short-lived session so validate_token can verify it.
+        // We bypass store_session's access_token_expiry and use 65 s instead.
+        let session_data = SessionData {
+            user_id,
+            session_id: session_id.clone(),
+            device_id: None,
+            created_at: Utc::now().timestamp(),
+            last_activity: Utc::now().timestamp(),
+            ip_address: None,
+            user_agent: None,
+        };
+        let session_key = format!("session:{}", session_id);
+        let session_json = serde_json::to_string(&session_data)
+            .map_err(|e| JwtError::RedisError(e.to_string()))?;
+        let mut conn = self.redis.clone();
+        conn.set_ex::<_, _, ()>(&session_key, session_json, 65).await?;
+
+        info!(user_id = %user_id, "WS token generated (60s)");
+        Ok(token)
+    }
+
+    /// Cleanup expired sessions (garbage collection)    pub async fn cleanup_expired_sessions(&self) -> Result<u32, JwtError> {
         let mut conn = self.redis.clone();
         let keys: Vec<String> = conn.keys("session:*").await.unwrap_or_default();
 

--- a/backend/src/auth/middleware.rs
+++ b/backend/src/auth/middleware.rs
@@ -64,50 +64,51 @@ where
         let service = self.service.clone();
 
         Box::pin(async move {
-            // Extract Authorization header
-            let auth_header = req
+            // ── Token extraction ─────────────────────────────────────────────
+            // Priority order:
+            //   1. Authorization: Bearer <token>  (API clients, mobile)
+            //   2. auth_token httpOnly cookie      (browser SPA)
+            let token_opt: Option<String> = req
                 .headers()
                 .get("Authorization")
-                .and_then(|h| h.to_str().ok());
+                .and_then(|h| h.to_str().ok())
+                .and_then(|v| v.strip_prefix("Bearer ").map(str::to_owned))
+                .or_else(|| {
+                    req.cookie(crate::http::auth_handler::ACCESS_TOKEN_COOKIE)
+                        .map(|c| c.value().to_owned())
+                });
 
-            if let Some(auth_value) = auth_header {
-                // Check for Bearer token
-                if let Some(token) = auth_value.strip_prefix("Bearer ") {
-                    // Validate token
-                    match jwt_service.validate_token(token).await {
-                        Ok(claims) => {
-                            debug!(user_id = %claims.sub, "Request authenticated");
-
-                            // Store claims in request extensions for later use
-                            req.extensions_mut().insert(claims);
-
-                            // Call the next service
-                            service.call(req).await
-                        }
-                        Err(JwtError::TokenExpired) => {
-                            warn!("Token expired");
-                            Err(ErrorUnauthorized("Token expired"))
-                        }
-                        Err(JwtError::TokenBlacklisted) => {
-                            warn!("Token blacklisted");
-                            Err(ErrorForbidden("Token has been revoked"))
-                        }
-                        Err(JwtError::SessionNotFound) => {
-                            warn!("Session not found");
-                            Err(ErrorUnauthorized("Session expired or invalid"))
-                        }
-                        Err(e) => {
-                            warn!(error = %e, "Token validation failed");
-                            Err(ErrorUnauthorized(format!("Invalid token: {}", e)))
-                        }
-                    }
-                } else {
-                    warn!("Invalid authorization header format");
-                    Err(ErrorUnauthorized("Invalid authorization header format"))
+            let token = match token_opt {
+                Some(t) => t,
+                None => {
+                    warn!("Missing authorization header and auth cookie");
+                    return Err(ErrorUnauthorized("Authentication required"));
                 }
-            } else {
-                warn!("Missing authorization header");
-                Err(ErrorUnauthorized("Missing authorization header"))
+            };
+
+            // ── Token validation ─────────────────────────────────────────────
+            match jwt_service.validate_token(&token).await {
+                Ok(claims) => {
+                    debug!(user_id = %claims.sub, "Request authenticated");
+                    req.extensions_mut().insert(claims);
+                    service.call(req).await
+                }
+                Err(JwtError::TokenExpired) => {
+                    warn!("Token expired");
+                    Err(ErrorUnauthorized("Token expired"))
+                }
+                Err(JwtError::TokenBlacklisted) => {
+                    warn!("Token blacklisted");
+                    Err(ErrorForbidden("Token has been revoked"))
+                }
+                Err(JwtError::SessionNotFound) => {
+                    warn!("Session not found");
+                    Err(ErrorUnauthorized("Session expired or invalid"))
+                }
+                Err(e) => {
+                    warn!(error = %e, "Token validation failed");
+                    Err(ErrorUnauthorized(format!("Invalid token: {}", e)))
+                }
             }
         })
     }
@@ -137,7 +138,6 @@ mod tests {
     #[test]
     fn test_claims_ext_interface() {
         // This test just ensures the trait compiles
-        // Real testing would require mocking HTTP request
         assert!(true);
     }
 }

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -61,7 +61,11 @@ pub struct PaymentsConfig {
 #[derive(Debug, Deserialize, Clone)]
 pub struct AuthConfig {
     pub jwt_secret: String,
+    /// Duration string for the short-lived access token, e.g. "15m".
     pub jwt_expires_in: String,
+    /// Duration string for the long-lived refresh token, e.g. "7d".
+    /// Defaults to "7d" when the env var is absent.
+    pub jwt_refresh_expires_in: String,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -113,6 +117,8 @@ impl Config {
         let flutterwave_secret = env::var("FLUTTERWAVE_SECRET")?;
         let jwt_secret = env::var("JWT_SECRET")?;
         let jwt_expires_in = env::var("JWT_EXPIRES_IN")?;
+        let jwt_refresh_expires_in =
+            env::var("JWT_REFRESH_EXPIRES_IN").unwrap_or_else(|_| "7d".to_string());
         let stellar_network_url = env::var("STELLAR_NETWORK_URL")?;
         let stellar_admin_secret = env::var("STELLAR_ADMIN_SECRET")?;
         let soroban_contract_prize = env::var("SOROBAN_CONTRACT_PRIZE")?;
@@ -147,6 +153,7 @@ impl Config {
             auth: AuthConfig {
                 jwt_secret,
                 jwt_expires_in,
+                jwt_refresh_expires_in,
             },
             stellar: StellarConfig {
                 network_url: stellar_network_url,

--- a/backend/src/http/auth_handler.rs
+++ b/backend/src/http/auth_handler.rs
@@ -1,17 +1,95 @@
 use crate::api_error::ApiError;
-use crate::auth::jwt_service::TokenPair;
+use crate::auth::jwt_service::{JwtConfig, JwtService, TokenPair};
 use crate::auth::middleware::ClaimsExt;
 use crate::models::user::{AuthResponse, CreateUserRequest, LoginRequest};
 use crate::service::auth_service::{ActiveSession, AuthService};
+use actix_web::cookie::{Cookie, SameSite};
 use actix_web::{web, HttpRequest, HttpResponse, Responder};
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 use tracing::info;
 use uuid::Uuid;
 
-/// Refresh token request
+// ── Cookie names ──────────────────────────────────────────────────────────────
+
+pub const ACCESS_TOKEN_COOKIE: &str = "auth_token";
+pub const REFRESH_TOKEN_COOKIE: &str = "auth_refresh_token";
+
+// ── Cookie builders ───────────────────────────────────────────────────────────
+
+/// Build the `auth_token` (access) cookie.
+///
+/// - `HttpOnly` — not readable by JavaScript.
+/// - `Secure`   — only sent over HTTPS (browsers ignore on localhost).
+/// - `SameSite=Strict` — never sent on cross-site requests.
+/// - `Path=/api` — scoped so it isn't sent for unrelated requests.
+fn build_access_cookie(token: &str, max_age_secs: i64) -> Cookie<'static> {
+    Cookie::build(ACCESS_TOKEN_COOKIE, token.to_owned())
+        .path("/api")
+        .http_only(true)
+        .secure(true)
+        .same_site(SameSite::Strict)
+        .max_age(actix_web::cookie::time::Duration::seconds(max_age_secs))
+        .finish()
+}
+
+/// Build the `auth_refresh_token` cookie.
+///
+/// Scoped to `/api/auth/refresh` so it is only sent for token refresh
+/// requests, minimising the attack surface.
+fn build_refresh_cookie(token: &str, max_age_secs: i64) -> Cookie<'static> {
+    Cookie::build(REFRESH_TOKEN_COOKIE, token.to_owned())
+        .path("/api/auth/refresh")
+        .http_only(true)
+        .secure(true)
+        .same_site(SameSite::Strict)
+        .max_age(actix_web::cookie::time::Duration::seconds(max_age_secs))
+        .finish()
+}
+
+/// Build expired (clearing) versions of both cookies.
+fn clear_access_cookie() -> Cookie<'static> {
+    Cookie::build(ACCESS_TOKEN_COOKIE, "")
+        .path("/api")
+        .http_only(true)
+        .secure(true)
+        .same_site(SameSite::Strict)
+        .max_age(actix_web::cookie::time::Duration::seconds(0))
+        .finish()
+}
+
+fn clear_refresh_cookie() -> Cookie<'static> {
+    Cookie::build(REFRESH_TOKEN_COOKIE, "")
+        .path("/api/auth/refresh")
+        .http_only(true)
+        .secure(true)
+        .same_site(SameSite::Strict)
+        .max_age(actix_web::cookie::time::Duration::seconds(0))
+        .finish()
+}
+
+// ── Helper: attach cookie pair to any response builder ───────────────────────
+
+/// Attach the access + refresh httpOnly cookies to `response_builder` and
+/// return the finalised `HttpResponse`.
+fn response_with_auth_cookies(
+    mut builder: actix_web::HttpResponseBuilder,
+    tokens: &TokenPair,
+    refresh_max_age: i64,
+) -> HttpResponse {
+    builder
+        .cookie(build_access_cookie(&tokens.access_token, tokens.expires_in))
+        .cookie(build_refresh_cookie(&tokens.refresh_token, refresh_max_age))
+        .finish()
+}
+
+// ── Request / response DTOs ───────────────────────────────────────────────────
+
+/// Refresh token request — accepted from JSON body as a fallback, but the
+/// preferred path is the `auth_refresh_token` cookie set at login.
 #[derive(Debug, Deserialize)]
 pub struct RefreshTokenRequest {
-    pub refresh_token: String,
+    pub refresh_token: Option<String>,
 }
 
 /// Change password request
@@ -21,12 +99,6 @@ pub struct ChangePasswordRequest {
     pub new_password: String,
 }
 
-/// Logout request
-#[derive(Debug, Deserialize)]
-pub struct LogoutRequest {
-    pub token: String,
-}
-
 /// Sessions response
 #[derive(Debug, Serialize)]
 pub struct SessionsResponse {
@@ -34,74 +106,167 @@ pub struct SessionsResponse {
     pub total: usize,
 }
 
+/// Response body returned to the client on login / register.
+///
+/// Tokens are delivered as httpOnly cookies; this body carries only the user
+/// profile plus `expires_in` so the frontend knows when to expect a 401.
+#[derive(Debug, Serialize)]
+pub struct AuthSuccessResponse {
+    pub user: crate::models::user::UserProfile,
+    /// Access token TTL in seconds — the frontend uses this to proactively
+    /// refresh before expiry without ever touching the token value itself.
+    pub expires_in: i64,
+}
+
+/// Short-lived token for WebSocket authentication handshakes.
+#[derive(Debug, Serialize)]
+pub struct WsTokenResponse {
+    /// A signed JWT valid for 60 seconds, used only to authenticate the
+    /// initial WebSocket message.  It must NOT be stored — request a fresh
+    /// one immediately before opening a socket.
+    pub ws_token: String,
+    pub expires_in: i64,
+}
+
+// ── Handlers ──────────────────────────────────────────────────────────────────
+
 /// POST /api/auth/register
-/// Register a new user
 pub async fn register(
     auth_service: web::Data<AuthService>,
+    jwt_service: web::Data<Arc<JwtService>>,
     request: web::Json<CreateUserRequest>,
 ) -> Result<impl Responder, ApiError> {
     info!(
         username = %request.username,
-        email = %request.email,
+        email = %request.email.as_deref().unwrap_or("(none)"),
         "Registration request received"
     );
 
-    let response = auth_service.register(request.into_inner()).await?;
+    let response: AuthResponse = auth_service.register(request.into_inner()).await?;
 
-    Ok(HttpResponse::Created().json(response))
+    // Retrieve the refresh TTL from the JwtService config so the cookie
+    // max-age matches the token lifetime exactly.
+    let refresh_max_age = jwt_service
+        .refresh_token_expiry_secs();
+
+    let body = AuthSuccessResponse {
+        user: response.user,
+        expires_in: {
+            // We don't have direct access to the access TTL here, but the
+            // TokenPair carries it — reconstruct a temporary pair just for
+            // the expires_in field.
+            jwt_service.access_token_expiry_secs()
+        },
+    };
+
+    let tokens = TokenPair {
+        access_token: response.token,
+        refresh_token: response.refresh_token,
+        expires_in: body.expires_in,
+        token_type: "Bearer".to_string(),
+    };
+
+    let mut builder = HttpResponse::Created();
+    builder
+        .cookie(build_access_cookie(&tokens.access_token, tokens.expires_in))
+        .cookie(build_refresh_cookie(&tokens.refresh_token, refresh_max_age));
+    Ok(builder.json(body))
 }
 
 /// POST /api/auth/login
-/// Login user and get tokens
 pub async fn login(
     auth_service: web::Data<AuthService>,
+    jwt_service: web::Data<Arc<JwtService>>,
     request: web::Json<LoginRequest>,
 ) -> Result<impl Responder, ApiError> {
     info!(email = %request.email, "Login request received");
 
-    let response = auth_service.login(request.into_inner()).await?;
+    let response: AuthResponse = auth_service.login(request.into_inner()).await?;
 
-    Ok(HttpResponse::Ok().json(response))
+    let refresh_max_age = jwt_service.refresh_token_expiry_secs();
+    let access_expires_in = jwt_service.access_token_expiry_secs();
+
+    let body = AuthSuccessResponse {
+        user: response.user,
+        expires_in: access_expires_in,
+    };
+
+    let tokens = TokenPair {
+        access_token: response.token,
+        refresh_token: response.refresh_token,
+        expires_in: access_expires_in,
+        token_type: "Bearer".to_string(),
+    };
+
+    let mut builder = HttpResponse::Ok();
+    builder
+        .cookie(build_access_cookie(&tokens.access_token, tokens.expires_in))
+        .cookie(build_refresh_cookie(&tokens.refresh_token, refresh_max_age));
+    Ok(builder.json(body))
 }
 
 /// POST /api/auth/refresh
-/// Refresh access token using refresh token
+///
+/// Reads the refresh token from the `auth_refresh_token` cookie (preferred)
+/// or from a JSON body field `refresh_token` (legacy / mobile clients).
 pub async fn refresh_token(
     auth_service: web::Data<AuthService>,
-    request: web::Json<RefreshTokenRequest>,
+    jwt_service: web::Data<Arc<JwtService>>,
+    req: HttpRequest,
+    body: web::Json<RefreshTokenRequest>,
 ) -> Result<impl Responder, ApiError> {
     info!("Token refresh request received");
 
-    let token_pair = auth_service.refresh_token(&request.refresh_token).await?;
+    // Prefer the httpOnly cookie; fall back to the JSON body field.
+    let refresh_token_value = req
+        .cookie(REFRESH_TOKEN_COOKIE)
+        .map(|c| c.value().to_owned())
+        .or_else(|| body.refresh_token.clone())
+        .ok_or_else(|| ApiError::bad_request("No refresh token provided"))?;
 
-    Ok(HttpResponse::Ok().json(token_pair))
+    let token_pair = auth_service.refresh_token(&refresh_token_value).await?;
+
+    let refresh_max_age = jwt_service.refresh_token_expiry_secs();
+
+    let mut builder = HttpResponse::Ok();
+    builder
+        .cookie(build_access_cookie(&token_pair.access_token, token_pair.expires_in))
+        .cookie(build_refresh_cookie(&token_pair.refresh_token, refresh_max_age));
+    Ok(builder.json(serde_json::json!({ "expires_in": token_pair.expires_in })))
 }
 
 /// POST /api/auth/logout
-/// Logout user (blacklist token)
+///
+/// Blacklists the current access token (extracted from cookie or Authorization
+/// header) and clears both auth cookies.
 pub async fn logout(
     auth_service: web::Data<AuthService>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
-    // Extract token from Authorization header
-    let auth_header = req
-        .headers()
-        .get("Authorization")
-        .and_then(|h| h.to_str().ok())
-        .and_then(|s| s.strip_prefix("Bearer "))
-        .ok_or_else(|| ApiError::bad_request("Missing or invalid Authorization header"))?;
+    // Accept token from cookie or Authorization header.
+    let token = req
+        .cookie(ACCESS_TOKEN_COOKIE)
+        .map(|c| c.value().to_owned())
+        .or_else(|| {
+            req.headers()
+                .get("Authorization")
+                .and_then(|h| h.to_str().ok())
+                .and_then(|s| s.strip_prefix("Bearer "))
+                .map(str::to_owned)
+        })
+        .ok_or_else(|| ApiError::bad_request("No auth token found"))?;
 
-    auth_service.logout(auth_header).await?;
+    auth_service.logout(&token).await?;
 
     info!("User logged out successfully");
 
-    Ok(HttpResponse::Ok().json(serde_json::json!({
-        "message": "Logged out successfully"
-    })))
+    Ok(HttpResponse::Ok()
+        .cookie(clear_access_cookie())
+        .cookie(clear_refresh_cookie())
+        .json(serde_json::json!({ "message": "Logged out successfully" })))
 }
 
 /// GET /api/auth/me
-/// Get current user profile (requires authentication)
 pub async fn get_current_user(
     auth_service: web::Data<AuthService>,
     req: HttpRequest,
@@ -122,7 +287,6 @@ pub async fn get_current_user(
 }
 
 /// POST /api/auth/change-password
-/// Change user password (requires authentication)
 pub async fn change_password(
     auth_service: web::Data<AuthService>,
     req: HttpRequest,
@@ -138,13 +302,16 @@ pub async fn change_password(
 
     info!(user_id = %user_id, "Password changed successfully");
 
-    Ok(HttpResponse::Ok().json(serde_json::json!({
-        "message": "Password changed successfully. All sessions have been revoked."
-    })))
+    // Clear cookies — the user must log in again after a password change.
+    Ok(HttpResponse::Ok()
+        .cookie(clear_access_cookie())
+        .cookie(clear_refresh_cookie())
+        .json(serde_json::json!({
+            "message": "Password changed successfully. All sessions have been revoked."
+        })))
 }
 
 /// POST /api/auth/revoke-sessions
-/// Revoke all user sessions (requires authentication)
 pub async fn revoke_all_sessions(
     auth_service: web::Data<AuthService>,
     req: HttpRequest,
@@ -157,14 +324,16 @@ pub async fn revoke_all_sessions(
 
     info!(user_id = %user_id, count = count, "Sessions revoked");
 
-    Ok(HttpResponse::Ok().json(serde_json::json!({
-        "message": format!("{} session(s) revoked successfully", count),
-        "count": count
-    })))
+    Ok(HttpResponse::Ok()
+        .cookie(clear_access_cookie())
+        .cookie(clear_refresh_cookie())
+        .json(serde_json::json!({
+            "message": format!("{} session(s) revoked successfully", count),
+            "count": count
+        })))
 }
 
 /// GET /api/auth/sessions
-/// Get all active sessions for current user (requires authentication)
 pub async fn get_sessions(
     auth_service: web::Data<AuthService>,
     req: HttpRequest,
@@ -179,13 +348,11 @@ pub async fn get_sessions(
     Ok(HttpResponse::Ok().json(SessionsResponse { sessions, total }))
 }
 
-/// GET /api/auth/analytics
-/// Get token analytics (admin only)
+/// GET /api/auth/analytics  (admin only)
 pub async fn get_analytics(
-    auth_service: web::Data<AuthService>,
+    _auth_service: web::Data<AuthService>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
-    // Check if user is admin
     let claims = req
         .claims()
         .ok_or_else(|| ApiError::unauthorized("User not authenticated"))?;
@@ -203,12 +370,36 @@ pub async fn get_analytics(
     })))
 }
 
-/// Configure authentication routes.
+/// GET /api/auth/ws-token
 ///
-/// This function is intended to be called via `.configure(...)` inside an
-/// existing `/api` scope.  It therefore opens a `/auth` sub-scope — **not**
-/// `/api/auth` — so the resulting paths resolve to `/api/auth/…` without a
-/// duplicate `/api` prefix.
+/// Issues a short-lived (60-second) signed access token for authenticating
+/// the initial WebSocket handshake message.  The token is NOT stored in a
+/// cookie — it is returned in the JSON body and used immediately.
+///
+/// Requires: valid `auth_token` cookie (i.e. the user must already be logged in).
+pub async fn get_ws_token(
+    jwt_service: web::Data<Arc<JwtService>>,
+    req: HttpRequest,
+) -> Result<impl Responder, ApiError> {
+    let claims = req
+        .claims()
+        .ok_or_else(|| ApiError::unauthorized("User not authenticated"))?;
+
+    let user_id = Uuid::parse_str(&claims.sub)
+        .map_err(|_| ApiError::internal_error("Invalid user ID in token"))?;
+
+    let ws_token = jwt_service
+        .generate_ws_token(user_id, claims.roles)
+        .await
+        .map_err(|e| ApiError::internal_error(format!("WS token generation failed: {}", e)))?;
+
+    Ok(HttpResponse::Ok().json(WsTokenResponse {
+        ws_token,
+        expires_in: 60,
+    }))
+}
+
+/// Configure authentication routes.
 pub fn configure_routes(cfg: &mut web::ServiceConfig) {
     cfg.service(
         web::scope("/auth")
@@ -220,7 +411,8 @@ pub fn configure_routes(cfg: &mut web::ServiceConfig) {
             .route("/change-password", web::post().to(change_password))
             .route("/revoke-sessions", web::post().to(revoke_all_sessions))
             .route("/sessions", web::get().to(get_sessions))
-            .route("/analytics", web::get().to(get_analytics)),
+            .route("/analytics", web::get().to(get_analytics))
+            .route("/ws-token", web::get().to(get_ws_token)),
     );
 }
 
@@ -229,10 +421,16 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_request_deserialization() {
+    fn test_refresh_request_optional_field() {
+        // Fully absent field
+        let json = r#"{}"#;
+        let req: RefreshTokenRequest = serde_json::from_str(json).unwrap();
+        assert!(req.refresh_token.is_none());
+
+        // Present field
         let json = r#"{"refresh_token":"test_token"}"#;
         let req: RefreshTokenRequest = serde_json::from_str(json).unwrap();
-        assert_eq!(req.refresh_token, "test_token");
+        assert_eq!(req.refresh_token.as_deref(), Some("test_token"));
     }
 
     #[test]

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -131,7 +131,11 @@ async fn main() -> io::Result<()> {
     let address_book = Arc::new(WsAddressBook::new());
 
     // Initialize Auth Services for Realtime
-    let jwt_config = crate::auth::jwt_service::JwtConfig::default();
+    let jwt_config = crate::auth::jwt_service::JwtConfig::from_config(
+        config.auth.jwt_secret.clone(),
+        &config.auth.jwt_expires_in,
+        &config.auth.jwt_refresh_expires_in,
+    );
     let jwt_service = Arc::new(crate::auth::jwt_service::JwtService::new(jwt_config.clone(), redis_conn.clone()));
     let auth_guard = Arc::new(crate::realtime::auth::RealtimeAuth::new(db_pool.clone()));
 

--- a/frontend/src/app/[locale]/layout.tsx
+++ b/frontend/src/app/[locale]/layout.tsx
@@ -40,12 +40,13 @@ export const metadata: Metadata = {
   },
 };
 
+// WCAG 2.1 SC 1.4.4 (Resize Text, AA): never disable pinch-to-zoom.
+// iOS auto-zoom on input focus is prevented by font-size: 16px in globals.css
+// (see the `input, textarea, select { font-size: 16px }` rule under @supports).
 export const viewport: Viewport = {
   themeColor: "#111827",
   width: "device-width",
   initialScale: 1,
-  maximumScale: 1,
-  userScalable: false,
 };
 
 export default function RootLayout({

--- a/frontend/src/contexts/NotificationContext.tsx
+++ b/frontend/src/contexts/NotificationContext.tsx
@@ -419,14 +419,11 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
     // 1008 = policy violation, 4401/4403 = app-level auth failure codes
     const AUTH_FAILURE_CLOSE_CODES = [1008, 4401, 4403];
 
-    const getAuthToken = () =>
-      localStorage.getItem("auth_token") ?? sessionStorage.getItem("auth_token");
-
     const buildWsUrl = () => {
       const protocol = window.location.protocol === "https:" ? "wss" : "ws";
-      // The token is deliberately NOT part of the URL: query strings end up
-      // in server access logs, browser history, and Referer headers. Auth is
-      // performed via the first message after the socket opens instead.
+      // Token is NOT part of the URL — query strings appear in server access
+      // logs, browser history, and Referer headers.  Auth is performed via
+      // the first JSON message sent after the socket opens.
       return `${protocol}://${window.location.host}/ws/notifications`;
     };
 
@@ -491,32 +488,48 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
 
     const connect = () => {
       if (closed) return;
-      try {
-        ws = new WebSocket(buildWsUrl());
-      } catch {
-        scheduleReconnect();
-        return;
-      }
 
-      ws.onopen = () => {
-        retry = 0;
-        const token = getAuthToken();
-        if (token) {
-          ws?.send(JSON.stringify({ type: "auth", token }));
-        }
-      };
-      ws.onmessage = (event) => handleMessage(event.data);
-      ws.onclose = (event) => {
-        if (closed) return;
-        if (AUTH_FAILURE_CLOSE_CODES.includes(event.code)) {
-          authFailed = true;
-          return;
-        }
-        scheduleReconnect();
-      };
-      ws.onerror = () => {
-        ws?.close();
-      };
+      // Fetch a short-lived (60 s) WS token from the server immediately
+      // before opening the socket.  The token is obtained via the httpOnly
+      // cookie session — it is never read from localStorage.
+      // It is held only in this closure and discarded once sent.
+      api
+        .getWsToken()
+        .then(({ ws_token }) => {
+          if (closed) return;
+
+          try {
+            ws = new WebSocket(buildWsUrl());
+          } catch {
+            scheduleReconnect();
+            return;
+          }
+
+          ws.onopen = () => {
+            retry = 0;
+            // Send the short-lived token as the first message — this is the
+            // only moment it exists in JS memory.
+            ws?.send(JSON.stringify({ type: "auth", token: ws_token }));
+          };
+          ws.onmessage = (event) => handleMessage(event.data);
+          ws.onclose = (event) => {
+            if (closed) return;
+            if (AUTH_FAILURE_CLOSE_CODES.includes(event.code)) {
+              authFailed = true;
+              return;
+            }
+            scheduleReconnect();
+          };
+          ws.onerror = () => {
+            ws?.close();
+          };
+        })
+        .catch(() => {
+          // Could not obtain a WS token (e.g. session expired) — back off and
+          // retry; the auth-failure handler in ApiClient will redirect to
+          // login if the session is truly gone.
+          if (!closed) scheduleReconnect();
+        });
     };
 
     connect();

--- a/frontend/src/hooks/useAuth.tsx
+++ b/frontend/src/hooks/useAuth.tsx
@@ -1,11 +1,22 @@
 "use client";
 
-import { useState, createContext, useContext, useCallback, useEffect, useRef } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { useRouter } from "next/navigation";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { AuthUser, LoginRequest, RegisterRequest } from "@/types";
 import { api } from "@/lib/api";
 import { AuthApiError, REGISTER_ERROR_MAP } from "@/lib/authErrors";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
 
 interface AuthContextType {
   user: AuthUser | null;
@@ -17,59 +28,72 @@ interface AuthContextType {
   clearError: () => void;
   verifyEmail: (token: string) => Promise<void>;
   resendVerificationEmail: (email: string) => Promise<void>;
-  /** Exposed so components can manually trigger a token refresh if needed. */
-  refreshAccessToken: () => Promise<string>;
+  /** Trigger a silent token refresh. Returns the new TTL in seconds. */
+  refreshAccessToken: () => Promise<number>;
   /** True while a token refresh is in flight. */
   isRefreshing: boolean;
 }
 
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
-const TOKEN_KEY = "auth_token";
-const REFRESH_TOKEN_KEY = "auth_refresh_token";
+// ---------------------------------------------------------------------------
+// Non-sensitive storage keys
+//
+// Tokens are NEVER stored in localStorage / sessionStorage.
+// Only the public user profile (no secrets) is cached here so the UI can
+// render immediately on page reload without a network round-trip.
+// ---------------------------------------------------------------------------
+
 const STORAGE_KEY = "arenax_auth_user";
-const REMEMBER_KEY = "arenax_remember_me";
 const PENDING_VERIFICATION_EMAIL_KEY = "arenax_pending_email";
 
 export const AUTH_PROFILE_QUERY_KEY = ["auth", "profile"] as const;
 
-function getStorage(remember: boolean): Storage {
-  return remember ? localStorage : sessionStorage;
-}
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
-function mapBackendUserToAuthUser(
+function mapBackendUser(
   backendUser: {
     id: string;
-    email: string;
+    email?: string;
     username: string;
-    isVerified: boolean;
+    isVerified?: boolean;
+    is_verified?: boolean;
     [key: string]: unknown;
   },
-  accessToken: string,
-  refreshToken: string
 ): AuthUser {
   return {
     id: backendUser.id,
     username: backendUser.username,
-    email: backendUser.email,
-    isVerified: backendUser.isVerified,
-    elo: typeof (backendUser as Record<string, unknown>).elo === "number"
-      ? ((backendUser as Record<string, unknown>).elo as number)
-      : 0,
+    email: (backendUser.email as string | undefined) ?? "",
+    isVerified:
+      (backendUser.isVerified as boolean | undefined) ??
+      (backendUser.is_verified as boolean | undefined) ??
+      false,
+    elo:
+      typeof backendUser.elo === "number" ? (backendUser.elo as number) : 0,
     createdAt:
-      typeof (backendUser as Record<string, unknown>).createdAt === "string"
-        ? ((backendUser as Record<string, unknown>).createdAt as string)
-        : new Date().toISOString(),
-    token: accessToken,
-    refreshToken,
+      typeof backendUser.createdAt === "string"
+        ? (backendUser.createdAt as string)
+        : typeof backendUser.created_at === "string"
+          ? (backendUser.created_at as string)
+          : new Date().toISOString(),
+    // token / refreshToken fields are intentionally omitted — tokens live
+    // exclusively in httpOnly cookies and are invisible to JavaScript.
+    token: "",
+    refreshToken: "",
   };
 }
 
-function readStoredUser(): AuthUser | null {
+/** Read the cached public profile from sessionStorage (no secrets). */
+function readCachedUser(): AuthUser | null {
   if (typeof window === "undefined") return null;
-  const remember = localStorage.getItem(REMEMBER_KEY) === "true";
-  const storage = getStorage(remember);
-  const stored = storage.getItem(STORAGE_KEY);
+  const stored = sessionStorage.getItem(STORAGE_KEY);
   if (!stored) return null;
   try {
     return JSON.parse(stored) as AuthUser;
@@ -78,128 +102,156 @@ function readStoredUser(): AuthUser | null {
   }
 }
 
-function getStoredToken(): { token: string; refreshToken: string } | null {
-  if (typeof window === "undefined") return null;
-  const token = localStorage.getItem(TOKEN_KEY) ?? sessionStorage.getItem(TOKEN_KEY);
-  const refresh = localStorage.getItem(REFRESH_TOKEN_KEY) ?? sessionStorage.getItem(REFRESH_TOKEN_KEY);
-  if (token && refresh) return { token, refreshToken: refresh };
-  return null;
+/** Persist the public profile to sessionStorage for hydration speed. */
+function cacheUser(user: AuthUser | null): void {
+  if (typeof window === "undefined") return;
+  if (user) {
+    // Strip any accidental token fields before caching.
+    const safe = { ...user, token: "", refreshToken: "" };
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(safe));
+  } else {
+    sessionStorage.removeItem(STORAGE_KEY);
+  }
 }
 
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
 export const useAuth = () => {
-  const context = useContext(AuthContext);
-  if (context === undefined) {
+  const ctx = useContext(AuthContext);
+  if (ctx === undefined) {
     throw new Error("useAuth must be used within an AuthProvider");
   }
-  return context;
+  return ctx;
 };
 
-export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+export const AuthProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
   const router = useRouter();
   const queryClient = useQueryClient();
-  const [hasToken, setHasToken] = useState(() => !!getStoredToken());
+
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isRefreshing, setIsRefreshing] = useState(false);
-  // Track isRefreshing via a ref so the stable callback can read it
   const isRefreshingRef = useRef(false);
 
   const clearError = useCallback(() => setError(null), []);
 
+  // ── Session probe ──────────────────────────────────────────────────────────
+  // We determine whether the user is logged in by fetching their profile.
+  // The httpOnly cookie is sent automatically; a 401 means no active session.
+  // `placeholderData` hydrates the UI instantly from the sessionStorage cache.
+
   const profileQuery = useQuery({
     queryKey: AUTH_PROFILE_QUERY_KEY,
     queryFn: async (): Promise<AuthUser | null> => {
-      const stored = getStoredToken();
-      if (!stored) return null;
-      const profile = await api.getProfile();
-      return {
-        id: profile.id,
-        username: profile.username,
-        email: profile.email ?? "",
-        isVerified: profile.is_verified,
-        elo: typeof profile.elo === "number" ? profile.elo : 0,
-        createdAt: profile.created_at,
-        token: stored.token,
-        refreshToken: stored.refreshToken,
-      };
+      try {
+        const profile = await api.getProfile();
+        const user = mapBackendUser({
+          id: profile.id,
+          username: profile.username,
+          email: profile.email ?? undefined,
+          is_verified: profile.is_verified,
+          elo: profile.elo,
+          created_at: profile.created_at,
+        });
+        cacheUser(user);
+        return user;
+      } catch {
+        // 401 or network error → not authenticated
+        cacheUser(null);
+        return null;
+      }
     },
-    enabled: hasToken,
     staleTime: 60_000,
     gcTime: 300_000,
-    placeholderData: () => readStoredUser(),
+    placeholderData: readCachedUser,
+    // Always attempt the probe — the cookie (not a localStorage flag) is the
+    // source of truth.
+    enabled: true,
+    retry: false,
   });
 
   const user = profileQuery.data ?? null;
 
-  const persistSession = useCallback(
-    (authUser: AuthUser, rememberMe: boolean) => {
-      localStorage.setItem(REMEMBER_KEY, String(rememberMe));
-      const storage = getStorage(rememberMe);
-      storage.setItem(STORAGE_KEY, JSON.stringify(authUser));
-      storage.setItem(TOKEN_KEY, authUser.token);
-      storage.setItem(REFRESH_TOKEN_KEY, authUser.refreshToken);
-    },
-    []
-  );
+  // ── Login ──────────────────────────────────────────────────────────────────
 
   const login = async (
-    credentials: LoginRequest & { rememberMe?: boolean }
+    credentials: LoginRequest & { rememberMe?: boolean },
   ) => {
     try {
       setLoading(true);
       setError(null);
-      const { rememberMe = false } = credentials;
+
       const response = await api.login({
         email: credentials.email,
         password: credentials.password,
       });
-      const authUser = mapBackendUserToAuthUser(
-        response.user as Parameters<typeof mapBackendUserToAuthUser>[0],
-        response.tokens.accessToken,
-        response.tokens.refreshToken
+
+      // The server has now set the httpOnly cookies.  Pull the user object
+      // from the response body — it carries no token values.
+      const authUser = mapBackendUser(
+        response.user as Parameters<typeof mapBackendUser>[0],
       );
-      persistSession(authUser, rememberMe);
+
+      cacheUser(authUser);
       queryClient.setQueryData(AUTH_PROFILE_QUERY_KEY, authUser);
-      setHasToken(true);
     } catch (err) {
       const message =
         err instanceof Error ? err.message : "Invalid email or password";
       setError(message);
+      throw err;
     } finally {
       setLoading(false);
     }
   };
+
+  // ── Register ───────────────────────────────────────────────────────────────
 
   const register = async (userData: RegisterRequest) => {
     try {
       setLoading(true);
       setError(null);
+
       const response = await api.register({
         username: userData.username,
         email: userData.email,
         password: userData.password,
       });
-      const authUser = mapBackendUserToAuthUser(
-        response.user as Parameters<typeof mapBackendUserToAuthUser>[0],
-        response.tokens.accessToken,
-        response.tokens.refreshToken
+
+      // Cookies are set by the server; store only the public profile locally.
+      const authUser = mapBackendUser(
+        response.user as Parameters<typeof mapBackendUser>[0],
       );
+
       queryClient.setQueryData(AUTH_PROFILE_QUERY_KEY, authUser);
-      setHasToken(true);
-      localStorage.setItem(PENDING_VERIFICATION_EMAIL_KEY, userData.email);
-      // Don't persist session yet - user needs to verify email
+
+      if (typeof window !== "undefined") {
+        localStorage.setItem(PENDING_VERIFICATION_EMAIL_KEY, userData.email);
+      }
+      // Do not cache the full profile until email is verified.
     } catch (err) {
       if (err instanceof AuthApiError && REGISTER_ERROR_MAP[err.code]) {
-        // Field-specific error — let the form surface it inline; don't set context error
         throw err;
       }
       const message =
         err instanceof Error ? err.message : "Registration failed";
       setError(message);
+      throw err;
     } finally {
       setLoading(false);
     }
   };
+
+  // ── Verify email ───────────────────────────────────────────────────────────
 
   const verifyEmail = async (token: string) => {
     try {
@@ -207,20 +259,19 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
       setError(null);
       await api.verifyEmail(token);
       if (user) {
-        const updatedUser = { ...user, isVerified: true };
-        queryClient.setQueryData(AUTH_PROFILE_QUERY_KEY, updatedUser);
-        const remember = localStorage.getItem(REMEMBER_KEY) === "true";
-        persistSession(updatedUser, remember);
+        const updated = { ...user, isVerified: true };
+        cacheUser(updated);
+        queryClient.setQueryData(AUTH_PROFILE_QUERY_KEY, updated);
       }
     } catch (err) {
-      const message =
-        err instanceof Error ? err.message : "Verification failed";
-      setError(message);
+      setError(err instanceof Error ? err.message : "Verification failed");
       throw err;
     } finally {
       setLoading(false);
     }
   };
+
+  // ── Resend verification ────────────────────────────────────────────────────
 
   const resendVerificationEmail = async (email: string) => {
     try {
@@ -229,7 +280,9 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
       await api.resendVerificationEmail(email);
     } catch (err) {
       const message =
-        err instanceof Error ? err.message : "Failed to resend verification email";
+        err instanceof Error
+          ? err.message
+          : "Failed to resend verification email";
       setError(message);
       throw err;
     } finally {
@@ -237,20 +290,25 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     }
   };
 
+  // ── Logout ─────────────────────────────────────────────────────────────────
+
   const logout = useCallback(() => {
-    [localStorage, sessionStorage].forEach((storage) => {
-      storage.removeItem(STORAGE_KEY);
-      storage.removeItem(TOKEN_KEY);
-      storage.removeItem(REFRESH_TOKEN_KEY);
-    });
-    localStorage.removeItem(REMEMBER_KEY);
-    localStorage.removeItem(PENDING_VERIFICATION_EMAIL_KEY);
-    setHasToken(false);
+    // Tell the server to blacklist the current token and clear cookies.
+    // Fire-and-forget — clear local state immediately regardless of outcome.
+    api.logout().catch(() => {});
+
+    cacheUser(null);
+    if (typeof window !== "undefined") {
+      localStorage.removeItem(PENDING_VERIFICATION_EMAIL_KEY);
+    }
     setError(null);
     queryClient.removeQueries({ queryKey: AUTH_PROFILE_QUERY_KEY });
   }, [queryClient]);
 
-  const refreshAccessToken = useCallback(async (): Promise<string> => {
+  // ── Token refresh ──────────────────────────────────────────────────────────
+
+  const refreshAccessToken = useCallback(async (): Promise<number> => {
+    if (isRefreshingRef.current) return 0;
     isRefreshingRef.current = true;
     setIsRefreshing(true);
     try {
@@ -261,8 +319,10 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     }
   }, []);
 
-  // Register the auth-failure handler with ApiClient once on mount so it can
-  // trigger logout + redirect when a refresh attempt fails inside request().
+  // ── Wire auth-failure handler ──────────────────────────────────────────────
+  // When ApiClient can't refresh (session truly expired), it calls this so
+  // we log the user out and redirect to the login page.
+
   useEffect(() => {
     api.setOnAuthFailure(() => {
       logout();
@@ -270,9 +330,23 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     });
   }, [logout, router]);
 
+  // ── Context value ──────────────────────────────────────────────────────────
+
   return (
     <AuthContext.Provider
-      value={{ user, login, register, logout, loading, error, clearError, verifyEmail, resendVerificationEmail, refreshAccessToken, isRefreshing }}
+      value={{
+        user,
+        login,
+        register,
+        logout,
+        loading,
+        error,
+        clearError,
+        verifyEmail,
+        resendVerificationEmail,
+        refreshAccessToken,
+        isRefreshing,
+      }}
     >
       {children}
     </AuthContext.Provider>

--- a/frontend/src/hooks/useMatchWebSocket.ts
+++ b/frontend/src/hooks/useMatchWebSocket.ts
@@ -1,7 +1,11 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { BracketMatchStatus, ScoreReport } from "@/types/bracket";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
 
 export interface MatchUpdate {
   matchId: string;
@@ -26,37 +30,24 @@ interface UseMatchWebSocketReturn {
   disconnect: () => void;
 }
 
-const scriptedUpdates: Record<string, MatchUpdate[]> = {
-  "1-match-13": [
-    {
-      matchId: "1-match-13",
-      scorePlayer1: 1,
-      scorePlayer2: 1,
-      status: "in_progress",
-      message: "Map three has started.",
-      timestamp: 1,
-    },
-    {
-      matchId: "1-match-13",
-      scorePlayer1: 2,
-      scorePlayer2: 1,
-      status: "completed",
-      winnerId: "user-123",
-      message: "ProGamer99 closed the semifinal and locked a finals berth.",
-      timestamp: 2,
-    },
-  ],
-  "2-match-10": [
-    {
-      matchId: "2-match-10",
-      scorePlayer1: 1,
-      scorePlayer2: 1,
-      status: "disputed",
-      message: "Conflicting score reports detected.",
-      timestamp: 1,
-    },
-  ],
-};
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Maximum reconnect delay (ms). */
+const MAX_RECONNECT_DELAY_MS = 30_000;
+
+// ---------------------------------------------------------------------------
+// useMatchWebSocket
+//
+// Real WebSocket implementation — no simulation scaffolding.
+//
+// Authentication: the browser automatically sends the `auth_token` httpOnly
+// cookie with the WebSocket upgrade request (same-origin).  No token is ever
+// embedded in the URL or passed via localStorage.
+//
+// Reconnection: exponential back-off capped at MAX_RECONNECT_DELAY_MS.
+// ---------------------------------------------------------------------------
 
 export function useMatchWebSocket({
   matchId,
@@ -65,103 +56,197 @@ export function useMatchWebSocket({
   const [isConnected, setIsConnected] = useState(false);
   const [lastUpdate, setLastUpdate] = useState<MatchUpdate | null>(null);
   const [connectionError, setConnectionError] = useState<string | null>(null);
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const updateIndexRef = useRef(0);
 
-  const updates = useMemo(
-    () => scriptedUpdates[matchId] ?? [],
-    [matchId],
-  );
+  const wsRef = useRef<WebSocket | null>(null);
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const retryCountRef = useRef(0);
+  // Set to true when the cleanup function runs so stale async callbacks
+  // don't attempt to reconnect after the component has unmounted.
+  const closedRef = useRef(false);
+
+  // ── Helpers ──────────────────────────────────────────────────────────────
+
+  const clearReconnectTimer = () => {
+    if (reconnectTimerRef.current !== null) {
+      clearTimeout(reconnectTimerRef.current);
+      reconnectTimerRef.current = null;
+    }
+  };
+
+  const buildWsUrl = useCallback(() => {
+    const protocol = window.location.protocol === "https:" ? "wss" : "ws";
+    // matchId is path-encoded to prevent URL injection.
+    return `${protocol}://${window.location.host}/ws/match/${encodeURIComponent(matchId)}`;
+  }, [matchId]);
+
+  // ── Disconnect ────────────────────────────────────────────────────────────
 
   const disconnect = useCallback(() => {
-    if (intervalRef.current) {
-      clearInterval(intervalRef.current);
-      intervalRef.current = null;
+    clearReconnectTimer();
+    retryCountRef.current = 0;
+    if (wsRef.current) {
+      // Remove handlers before closing so onclose doesn't schedule a reconnect.
+      wsRef.current.onopen = null;
+      wsRef.current.onmessage = null;
+      wsRef.current.onclose = null;
+      wsRef.current.onerror = null;
+      wsRef.current.close(1000, "Client disconnect");
+      wsRef.current = null;
     }
-    if (reconnectTimeoutRef.current) {
-      clearTimeout(reconnectTimeoutRef.current);
-      reconnectTimeoutRef.current = null;
-    }
-    updateIndexRef.current = 0;
     setIsConnected(false);
+    setConnectionError(null);
   }, []);
 
+  // ── Connect ───────────────────────────────────────────────────────────────
+
   const connect = useCallback(() => {
-    setConnectionError(null);
-    setLastUpdate(null);
+    if (closedRef.current || !enabled || !matchId) return;
 
-    const connectTimeout = setTimeout(() => {
-      setIsConnected(true);
-
-      if (!enabled || updates.length === 0) {
-        return;
-      }
-
-      intervalRef.current = setInterval(() => {
-        const nextUpdate = updates[updateIndexRef.current];
-        if (!nextUpdate) {
-          if (intervalRef.current) {
-            clearInterval(intervalRef.current);
-            intervalRef.current = null;
-          }
-          return;
-        }
-
-        setLastUpdate({
-          ...nextUpdate,
-          timestamp: Date.now(),
-        });
-        updateIndexRef.current += 1;
-      }, 4500);
-    }, 600);
-
-    return () => clearTimeout(connectTimeout);
-  }, [enabled, updates]);
-
-  const reconnect = useCallback(() => {
-    disconnect();
-    connect();
-  }, [connect, disconnect]);
-
-  useEffect(() => {
-    if (enabled && matchId) {
-      const cleanup = connect();
-      return () => {
-        cleanup?.();
-        disconnect();
-      };
+    // Clean up any existing socket before opening a new one.
+    if (wsRef.current) {
+      wsRef.current.onopen = null;
+      wsRef.current.onmessage = null;
+      wsRef.current.onclose = null;
+      wsRef.current.onerror = null;
+      wsRef.current.close();
+      wsRef.current = null;
     }
 
-    disconnect();
-  }, [connect, disconnect, enabled, matchId]);
+    setConnectionError(null);
 
-  useEffect(() => {
-    if (!isConnected || !enabled || updates.length === 0) {
+    let ws: WebSocket;
+    try {
+      ws = new WebSocket(buildWsUrl());
+    } catch {
+      // URL construction failed — don't retry.
+      setConnectionError("Unable to open match feed connection.");
       return;
     }
 
-    const disconnectChance = setInterval(() => {
-      if (Math.random() < 0.015) {
-        setIsConnected(false);
-        setConnectionError("Live feed interrupted. Reconnecting to ArenaX relay...");
-        reconnectTimeoutRef.current = setTimeout(() => {
-          reconnect();
-        }, 1800);
+    wsRef.current = ws;
+
+    ws.onopen = () => {
+      if (closedRef.current) {
+        ws.close();
+        return;
       }
-    }, 12000);
+      retryCountRef.current = 0;
+      setIsConnected(true);
+      setConnectionError(null);
+    };
 
-    return () => clearInterval(disconnectChance);
-  }, [enabled, isConnected, reconnect, updates.length]);
+    ws.onmessage = (event: MessageEvent) => {
+      try {
+        const data = JSON.parse(event.data as string) as Partial<MatchUpdate> & {
+          type?: string;
+        };
 
-  return {
-    isConnected,
-    lastUpdate,
-    connectionError,
-    reconnect,
-    disconnect,
-  };
+        // Ignore keepalive pings.
+        if (data.type === "ping") return;
+
+        if (data.matchId) {
+          setLastUpdate({
+            matchId: data.matchId,
+            scorePlayer1: data.scorePlayer1,
+            scorePlayer2: data.scorePlayer2,
+            status: data.status,
+            winnerId: data.winnerId,
+            message: data.message,
+            timestamp: data.timestamp ?? Date.now(),
+          });
+        }
+      } catch {
+        // Ignore malformed messages.
+      }
+    };
+
+    ws.onclose = (event: CloseEvent) => {
+      setIsConnected(false);
+      wsRef.current = null;
+
+      if (closedRef.current) return;
+
+      // Permanent auth failures — do not retry.
+      const AUTH_FAILURE_CODES = [1008, 4401, 4403];
+      if (AUTH_FAILURE_CODES.includes(event.code)) {
+        setConnectionError("Authentication failed. Please refresh the page.");
+        return;
+      }
+
+      // Normal closure — no reconnect needed.
+      if (event.code === 1000) return;
+
+      // Transient failure — reconnect with exponential back-off.
+      const delay = Math.min(
+        MAX_RECONNECT_DELAY_MS,
+        1_000 * 2 ** retryCountRef.current,
+      );
+      retryCountRef.current += 1;
+      reconnectTimerRef.current = setTimeout(connect, delay);
+    };
+
+    ws.onerror = () => {
+      // onclose fires immediately after onerror — reconnect logic lives there.
+      ws.close();
+    };
+  }, [buildWsUrl, enabled, matchId]);
+
+  // ── Public reconnect ──────────────────────────────────────────────────────
+
+  const reconnect = useCallback(() => {
+    clearReconnectTimer();
+    retryCountRef.current = 0;
+    connect();
+  }, [connect]);
+
+  // ── Effect: open / close socket on mount / matchId / enabled changes ──────
+
+  useEffect(() => {
+    closedRef.current = false;
+
+    if (enabled && matchId) {
+      connect();
+    }
+
+    return () => {
+      closedRef.current = true;
+      disconnect();
+    };
+    // `connect` and `disconnect` are stable callbacks; re-run when the
+    // match or enabled flag changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [matchId, enabled]);
+
+  // ── Dev-only simulation ───────────────────────────────────────────────────
+  // Gated strictly behind NODE_ENV so it is tree-shaken out of the
+  // production bundle.  Never runs in production.
+
+  useEffect(() => {
+    if (process.env.NODE_ENV === "production") return;
+    if (!enabled || !matchId || !isConnected) return;
+
+    // In development, simulate a match update after 3 seconds so the UI can
+    // be tested without a live backend.
+    const timer = setTimeout(() => {
+      setLastUpdate({
+        matchId,
+        scorePlayer1: 0,
+        scorePlayer2: 0,
+        status: "in_progress",
+        message: "[dev] Match feed connected.",
+        timestamp: Date.now(),
+      });
+    }, 3_000);
+
+    return () => clearTimeout(timer);
+  }, [enabled, isConnected, matchId]);
+
+  return { isConnected, lastUpdate, connectionError, reconnect, disconnect };
 }
+
+// ---------------------------------------------------------------------------
+// useMatchScoreReporting  (unchanged — no simulation code was here)
+// ---------------------------------------------------------------------------
 
 interface ScoreSubmission {
   matchId: string;
@@ -190,7 +275,9 @@ export function useMatchScoreReporting(
   const [isReporting, setIsReporting] = useState(false);
   const [pendingReport, setPendingReport] = useState<ScoreReport | null>(null);
   const [conflictDetected, setConflictDetected] = useState(false);
-  const [conflictingReport, setConflictingReport] = useState<ScoreReport | null>(null);
+  const [conflictingReport, setConflictingReport] = useState<ScoreReport | null>(
+    null,
+  );
 
   const reportScore = useCallback(
     async (report: ScoreSubmission): Promise<boolean> => {
@@ -206,6 +293,7 @@ export function useMatchScoreReporting(
 
       setPendingReport(submittedReport);
 
+      // Small debounce to avoid double-submissions on fast taps.
       await new Promise((resolve) => setTimeout(resolve, 900));
 
       if (

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -50,39 +50,24 @@ import {
 import { AuthApiError } from "./authErrors";
 import { API_BASE } from "./constants";
 
-const TOKEN_KEY = "auth_token";
-const REFRESH_TOKEN_KEY = "auth_refresh_token";
-
-function getStoredToken(): string | null {
-  if (typeof window === "undefined") return null;
-  return localStorage.getItem(TOKEN_KEY) ?? sessionStorage.getItem(TOKEN_KEY);
-}
-
-function getStoredRefreshToken(): string | null {
-  if (typeof window === "undefined") return null;
-  return (
-    localStorage.getItem(REFRESH_TOKEN_KEY) ??
-    sessionStorage.getItem(REFRESH_TOKEN_KEY)
-  );
-}
-
-function updateStoredTokens(accessToken: string, refreshToken: string): void {
-  if (typeof window === "undefined") return;
-  // Preserve the storage location (local vs session) the user originally chose
-  const inLocal = !!localStorage.getItem(TOKEN_KEY);
-  const storage = inLocal ? localStorage : sessionStorage;
-  storage.setItem(TOKEN_KEY, accessToken);
-  storage.setItem(REFRESH_TOKEN_KEY, refreshToken);
-}
+// ---------------------------------------------------------------------------
+// ApiClient
+//
+// Tokens are stored exclusively in httpOnly cookies set by the server.
+// This file never reads or writes localStorage / sessionStorage for auth.
+// All fetch calls use `credentials: "include"` so the browser automatically
+// attaches the auth_token and auth_refresh_token cookies.
+// ---------------------------------------------------------------------------
 
 class ApiClient {
   private baseURL: string;
 
-  // Shared in-flight refresh promise so parallel requests all await the same call
-  private refreshPromise: Promise<string> | null = null;
+  // Shared in-flight refresh promise so parallel 401s share a single call.
+  private refreshPromise: Promise<number> | null = null;
   public isRefreshing = false;
 
-  // Callback set by useAuth so the client can trigger logout + redirect
+  // Callback set by useAuth so the client can trigger logout + redirect when
+  // a refresh attempt itself fails.
   private onAuthFailure?: () => void;
 
   constructor(baseURL: string = "/api") {
@@ -95,41 +80,39 @@ class ApiClient {
   }
 
   /**
-   * Refresh the access token using the stored refresh token.
-   * Multiple concurrent callers share the same promise so only one HTTP
-   * request is made regardless of how many 401s fire simultaneously.
+   * Silently refresh the access token.
+   *
+   * The browser sends the `auth_refresh_token` cookie automatically.
+   * The server validates it, rotates both cookies (access + refresh), and
+   * returns `{ expires_in }`.
+   *
+   * Returns the new access token TTL in seconds (useful for scheduling the
+   * next proactive refresh).  Multiple concurrent callers share one request.
    */
-  async refreshAccessToken(): Promise<string> {
+  async refreshAccessToken(): Promise<number> {
     if (this.refreshPromise) return this.refreshPromise;
 
     this.isRefreshing = true;
     this.refreshPromise = (async () => {
-      const refreshToken = getStoredRefreshToken();
-      if (!refreshToken) throw new Error("No refresh token available");
-
       const url = `${this.baseURL}/auth/refresh`;
       const response = await fetch(url, {
         method: "POST",
+        credentials: "include",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ refresh_token: refreshToken }),
+        // No body needed — the refresh token arrives as a cookie.
+        body: JSON.stringify({}),
       });
 
       if (!response.ok) {
         throw new Error("Refresh failed");
       }
 
-      const data = await response.json() as {
-        access_token: string;
-        refresh_token: string;
-      };
-
-      updateStoredTokens(data.access_token, data.refresh_token);
-      return data.access_token;
-    })()
-      .finally(() => {
-        this.isRefreshing = false;
-        this.refreshPromise = null;
-      });
+      const data = await response.json() as { expires_in: number };
+      return data.expires_in ?? 900;
+    })().finally(() => {
+      this.isRefreshing = false;
+      this.refreshPromise = null;
+    });
 
     return this.refreshPromise;
   }
@@ -141,28 +124,28 @@ class ApiClient {
   ): Promise<T> {
     const url = `${this.baseURL}${endpoint}`;
 
-    const token = getStoredToken();
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
       ...(options.headers as Record<string, string>),
     };
 
-    if (token) {
-      headers.Authorization = `Bearer ${token}`;
-    }
+    const response = await fetch(url, {
+      ...options,
+      headers,
+      // Always include cookies — the httpOnly auth_token cookie carries the
+      // JWT; no Authorization header is needed.
+      credentials: "include",
+    });
 
-    const response = await fetch(url, { ...options, headers });
-
-    // Intercept 401 — attempt a silent token refresh and retry once
+    // Intercept 401 — attempt a silent token refresh and retry once.
     if (response.status === 401 && !_isRetry) {
       try {
         await this.refreshAccessToken();
       } catch {
-        // Refresh itself failed — session is unrecoverable
+        // Refresh itself failed — session is unrecoverable.
         this.onAuthFailure?.();
         throw new Error("SESSION_EXPIRED");
       }
-      // Retry the original request with the new token
       return this.request<T>(endpoint, options, true);
     }
 
@@ -179,7 +162,10 @@ class ApiClient {
     return data.data;
   }
 
-  // Auth endpoints — backend returns { user, tokens } directly (no .data wrapper)
+  /**
+   * Auth endpoints return `{ user, expires_in }` directly (no `.data` wrapper).
+   * Tokens are delivered as httpOnly cookies — this method never sees them.
+   */
   private async authRequest<T>(
     endpoint: string,
     options: RequestInit = {},
@@ -189,7 +175,11 @@ class ApiClient {
       "Content-Type": "application/json",
       ...(options.headers as Record<string, string>),
     };
-    const response = await fetch(url, { ...options, headers });
+    const response = await fetch(url, {
+      ...options,
+      headers,
+      credentials: "include",
+    });
     const json = await response.json().catch(() => ({}));
     if (!response.ok) {
       const message =
@@ -205,45 +195,61 @@ class ApiClient {
     return json as T;
   }
 
-  /** Fetch the session detail used by the lobby page. */
-  async getMatchSession(sessionId: string): Promise<{
-    session_id: string;
-    game_mode: string;
-    status: string;
-    players: Array<{
-      id: string;
-      username: string;
-      elo_rating: number;
-      avatar_url?: string;
-      is_ready: boolean;
-    }>;
-    created_at: string;
-  }> {
-    return this.request(`/matchmaking/sessions/${sessionId}`);
-  }
+  // ── Auth ────────────────────────────────────────────────────────────────────
 
-  /** Mark the current user as ready in a lobby session. */
-  async readyUp(sessionId: string): Promise<{ success: boolean }> {
-    return this.request(`/matchmaking/sessions/${sessionId}/ready`, {
-      method: "POST",
-    });
-  }
-
+  /**
+   * POST /api/auth/login
+   *
+   * Server sets `auth_token` + `auth_refresh_token` httpOnly cookies.
+   * Response body: `{ user, expires_in }`.
+   */
   async login(credentials: { email: string; password: string }) {
-    return this.authRequest<{ user: unknown; tokens: { accessToken: string; refreshToken: string } }>(
-      "/auth/login",
-      { method: "POST", body: JSON.stringify(credentials) }
-    );
+    return this.authRequest<{
+      user: unknown;
+      expires_in: number;
+    }>("/auth/login", { method: "POST", body: JSON.stringify(credentials) });
   }
 
+  /**
+   * POST /api/auth/register
+   *
+   * Same cookie behaviour as login.
+   * Response body: `{ user, expires_in }`.
+   */
   async register(userData: {
     username: string;
     email: string;
     password: string;
   }) {
-    return this.authRequest<{ user: unknown; tokens: { accessToken: string; refreshToken: string } }>(
-      "/auth/register",
-      { method: "POST", body: JSON.stringify(userData) }
+    return this.authRequest<{
+      user: unknown;
+      expires_in: number;
+    }>("/auth/register", {
+      method: "POST",
+      body: JSON.stringify(userData),
+    });
+  }
+
+  /**
+   * POST /api/auth/logout
+   *
+   * Server blacklists the current access token and clears both cookies.
+   */
+  async logout() {
+    return this.authRequest<{ message: string }>("/auth/logout", {
+      method: "POST",
+    });
+  }
+
+  /**
+   * GET /api/auth/ws-token
+   *
+   * Returns a 60-second token for the initial WebSocket auth message.
+   * Must be called immediately before opening the socket.
+   */
+  async getWsToken(): Promise<{ ws_token: string; expires_in: number }> {
+    return this.authRequest<{ ws_token: string; expires_in: number }>(
+      "/auth/ws-token",
     );
   }
 
@@ -259,18 +265,20 @@ class ApiClient {
   }
 
   async verifyEmail(token: string) {
-    return this.authRequest<{ message: string }>(
-      "/auth/verify-email",
-      { method: "POST", body: JSON.stringify({ token }) }
-    );
+    return this.authRequest<{ message: string }>("/auth/verify-email", {
+      method: "POST",
+      body: JSON.stringify({ token }),
+    });
   }
 
   async resendVerificationEmail(email: string) {
     return this.authRequest<{ message: string }>(
       "/auth/resend-verification-email",
-      { method: "POST", body: JSON.stringify({ email }) }
+      { method: "POST", body: JSON.stringify({ email }) },
     );
   }
+
+  // ── User / Profile ───────────────────────────────────────────────────────────
 
   async getProfile() {
     return this.request<{
@@ -330,7 +338,32 @@ class ApiClient {
     return this.request<{ id: string }[]>("/users/me/tournaments");
   }
 
-  // Tournament endpoints
+  /** Fetch the session detail used by the lobby page. */
+  async getMatchSession(sessionId: string): Promise<{
+    session_id: string;
+    game_mode: string;
+    status: string;
+    players: Array<{
+      id: string;
+      username: string;
+      elo_rating: number;
+      avatar_url?: string;
+      is_ready: boolean;
+    }>;
+    created_at: string;
+  }> {
+    return this.request(`/matchmaking/sessions/${sessionId}`);
+  }
+
+  /** Mark the current user as ready in a lobby session. */
+  async readyUp(sessionId: string): Promise<{ success: boolean }> {
+    return this.request(`/matchmaking/sessions/${sessionId}/ready`, {
+      method: "POST",
+    });
+  }
+
+  // ── Tournaments ──────────────────────────────────────────────────────────────
+
   async getTournaments(params?: TournamentFilters): Promise<Tournament[]> {
     const queryString = params
       ? "?" + new URLSearchParams(params as Record<string, string>)
@@ -342,7 +375,9 @@ class ApiClient {
     return this.request<Tournament>(`/tournaments/${id}`);
   }
 
-  async createTournament(tournament: CreateTournamentRequest): Promise<Tournament> {
+  async createTournament(
+    tournament: CreateTournamentRequest,
+  ): Promise<Tournament> {
     return this.request<Tournament>("/tournaments", {
       method: "POST",
       body: JSON.stringify(tournament),
@@ -355,7 +390,8 @@ class ApiClient {
     });
   }
 
-  // Match endpoints
+  // ── Matches ──────────────────────────────────────────────────────────────────
+
   async getMatches(params?: MatchFilters): Promise<Match[]> {
     const queryString = params
       ? "?" + new URLSearchParams(params as Record<string, string>)
@@ -367,20 +403,28 @@ class ApiClient {
     return this.request<Match>(`/matches/${id}`);
   }
 
-  async reportMatchScore(id: string, result: ReportScoreRequest): Promise<{ message: string }> {
+  async reportMatchScore(
+    id: string,
+    result: ReportScoreRequest,
+  ): Promise<{ message: string }> {
     return this.request<{ message: string }>(`/matches/${id}/report`, {
       method: "POST",
       body: JSON.stringify(result),
     });
   }
 
-  // Health check
+  // ── Health ───────────────────────────────────────────────────────────────────
+
   async healthCheck() {
     return this.request("/health");
   }
 
-  // Notification endpoints (persistent, stored in DB)
-  async getNotifications(params?: { offset?: number; limit?: number }): Promise<
+  // ── Notifications ─────────────────────────────────────────────────────────────
+
+  async getNotifications(params?: {
+    offset?: number;
+    limit?: number;
+  }): Promise<
     Array<{
       id: string;
       type: string;
@@ -394,7 +438,8 @@ class ApiClient {
   > {
     try {
       const query = new URLSearchParams();
-      if (params?.offset !== undefined) query.set("offset", String(params.offset));
+      if (params?.offset !== undefined)
+        query.set("offset", String(params.offset));
       if (params?.limit !== undefined) query.set("limit", String(params.limit));
       const qs = query.toString();
       return await this.request(`/notifications${qs ? `?${qs}` : ""}`);
@@ -417,24 +462,19 @@ class ApiClient {
   }
 
   async markNotificationRead(id: string) {
-    return this.request(`/notifications/${id}/read`, {
-      method: "PATCH",
-    });
+    return this.request(`/notifications/${id}/read`, { method: "PATCH" });
   }
 
   async markAllNotificationsRead() {
-    return this.request("/notifications/read-all", {
-      method: "PATCH",
-    });
+    return this.request("/notifications/read-all", { method: "PATCH" });
   }
 
   async deleteNotification(id: string) {
-    return this.request(`/notifications/${id}`, {
-      method: "DELETE",
-    });
+    return this.request(`/notifications/${id}`, { method: "DELETE" });
   }
 
-  // Governance endpoints
+  // ── Governance ───────────────────────────────────────────────────────────────
+
   async getProposals(): Promise<Proposal[]> {
     try {
       return await this.request<Proposal[]>("/governance");
@@ -455,12 +495,16 @@ class ApiClient {
   }
 
   async startVoting(id: string): Promise<{ message: string }> {
-    return this.request<{ message: string }>(`/governance/${id}/start-voting`, {
-      method: "POST",
-    });
+    return this.request<{ message: string }>(
+      `/governance/${id}/start-voting`,
+      { method: "POST" },
+    );
   }
 
-  async voteOnProposal(id: string, signature?: string): Promise<{ message: string }> {
+  async voteOnProposal(
+    id: string,
+    signature?: string,
+  ): Promise<{ message: string }> {
     return this.request<{ message: string }>(`/governance/${id}/vote`, {
       method: "POST",
       body: JSON.stringify({ signature }),
@@ -473,21 +517,29 @@ class ApiClient {
     });
   }
 
-  // Admin/Dispute endpoints
+  // ── Admin / Disputes ──────────────────────────────────────────────────────────
+
   async getDisputes(): Promise<Dispute[]> {
     return this.request<Dispute[]>("/admin/disputes");
   }
 
-  async resolveDispute(id: string, data: ResolveDisputePayload): Promise<{ message: string }> {
+  async resolveDispute(
+    id: string,
+    data: ResolveDisputePayload,
+  ): Promise<{ message: string }> {
     return this.request<{ message: string }>(`/admin/disputes/${id}/resolve`, {
       method: "POST",
       body: JSON.stringify(data),
     });
   }
 
-  async getActiveMatches(): Promise<import("../types/match").MatchWithPlayers[]> {
+  async getActiveMatches(): Promise<
+    import("../types/match").MatchWithPlayers[]
+  > {
     try {
-      return await this.request<import("../types/match").MatchWithPlayers[]>("/matches?status=in_progress&mine=true");
+      return await this.request<import("../types/match").MatchWithPlayers[]>(
+        "/matches?status=in_progress&mine=true",
+      );
     } catch {
       return [];
     }
@@ -511,21 +563,25 @@ class ApiClient {
     return this.request<KycReview>(`/admin/kyc/${id}`);
   }
 
-  async processKycReview(id: string, data: ProcessKycPayload): Promise<{ message: string }> {
+  async processKycReview(
+    id: string,
+    data: ProcessKycPayload,
+  ): Promise<{ message: string }> {
     return this.request<{ message: string }>(`/admin/kyc/${id}/process`, {
       method: "POST",
       body: JSON.stringify(data),
     });
   }
 
-  // Settings endpoints
+  // ── Settings ──────────────────────────────────────────────────────────────────
+
   async getSettings(): Promise<any> {
-    return this.request('/users/me/settings');
+    return this.request("/users/me/settings");
   }
 
   async updateSettings(data: any): Promise<any> {
-    return this.request('/users/me/settings', {
-      method: 'PATCH',
+    return this.request("/users/me/settings", {
+      method: "PATCH",
       body: JSON.stringify(data),
     });
   }

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -35,7 +35,15 @@ export interface EloPoint {
 }
 
 export interface AuthUser extends User {
+  /**
+   * @deprecated Tokens are stored in httpOnly cookies. This field is always
+   * an empty string and exists only for backward compatibility with existing
+   * type consumers.
+   */
   token: string;
+  /**
+   * @deprecated See `token` above.
+   */
   refreshToken: string;
 }
 


### PR DESCRIPTION
security: httpOnly cookies, WCAG viewport, JWT refresh config, remove WS simulation

- WCAG 2.1 SC 1.4.4: remove maximumScale/userScalable from viewport export
  iOS zoom prevention retained via existing font-size:16px rule in globals.css

- JWT refresh tokens: add JWT_REFRESH_EXPIRES_IN env var (default 7d)
  JwtConfig::from_config() wires validated config into JwtService in main.rs
  Added access_token_expiry_secs(), refresh_token_expiry_secs(), generate_ws_token()

- httpOnly cookie token storage (OWASP XSS mitigation):
  Backend: login/register set auth_token + auth_refresh_token httpOnly Secure
  SameSite=Strict cookies; response body carries {user, expires_in} only
  refresh reads auth_refresh_token cookie, falls back to JSON body
  logout/change-password/revoke-sessions clear both cookies
  GET /api/auth/ws-token issues 60s short-lived token for WS handshakes
  Middleware accepts auth_token cookie when no Authorization header present
  Frontend api.ts: all localStorage token reads removed, credentials:include
  on every fetch, refreshAccessToken uses cookie rotation endpoint
  useAuth.tsx: no token writes to storage; session proven by /api/auth/me
  probe; only public profile cached in sessionStorage

- NotificationContext.tsx: removed localStorage auth_token read
  WS auth now fetches short-lived ws_token from /api/auth/ws-token
  immediately before opening socket; token never stored

- useMatchWebSocket.ts: remove scriptedUpdates object, random-disconnect
  simulation interval (Math.random()<0.015), fake connect timeout
  Replace with real WebSocket to /ws/match/{matchId} with exponential
  backoff reconnect and same-origin cookie auth
  Dev-only simulation gated behind NODE_ENV !== production
closes #724 closes #725 closes #723 closes #659 