### PR TITLE
fix(server): repair broken API versioning and wire up URL versioning

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,5 +1,5 @@
 import cors from 'cors';
-import express, { Express, Request, Response } from 'express';
+import express, { Express, NextFunction, Request, Response } from 'express';
 import helmet from 'helmet';
 import passport from 'passport';
 import Redis from 'ioredis';
@@ -10,6 +10,8 @@ import { localeMiddleware } from './middleware/locale.middleware';
 import { correlationMiddleware } from './middleware/correlation.middleware';
 import { requestLogger } from './middleware/request-logger.middleware';
 import { metricsMiddleware } from './middleware/metrics.middleware';
+import { apiVersionMiddleware } from './middleware/api-version.middleware';
+import { apiVersionRegistry } from './config/api-versions';
 import routes from './routes/index';
 import { getEnv } from './config/env';
 import { getGraphQLExecutor } from './graphql/server';
@@ -157,6 +159,17 @@ export const createApp = (): Express => {
     app.use(localeMiddleware);
     app.use(passport.initialize());
     app.use(metricsMiddleware);
+
+    // Resolves the requested API version from the URL (`/api/v1/...`) or
+    // `Accept` header, attaches it to `res.locals.apiVersion`, and sets
+    // RFC 8594 Deprecation/Sunset headers once a version is deprecated.
+    app.use(apiVersionMiddleware(apiVersionRegistry));
+    app.use((req: Request, res: Response, next: NextFunction) => {
+        const apiVersion = (res.locals as { apiVersion?: { name: string } }).apiVersion;
+        if (apiVersion) res.setHeader('X-API-Version', apiVersion.name);
+        next();
+    });
+
     app.use('/api', routes);
 
     const graphql = getGraphQLExecutor();

--- a/server/src/config/api-versions.ts
+++ b/server/src/config/api-versions.ts
@@ -1,0 +1,17 @@
+import { InMemoryApiVersionRegistry } from '../middleware/api-version.middleware';
+
+/**
+ * Single source of truth for which API versions exist and their status.
+ * Consumed by `apiVersionMiddleware` (deprecation/sunset headers) and the
+ * `GET /api/versions` discovery endpoint.
+ */
+export const apiVersionRegistry = new InMemoryApiVersionRegistry();
+
+apiVersionRegistry.register(
+    {
+        name: 'v1',
+        status: 'live',
+        introducedAt: '2026-02-19T00:00:00.000Z',
+    },
+    { default: true },
+);

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -24,6 +24,7 @@ import { publicRateLimiter } from '../middleware/rate-limit.middleware';
 import { auditMiddleware } from '../middleware/audit.middleware';
 import { maintenanceMiddleware } from '../middleware/maintenance.middleware';
 import { MaintenanceService } from '../services/maintenance.service';
+import { apiVersionRegistry } from '../config/api-versions';
 
 const router: Router = Router();
 
@@ -35,28 +36,49 @@ router.get('/maintenance/status', (req, res) => {
     res.status(200).json(MaintenanceService.getInstance().getStatus());
 });
 
+router.get('/versions', (req, res) => {
+    res.status(200).json({
+        current: apiVersionRegistry.getDefault().name,
+        versions: apiVersionRegistry.list(),
+    });
+});
+
 router.use(maintenanceMiddleware);
 
-router.use('/api/v1/auth', authRoutes);
-router.use('/profiles', profileRoutes);
-router.use('/matches', matchRoutes);
-router.use('/api/v1/admin', adminRoutes);
-router.use('/governance', governanceRoutes);
-router.use('/soroban', sorobanRoutes);
-router.use('/wallets', walletRoutes);
-router.use('/wallet', walletRoutes);
+// This router is mounted at `/api` in app.ts, so a canonical v1 route only
+// needs a `/v1/...` prefix here — mounting `/api/v1/...` under it produced
+// unreachable `/api/api/v1/...` paths (see #657). Routes that previously
+// had that double prefix, or none at all, are given a single `/v1/...`
+// mount here. `mountVersioned` additionally keeps the pre-versioning
+// unversioned path alive as a deprecated alias for clients/tests that
+// haven't migrated yet, so both `/api/v1/<resource>` and `/api/<resource>`
+// keep working during the transition.
+const mountVersioned = (base: string, handler: Router) => {
+    router.use(`/v1${base}`, handler);
+    router.use(base, handler);
+};
+
+mountVersioned('/auth', authRoutes);
+mountVersioned('/profiles', profileRoutes);
+mountVersioned('/matches', matchRoutes);
+mountVersioned('/admin', adminRoutes);
+mountVersioned('/governance', governanceRoutes);
+mountVersioned('/soroban', sorobanRoutes);
+mountVersioned('/wallets', walletRoutes);
+mountVersioned('/wallet', walletRoutes);
+mountVersioned('/analytics', analyticsRoutes);
 router.use('/v1/achievements', achievementRoutes);
 router.use('/v1/tournaments', tournamentRoutes);
-router.use('/api/v1/analytics', analyticsRoutes);
+router.use('/v1/search', searchRoutes);
+router.use('/v1/cache', cacheRoutes);
+router.use('/v1/gateway', apiGatewayRoutes);
+router.use('/v1/queue', queueRoutes);
+router.use('/v1/access-control', accessControlRoutes);
+router.use('/v1/assets', crossGameAssetRoutes);
+router.use('/v1/i18n', i18nRoutes);
+
+// Unversioned infrastructure endpoints — not part of the public API surface.
 router.use('/metrics', metricsRoutes);
 router.use('/dashboard', dashboardRoutes);
-router.use('/v1/search', searchRoutes);
-router.use('/api/v1/cache', cacheRoutes);
-router.use('/api/v1/gateway', apiGatewayRoutes);
-router.use('/api/v1/queue', queueRoutes);
-router.use('/api/v1/access-control', accessControlRoutes);
-router.use('/api/v1/assets', crossGameAssetRoutes);
-router.use('/api/v1/i18n', i18nRoutes);
-
 
 export default router;


### PR DESCRIPTION
## Summary

Most API routes were mounted as `router.use('/api/v1/x', handler)` on a
router that `app.ts` already mounts at `/api`, which produced
**unreachable** `/api/api/v1/x` paths (confirmed against the Postman
collections, which expect `/api/v1/...`). A few other routes had no
version segment at all, so despite the versioning groundwork laid in
#476 (`api-version.middleware.ts`), the API had no working, consistent
versioning scheme and that middleware was never actually wired up.

## Changes

- Normalize every route in `routes/index.ts` to a single `/v1/<resource>`
  mount (the router is already under `/api`), and keep the
  pre-versioning unversioned path alive as a deprecated alias so
  existing clients/tests (`/api/auth/...`, `/api/admin`, etc.) keep
  working during the transition.
- Wire the existing `apiVersionMiddleware` into `app.ts` via a new
  `src/config/api-versions.ts` registry (`v1`, live/default). It resolves
  the requested version from the URL or `Accept` header, sets an
  `X-API-Version` response header, and will emit RFC 8594
  `Deprecation`/`Sunset` headers once a version is retired.
- Add `GET /api/versions` for version discovery.

## Test plan

- [x] `npx tsc --noEmit` — no new type errors introduced (pre-existing
  errors in `compression.middleware.ts` are unrelated and present on
  `main` too).
- [x] Manually traced Express route resolution for the old vs. new
  mount paths to confirm `/api/v1/auth/...` and `/api/auth/...` both now
  resolve, and the previous `/api/api/v1/...` dead paths are gone.
- [ ] CI build/test (this repo's `npm run build` currently fails on
  `main` due to unrelated pre-existing `compression.middleware.ts` type
  errors, which blocked running the full `node --test` suite locally in
  this environment)

Closes #657