### PR TITLE
feat(server): replace fixed-window rate limiting with a sliding window

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -15,7 +15,7 @@ import { getEnv } from './config/env';
 import { getGraphQLExecutor } from './graphql/server';
 import rateLimit from 'express-rate-limit';
 import { MemoryStore } from 'express-rate-limit';
-import { RedisRateLimitStore } from './middleware/rate-limit-redis.store';
+import { SlidingWindowRateLimitStore } from './middleware/sliding-window-rate-limit.store';
 import { FailoverStore } from './middleware/rate-limit-failover';
 import { createRateLimitHealthCheck, registerRateLimitMetricsProvider, getRateLimitMetrics } from './middleware/rate-limit-monitoring';
 import { initAdaptiveRateLimitRedis } from './middleware/adaptiveRateLimit.middleware';
@@ -100,12 +100,13 @@ export const createApp = (): Express => {
     app.use(xss()); // Prevent XSS attacks
     app.use(hpp()); // Prevent HTTP Parameter Pollution
 
-    // Global API rate limiter with Redis-backed store and in-memory failover
+    // Global API rate limiter with a sliding-window Redis-backed store and
+    // in-memory failover
     const globalRateLimitWindowMs = 15 * 60 * 1000;
     const redis = getRateLimitRedisClient();
     let apiLimiterStore: any;
     if (redis) {
-        const redisStore = new RedisRateLimitStore({
+        const redisStore = new SlidingWindowRateLimitStore({
             redis,
             prefix: 'rl:global:',
             windowMs: globalRateLimitWindowMs,

--- a/server/src/middleware/rate-limit.middleware.ts
+++ b/server/src/middleware/rate-limit.middleware.ts
@@ -1,7 +1,7 @@
 import rateLimit, { MemoryStore, Store } from 'express-rate-limit';
 import { Request, Response } from 'express';
 import Redis from 'ioredis';
-import { RedisRateLimitStore } from './rate-limit-redis.store';
+import { SlidingWindowRateLimitStore } from './sliding-window-rate-limit.store';
 import { FailoverStore } from './rate-limit-failover';
 import { logger } from '../services/logger.service';
 
@@ -54,10 +54,13 @@ function getRateLimitRedis(): Redis | null {
 function createRateLimitStore(windowMs: number, prefix: string): Store {
     const redis = getRateLimitRedis();
     if (!redis) {
+        // No Redis configured: fall back to express-rate-limit's in-process
+        // fixed-window MemoryStore. Sliding-window accuracy requires the
+        // shared Redis counters below.
         return new MemoryStore();
     }
 
-    const redisStore = new RedisRateLimitStore({ redis, prefix, windowMs });
+    const redisStore = new SlidingWindowRateLimitStore({ redis, prefix, windowMs });
     const memoryStore = new MemoryStore();
 
     return new FailoverStore(redisStore, memoryStore, {

--- a/server/src/middleware/sliding-window-rate-limit.store.ts
+++ b/server/src/middleware/sliding-window-rate-limit.store.ts
@@ -1,0 +1,145 @@
+import { Redis } from 'ioredis';
+import type { Store, IncrementResponse } from 'express-rate-limit';
+import { logger } from '../services/logger.service';
+
+/**
+ * Redis-backed sliding-window-counter store for express-rate-limit.
+ *
+ * The previous store (`RedisRateLimitStore`) used a fixed-window counter
+ * (INCR + EXPIRE), which lets clients burst up to 2x the limit around a
+ * window boundary (e.g. limit=100/min lets 100 requests at 0:59 and
+ * another 100 at 1:01). This store approximates a true sliding window
+ * without the memory cost of a sliding log (one Redis entry per request):
+ * it keeps a counter for the current fixed window and the previous one,
+ * and weights the previous window's count by how much of it still
+ * overlaps the trailing `windowMs` interval.
+ *
+ * `estimatedCount = currentWindowCount + previousWindowCount * overlap`
+ * where `overlap` is the fraction of the previous window still inside
+ * the sliding lookback (1.0 right at the boundary, decaying to 0.0 as
+ * the current window fills up). This is the same algorithm Cloudflare
+ * and Kong document for their sliding-window limiters — O(1) per
+ * request, two keys per window, and accurate to within the granularity
+ * of the underlying fixed window.
+ *
+ * @example
+ * ```ts
+ * const store = new SlidingWindowRateLimitStore({ redis, windowMs: 60_000 });
+ * const limiter = rateLimit({ store, windowMs: 60_000, limit: 100 });
+ * ```
+ */
+export class SlidingWindowRateLimitStore implements Store {
+  private redis: Redis;
+  private keyPrefix: string;
+  private windowMs: number;
+
+  constructor(options: { redis: Redis; prefix?: string; windowMs: number }) {
+    this.redis = options.redis;
+    this.keyPrefix = options.prefix ?? 'rlsw:';
+    this.windowMs = options.windowMs;
+  }
+
+  private windowKeys(now: number): { currentKey: string; previousKey: string; windowId: number } {
+    const windowId = Math.floor(now / this.windowMs);
+    return {
+      windowId,
+      currentKey: `w:${windowId}`,
+      previousKey: `w:${windowId - 1}`,
+    };
+  }
+
+  /**
+   * Atomically increments the current window's counter and reads the
+   * previous window's counter in a single round trip, so concurrent
+   * requests can't race between the two reads.
+   */
+  private async incrementAndReadPrevious(
+    currentRedisKey: string,
+    previousRedisKey: string,
+    ttlMs: number,
+  ): Promise<{ current: number; previous: number }> {
+    const script = `
+      local current = redis.call('INCR', KEYS[1])
+      if current == 1 then
+        redis.call('PEXPIRE', KEYS[1], ARGV[1])
+      end
+      local previous = tonumber(redis.call('GET', KEYS[2]) or '0')
+      return {current, previous}
+    `;
+    const result = (await this.redis.eval(
+      script,
+      2,
+      currentRedisKey,
+      previousRedisKey,
+      ttlMs,
+    )) as [number, number];
+
+    return { current: result[0], previous: result[1] };
+  }
+
+  async increment(key: string): Promise<IncrementResponse> {
+    const now = Date.now();
+    const { currentKey, previousKey, windowId } = this.windowKeys(now);
+    const currentRedisKey = `${this.keyPrefix}${key}:${currentKey}`;
+    const previousRedisKey = `${this.keyPrefix}${key}:${previousKey}`;
+    // Keep the "current" bucket alive for two windows so it can serve as
+    // the "previous" bucket for the next window without a second write.
+    const ttlMs = this.windowMs * 2;
+
+    try {
+      const { current, previous } = await this.incrementAndReadPrevious(
+        currentRedisKey,
+        previousRedisKey,
+        ttlMs,
+      );
+
+      const elapsedInCurrentWindow = now - windowId * this.windowMs;
+      const overlap = Math.max(0, (this.windowMs - elapsedInCurrentWindow) / this.windowMs);
+      const totalHits = Math.ceil(current + previous * overlap);
+      const resetTimeMs = (windowId + 1) * this.windowMs;
+
+      return { totalHits, resetTime: new Date(resetTimeMs) };
+    } catch (error) {
+      logger.error('Sliding window rate limit store increment failed', { key, error });
+      // On failure, treat as first hit so the request is allowed through.
+      return { totalHits: 1, resetTime: new Date(now + this.windowMs) };
+    }
+  }
+
+  async decrement(key: string): Promise<void> {
+    const now = Date.now();
+    const { currentKey } = this.windowKeys(now);
+    const currentRedisKey = `${this.keyPrefix}${key}:${currentKey}`;
+
+    try {
+      const count = await this.redis.decr(currentRedisKey);
+      if (count <= 0) {
+        await this.redis.del(currentRedisKey);
+      }
+    } catch (error) {
+      logger.error('Sliding window rate limit store decrement failed', { key, error });
+    }
+  }
+
+  async resetKey(key: string): Promise<void> {
+    const now = Date.now();
+    const { currentKey, previousKey } = this.windowKeys(now);
+
+    try {
+      await this.redis.del(`${this.keyPrefix}${key}:${currentKey}`, `${this.keyPrefix}${key}:${previousKey}`);
+    } catch (error) {
+      logger.error('Sliding window rate limit store resetKey failed', { key, error });
+    }
+  }
+
+  async resetAll(): Promise<void> {
+    try {
+      const keys = await this.redis.keys(`${this.keyPrefix}*`);
+      if (keys.length > 0) {
+        await this.redis.del(...keys);
+      }
+    } catch (error) {
+      logger.error('Sliding window rate limit store resetAll failed', { error });
+    }
+  }
+}

--- a/server/test/rate-limit-redis.test.js
+++ b/server/test/rate-limit-redis.test.js
@@ -69,6 +69,15 @@ class MockRedis {
   async exec() { return []; }
   on() { return this; }
   async connect() { return this; }
+
+  // Mirrors the increment-and-read-previous Lua script used by
+  // SlidingWindowRateLimitStore: INCR key[0], PEXPIRE on first write, GET key[1].
+  async eval(_script, _numkeys, currentKey, previousKey) {
+    const current = (this.store.get(currentKey) || 0) + 1;
+    this.store.set(currentKey, current);
+    const previous = Number(this.store.get(previousKey) || 0);
+    return [current, previous];
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -118,6 +127,96 @@ describe('RedisRateLimitStore', () => {
     const redis = new MockRedis();
     redis.incr = () => { throw new Error('ECONNREFUSED'); };
     const store = new RedisRateLimitStore({ redis, windowMs: 60000 });
+
+    const result = await store.increment('k');
+    assert.equal(result.totalHits, 1);
+    assert.ok(result.resetTime instanceof Date);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: SlidingWindowRateLimitStore
+// ---------------------------------------------------------------------------
+
+describe('SlidingWindowRateLimitStore', () => {
+  it('increments counter and returns totalHits + resetTime', async () => {
+    const { SlidingWindowRateLimitStore } = await import('../dist/middleware/sliding-window-rate-limit.store.js');
+    const redis = new MockRedis();
+    const store = new SlidingWindowRateLimitStore({ redis, windowMs: 60000 });
+
+    const result1 = await store.increment('user:123');
+    assert.equal(result1.totalHits, 1);
+    assert.ok(result1.resetTime instanceof Date);
+    assert.ok(result1.resetTime.getTime() > Date.now());
+
+    const result2 = await store.increment('user:123');
+    assert.equal(result2.totalHits, 2);
+  });
+
+  it('smooths bursts across a fixed-window boundary', async () => {
+    const { SlidingWindowRateLimitStore } = await import('../dist/middleware/sliding-window-rate-limit.store.js');
+    const redis = new MockRedis();
+    const windowMs = 60000;
+    const store = new SlidingWindowRateLimitStore({ redis, windowMs });
+
+    const realNow = Date.now;
+    try {
+      // Fill the first window with 100 hits.
+      Date.now = () => 0;
+      for (let i = 0; i < 100; i++) {
+        await store.increment('burst');
+      }
+
+      // A fixed-window counter would reset to 1 here, allowing another
+      // full burst. The sliding window should still see ~100 hits.
+      Date.now = () => windowMs + 1;
+      const rightAfterBoundary = await store.increment('burst');
+      assert.ok(
+        rightAfterBoundary.totalHits > 90,
+        `expected sliding window to carry over most of the previous window's hits, got ${rightAfterBoundary.totalHits}`,
+      );
+
+      // Well past the boundary, the previous window's weight should have
+      // decayed to (close to) nothing.
+      Date.now = () => windowMs * 2 + 5000;
+      const farFromBoundary = await store.increment('burst');
+      assert.ok(
+        farFromBoundary.totalHits < 10,
+        `expected the previous window's influence to have decayed, got ${farFromBoundary.totalHits}`,
+      );
+    } finally {
+      Date.now = realNow;
+    }
+  });
+
+  it('decrements counter', async () => {
+    const { SlidingWindowRateLimitStore } = await import('../dist/middleware/sliding-window-rate-limit.store.js');
+    const redis = new MockRedis();
+    const store = new SlidingWindowRateLimitStore({ redis, windowMs: 60000 });
+
+    await store.increment('k');
+    await store.increment('k');
+    await store.decrement('k');
+    const result = await store.increment('k');
+    assert.equal(result.totalHits, 2);
+  });
+
+  it('resets a single key', async () => {
+    const { SlidingWindowRateLimitStore } = await import('../dist/middleware/sliding-window-rate-limit.store.js');
+    const redis = new MockRedis();
+    const store = new SlidingWindowRateLimitStore({ redis, windowMs: 60000 });
+
+    await store.increment('k');
+    await store.resetKey('k');
+    const result = await store.increment('k');
+    assert.equal(result.totalHits, 1);
+  });
+
+  it('handles Redis errors gracefully', async () => {
+    const { SlidingWindowRateLimitStore } = await import('../dist/middleware/sliding-window-rate-limit.store.js');
+    const redis = new MockRedis();
+    redis.eval = () => { throw new Error('ECONNREFUSED'); };
+    const store = new SlidingWindowRateLimitStore({ redis, windowMs: 60000 });
 
     const result = await store.increment('k');
     assert.equal(result.totalHits, 1);


### PR DESCRIPTION
## Summary

The tiered rate limiters (`authRateLimiter`, `paymentRateLimiter`,
`adminRateLimiter`, `publicRateLimiter`, `apiKeyRateLimiter`) and the
global `/api` limiter in `app.ts` all used `RedisRateLimitStore`, a
fixed-window counter (Redis `INCR` + `EXPIRE`). Fixed windows let a
client burst up to 2x the configured limit right around a window
boundary — e.g. `limit=100/min` allows 100 requests at `0:59` and
another 100 at `1:01`, which is exactly the "limited accuracy" /
"better burst handling" gap called out in #658.

## Changes

- Add `SlidingWindowRateLimitStore`
  (`src/middleware/sliding-window-rate-limit.store.ts`), a Redis-backed
  **sliding-window-counter** store implementing express-rate-limit's
  `Store` interface. It tracks the current and previous fixed-window
  counts per key and weights the previous window's count by how much of
  it still overlaps the trailing `windowMs` interval:
  `estimatedCount = current + previous * overlap`. The
  increment-and-read-previous step is a single atomic Lua script (one
  Redis round trip, no race between the two reads). This is O(1) per
  request — two Redis keys per limited key — with no sliding-log memory
  overhead.
- Swap it in for `RedisRateLimitStore` in the tiered limiters
  (`rate-limit.middleware.ts`) and the global API limiter (`app.ts`),
  keeping the existing `MemoryStore` / `FailoverStore` fallback for when
  Redis is unavailable (that fallback stays fixed-window, which is an
  acceptable degradation since it's already an availability failover
  path).
- Add unit tests in `test/rate-limit-redis.test.js` covering basic
  increment/decrement/reset behavior and, notably, a
  boundary-smoothing test: it fills one window with 100 hits, jumps just
  past the window boundary and asserts the count is still >90 (a fixed
  window would show ~1), then jumps well past the boundary and asserts
  the previous window's influence has decayed to <10.

## Test plan

- [x] `npx tsc --noEmit` — no new type errors (pre-existing errors in
  `compression.middleware.ts` are unrelated, present on `main`, and
  currently failing CI there too).
- [x] Compiled `sliding-window-rate-limit.store.ts` in isolation (this
  repo's `npm run build` is currently broken on `main` from an unrelated
  PR, which also blocks running `test/rate-limit-redis.test.js` against
  `dist/` locally) and ran the new test cases against the compiled
  output directly — all 5 pass, including the boundary-smoothing
  assertions.
- [ ] Full `npm test` via CI once the unrelated build breakage on `main`
  is fixed.

Closes #658