### PR TITLE
feat(server): add Prometheus + Grafana monitoring stack

### DIFF
--- a/server/METRICS_DASHBOARD.md
+++ b/server/METRICS_DASHBOARD.md
@@ -126,6 +126,12 @@ scrape_configs:
     metrics_path: '/api/metrics'
 ```
 
+A ready-to-run Prometheus + Grafana stack (scrape config, alerting
+rules, and a provisioned Grafana dashboard) is bundled under
+`server/infra/monitoring/` — see
+[`docs/PROMETHEUS_GRAFANA_MONITORING.md`](docs/PROMETHEUS_GRAFANA_MONITORING.md)
+instead of hand-rolling the config above.
+
 ## Usage in Code
 
 ### Recording HTTP Metrics
@@ -221,8 +227,8 @@ METRICS_ENABLED="false"
 
 ## Future Enhancements
 
-- Add Grafana dashboard templates
-- Implement alerting rules
+- ~~Add Grafana dashboard templates~~ / ~~Implement alerting rules~~ —
+  done, see [`docs/PROMETHEUS_GRAFANA_MONITORING.md`](docs/PROMETHEUS_GRAFANA_MONITORING.md)
 - Add custom metric labels
 - Support for histogram quantiles
 - Real-time WebSocket updates for dashboard

--- a/server/docs/PROMETHEUS_GRAFANA_MONITORING.md
+++ b/server/docs/PROMETHEUS_GRAFANA_MONITORING.md
@@ -1,0 +1,92 @@
+# Monitoring — Prometheus + Grafana
+
+Closes #661.
+
+`arenax-server` already instruments itself with `prom-client`
+(`src/services/metrics.service.ts`) and exposes it at `GET /api/metrics`
+(see `METRICS_DASHBOARD.md` for what's recorded and how to record more).
+This change adds the **collection, storage, visualization, and alerting**
+side around that existing instrumentation — Prometheus scrapes the
+endpoint, Grafana visualizes it, and Prometheus's Alertmanager-compatible
+rule engine evaluates alert conditions — without changing how the app
+itself records metrics.
+
+## Architecture
+
+```
+prom-client (app process)
+  -> GET /api/metrics                       (already existed)
+       -> Prometheus (scrapes every 15s, evaluates infra/monitoring/alert.rules.yml)
+            -> Grafana (dashboards, provisioned from infra/monitoring/grafana/)
+```
+
+The app has **no runtime dependency on Prometheus or Grafana being up** —
+`/api/metrics` just serves whatever `prom-client`'s in-process registry
+currently holds; if nothing scrapes it, the app behaves exactly as
+before. This mirrors the same "app never depends on the observability
+stack" principle used for logging (see `docs/ELK_LOGGING.md`).
+
+## Components
+
+All under `server/infra/monitoring/`:
+
+- **`docker-compose.yml`** — Prometheus + Grafana.
+- **`prometheus.yml`** — scrape config. Scrapes `arenax-server` at
+  `host.docker.internal:3001/api/metrics` (the app runs on the host, not
+  in this compose network — see the comments in the file for the Linux
+  equivalent of `host.docker.internal`) and loads `alert.rules.yml`.
+- **`alert.rules.yml`** — alerting rules: scrape target down, 5xx error
+  rate > 5%, p95 HTTP latency > 1s, resident memory > 1.5GB, elevated
+  high/critical `errors_total`.
+- **`grafana/provisioning/datasources/prometheus.yml`** — auto-provisions
+  the Prometheus datasource (uid `arenax-prometheus`) so Grafana needs no
+  manual setup.
+- **`grafana/provisioning/dashboards/dashboards.yml`** +
+  **`grafana/dashboards/arenax-server-overview.json`** — auto-provisions
+  the "ArenaX Server Overview" dashboard: HTTP request rate by status
+  class, 5xx error ratio, HTTP latency p50/p95/p99, active connections,
+  DB query rate/latency by table, application errors by severity, cache
+  hit ratio, and process memory/CPU.
+
+## Running locally
+
+```bash
+# 1. Start the app so there's something to scrape
+cd server && npm run dev
+
+# 2. Start the monitoring stack
+docker compose -f server/infra/monitoring/docker-compose.yml up -d
+
+open http://localhost:9090   # Prometheus — check Status > Targets to confirm the scrape is up
+open http://localhost:3002   # Grafana — admin / admin (change the password on first login)
+```
+
+The "ArenaX Server Overview" dashboard is provisioned automatically
+under the **ArenaX** folder — no manual datasource or dashboard import
+needed.
+
+## Alerting
+
+`alert.rules.yml` is loaded by Prometheus's own rule engine
+(`ALERTS`/`ALERTS_FOR_STATE` are queryable directly in Prometheus, and
+firing alerts show under **Alerts** in the Prometheus UI). To actually
+route them to Slack/PagerDuty/email, point Prometheus at an
+Alertmanager instance (`alerting.alertmanagers` in `prometheus.yml`) —
+that's intentionally not bundled here since the routing destinations are
+environment-specific credentials, matching how `docs/ELK_LOGGING.md`
+handles Kibana alerting.
+
+## Production notes
+
+The bundled compose file is for local development:
+
+- Grafana ships with the default `admin/admin` credentials — set
+  `GF_SECURITY_ADMIN_PASSWORD` from a secret in any shared environment.
+- Prometheus's local TSDB (`--storage.tsdb.retention.time=15d`) is fine
+  for a single box; for HA or longer retention, use Thanos/Cortex/Mimir
+  or a managed Prometheus-compatible backend.
+- The `host.docker.internal` scrape target assumes the app runs on the
+  same host as the compose stack. If `arenax-server` is containerized
+  and joined to a shared network (or run in Kubernetes), replace the
+  static target with the container/service DNS name (or a Kubernetes
+  `ServiceMonitor` if using the Prometheus Operator).

--- a/server/infra/monitoring/alert.rules.yml
+++ b/server/infra/monitoring/alert.rules.yml
@@ -1,0 +1,55 @@
+groups:
+  - name: arenax-server
+    rules:
+      - alert: ArenaXServerDown
+        expr: up{job="arenax-server"} == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "arenax-server is not being scraped"
+          description: "Prometheus has not been able to scrape /api/metrics on arenax-server for 1 minute."
+
+      - alert: HighHttpErrorRate
+        expr: |
+          sum(rate(http_requests_total{status_code=~"5.."}[5m]))
+          /
+          sum(rate(http_requests_total[5m]))
+          > 0.05
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "5xx error rate above 5%"
+          description: "More than 5% of HTTP responses have been 5xx over the last 5 minutes."
+
+      - alert: HighHttpLatencyP95
+        expr: |
+          histogram_quantile(
+            0.95,
+            sum(rate(http_request_duration_seconds_bucket[5m])) by (le)
+          ) > 1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "p95 HTTP latency above 1s"
+          description: "95th percentile request duration has been above 1 second for 5 minutes."
+
+      - alert: HighProcessMemory
+        expr: process_resident_memory_bytes{job="arenax-server"} > 1.5e9
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "arenax-server resident memory above 1.5GB"
+          description: "Process RSS has been above 1.5GB for 10 minutes — check for leaks or scale up."
+
+      - alert: ElevatedApplicationErrors
+        expr: sum(rate(errors_total{severity=~"high|critical"}[5m])) > 1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High/critical application errors trending up"
+          description: "More than 1/s of high or critical severity errors recorded via errors_total over the last 5 minutes."

--- a/server/infra/monitoring/docker-compose.yml
+++ b/server/infra/monitoring/docker-compose.yml
@@ -1,0 +1,60 @@
+version: '3.8'
+
+# Prometheus + Grafana monitoring stack for #661.
+#
+# arenax-server already exposes Prometheus-format metrics at
+# `/api/metrics` via prom-client (src/services/metrics.service.ts,
+# src/routes/metrics.routes.ts) — this adds the scraping/storage/
+# visualization/alerting side around that existing instrumentation,
+# without changing how the app itself records metrics.
+#
+# Usage:
+#   docker compose -f server/infra/monitoring/docker-compose.yml up -d
+#   open http://localhost:9090   # Prometheus
+#   open http://localhost:3002   # Grafana (admin / admin, change on first login)
+services:
+  prometheus:
+    image: prom/prometheus:v2.54.1
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./alert.rules.yml:/etc/prometheus/alert.rules.yml:ro
+      - prometheus_data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--storage.tsdb.retention.time=15d'
+    ports:
+      - "9090:9090"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:9090/-/healthy || exit 1"]
+      interval: 15s
+      timeout: 10s
+      retries: 10
+    networks:
+      - monitoring-network
+
+  grafana:
+    image: grafana/grafana:11.2.0
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_USERS_ALLOW_SIGN_UP: "false"
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/etc/grafana/dashboards:ro
+    ports:
+      - "3002:3000"
+    depends_on:
+      prometheus:
+        condition: service_healthy
+    networks:
+      - monitoring-network
+
+networks:
+  monitoring-network:
+    driver: bridge
+
+volumes:
+  prometheus_data:
+  grafana_data:

--- a/server/infra/monitoring/grafana/dashboards/arenax-server-overview.json
+++ b/server/infra/monitoring/grafana/dashboards/arenax-server-overview.json
@@ -1,0 +1,172 @@
+{
+  "title": "ArenaX Server Overview",
+  "uid": "arenax-server-overview",
+  "tags": ["arenax", "server"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-6h", "to": "now" },
+  "panels": [
+    {
+      "id": 1,
+      "title": "HTTP Request Rate (by status class)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "arenax-prometheus" },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total[5m])) by (status_code)",
+          "legendFormat": "{{status_code}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "5xx Error Rate",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "arenax-prometheus" },
+      "fieldConfig": { "defaults": { "unit": "percentunit" }, "overrides": [] },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{status_code=~\"5..\"}[5m])) / sum(rate(http_requests_total[5m]))",
+          "legendFormat": "5xx ratio",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "HTTP Latency (p50 / p95 / p99)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "arenax-prometheus" },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Active Connections",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "arenax-prometheus" },
+      "targets": [
+        {
+          "expr": "active_connections",
+          "legendFormat": "active connections",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "DB Query Rate (by table)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "datasource": { "type": "prometheus", "uid": "arenax-prometheus" },
+      "targets": [
+        {
+          "expr": "sum(rate(db_queries_total[5m])) by (table, status)",
+          "legendFormat": "{{table}} ({{status}})",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "title": "DB Query Latency p95 (by table)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "datasource": { "type": "prometheus", "uid": "arenax-prometheus" },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(db_query_duration_seconds_bucket[5m])) by (le, table))",
+          "legendFormat": "{{table}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "title": "Application Errors (by severity)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
+      "datasource": { "type": "prometheus", "uid": "arenax-prometheus" },
+      "targets": [
+        {
+          "expr": "sum(rate(errors_total[5m])) by (severity)",
+          "legendFormat": "{{severity}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "title": "Cache Hit Ratio",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
+      "datasource": { "type": "prometheus", "uid": "arenax-prometheus" },
+      "fieldConfig": { "defaults": { "unit": "percentunit" }, "overrides": [] },
+      "targets": [
+        {
+          "expr": "sum(rate(cache_hits_total[5m])) / (sum(rate(cache_hits_total[5m])) + sum(rate(cache_misses_total[5m])))",
+          "legendFormat": "hit ratio",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "title": "Process Memory (RSS)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 32 },
+      "datasource": { "type": "prometheus", "uid": "arenax-prometheus" },
+      "fieldConfig": { "defaults": { "unit": "bytes" }, "overrides": [] },
+      "targets": [
+        {
+          "expr": "process_resident_memory_bytes{job=\"arenax-server\"}",
+          "legendFormat": "RSS",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "title": "Process CPU",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 32 },
+      "datasource": { "type": "prometheus", "uid": "arenax-prometheus" },
+      "targets": [
+        {
+          "expr": "rate(process_cpu_user_seconds_total{job=\"arenax-server\"}[5m])",
+          "legendFormat": "user cpu",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(process_cpu_system_seconds_total{job=\"arenax-server\"}[5m])",
+          "legendFormat": "system cpu",
+          "refId": "B"
+        }
+      ]
+    }
+  ]
+}

--- a/server/infra/monitoring/grafana/provisioning/dashboards/dashboards.yml
+++ b/server/infra/monitoring/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: arenax-server
+    orgId: 1
+    folder: ArenaX
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    options:
+      path: /etc/grafana/dashboards

--- a/server/infra/monitoring/grafana/provisioning/datasources/prometheus.yml
+++ b/server/infra/monitoring/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    uid: arenax-prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true

--- a/server/infra/monitoring/prometheus.yml
+++ b/server/infra/monitoring/prometheus.yml
@@ -1,0 +1,24 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+rule_files:
+  - /etc/prometheus/alert.rules.yml
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets: ['localhost:9090']
+
+  # arenax-server runs on the host (npm run dev / npm start), not inside
+  # this compose network — same pattern as infra/elk's bind-mounted log
+  # tailing. `host.docker.internal` reaches the host from a container on
+  # Docker Desktop (Mac/Windows). On Linux, either run Docker with
+  # `--add-host=host.docker.internal:host-gateway` (Docker Engine 20.10+)
+  # or replace the target below with the host's actual IP/hostname.
+  - job_name: arenax-server
+    metrics_path: /api/metrics
+    static_configs:
+      - targets: ['host.docker.internal:3001']
+        labels:
+          service: arenax-server


### PR DESCRIPTION
## Summary

`arenax-server` already instruments itself with `prom-client`
(`src/services/metrics.service.ts`) and exposes it at `GET /api/metrics`
— but nothing actually scraped, stored, visualized, or alerted on those
metrics. `METRICS_DASHBOARD.md` even listed *"Add Grafana dashboard
templates"* and *"Implement alerting rules"* as open future work. This
PR adds that missing collection/visualization/alerting layer around the
existing instrumentation, without touching how the app records metrics.

## Changes

New `server/infra/monitoring/`, following the same standalone-compose
pattern already used for `infra/elk` and `infra/redis-cluster`:

- `docker-compose.yml` — Prometheus (`:9090`) + Grafana (`:3002`).
- `prometheus.yml` — scrapes `arenax-server`'s `/api/metrics` every 15s
  (via `host.docker.internal`, since the app runs on the host like the
  ELK setup's Filebeat does) and loads `alert.rules.yml`.
- `alert.rules.yml` — 5 alerting rules: scrape target down, 5xx error
  rate > 5%, p95 HTTP latency > 1s, resident memory > 1.5GB, elevated
  high/critical `errors_total`.
- `grafana/provisioning/` — auto-provisions the Prometheus datasource
  and an **ArenaX Server Overview** dashboard (HTTP request rate by
  status class, 5xx ratio, latency p50/p95/p99, active connections, DB
  query rate/latency by table, errors by severity, cache hit ratio,
  process memory/CPU) — no manual Grafana setup needed.
- `docs/PROMETHEUS_GRAFANA_MONITORING.md` — architecture, how to run it
  locally, alerting notes, production notes. Linked from
  `METRICS_DASHBOARD.md`, which is also updated to mark the "Grafana
  dashboard templates" / "alerting rules" future-work items as done.

## Test plan

- [x] `docker compose -f server/infra/monitoring/docker-compose.yml
  config` — validates cleanly (only the pre-existing, harmless `version`
  key deprecation warning also present in `infra/elk`'s compose file).
- [x] Validated `alert.rules.yml`, `prometheus.yml`, and both Grafana
  provisioning YAML files parse correctly, and the dashboard JSON is
  well-formed.
- [ ] Full `docker compose up` + confirming Prometheus scrapes the app
  and Grafana renders the dashboard — the sandbox this was built in
  doesn't have a reachable Docker daemon, so this needs a manual pass in
  an environment with Docker running (`docker compose -f
  server/infra/monitoring/docker-compose.yml up -d`, then check
  Prometheus **Status > Targets** and open Grafana at `:3002`).

Closes #661