### PR TITLE
feat(server): enrich error logs with user, request, and correlation context

### DIFF
--- a/server/src/middleware/error.middleware.ts
+++ b/server/src/middleware/error.middleware.ts
@@ -1,9 +1,25 @@
+import { createHash } from 'node:crypto';
 import { Request, Response, NextFunction } from 'express';
 import { BaseError, InternalServerError, isBaseError } from '../errors';
 import { logger } from '../services/logger.service';
 import { captureException } from '../services/telemetry.service';
 import { HttpError } from '../utils/http-error';
 import { getEnv } from '../config/env';
+import { sanitizeData, sanitizeHeaders } from './request-logger.middleware';
+
+/**
+ * Groups repeated occurrences of "the same" error together for log
+ * search/aggregation, independent of the per-request correlation ID
+ * (which only ties together logs from a single request). IDs and
+ * numbers in the message are normalized out first so e.g. "User 123 not
+ * found" and "User 456 not found" produce the same fingerprint.
+ */
+const ID_LIKE_PATTERN = /[0-9a-fA-F-]{6,}|\d+/g;
+
+const buildErrorFingerprint = (route: string, code: string, message: string): string => {
+    const normalizedMessage = message.replace(ID_LIKE_PATTERN, '#');
+    return createHash('sha1').update(`${code}:${route}:${normalizedMessage}`).digest('hex').slice(0, 12);
+};
 
 const normalizeError = (err: unknown): BaseError => {
     if (isBaseError(err)) {
@@ -36,14 +52,24 @@ export const errorHandler = (
     const { isProductionLike } = getEnv();
     const requestId = req.requestId ?? 'unknown';
     const requestLogger = req.log ?? logger;
+    const route = req.route?.path ? `${req.baseUrl}${req.route.path}` : req.path;
+    const rawMessage = err instanceof Error ? err.message : String(err);
 
     requestLogger.error('Unhandled request error', {
         requestId,
+        correlationId: req.correlationId ?? requestId,
         method: req.method,
         path: req.originalUrl,
+        route,
+        query: sanitizeData(req.query || {}),
+        headers: sanitizeHeaders(req.headers || {}),
+        ip: req.ip,
+        userAgent: req.get('user-agent'),
+        user: req.user ? { id: req.user.id, role: req.user.role } : undefined,
         status: normalizedError.statusCode,
         errorCode: normalizedError.code,
-        message: err instanceof Error ? err.message : String(err),
+        errorFingerprint: buildErrorFingerprint(route, normalizedError.code, rawMessage),
+        message: rawMessage,
         stack: err instanceof Error ? err.stack : undefined,
         details: isBaseError(err) ? err.details : undefined
     });

--- a/server/test/error-middleware.test.js
+++ b/server/test/error-middleware.test.js
@@ -1,0 +1,112 @@
+const { describe, it, before } = require('node:test');
+const assert = require('node:assert/strict');
+
+process.env.DATABASE_URL = process.env.DATABASE_URL || 'postgresql://user:pass@localhost:5432/arenax_test';
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'test-secret-at-least-32-characters-long-ok';
+
+// Minimal req/res/next doubles — no supertest/express app needed since
+// errorHandler only touches a handful of req/res members.
+function makeReq(overrides = {}) {
+    const logs = [];
+    return {
+        requestId: 'req-1',
+        correlationId: 'corr-1',
+        method: 'GET',
+        originalUrl: '/api/v1/wallets/me?foo=bar',
+        path: '/wallets/me',
+        baseUrl: '',
+        route: { path: '/wallets/me' },
+        query: { foo: 'bar' },
+        headers: { authorization: 'Bearer secret-token', 'user-agent': 'jest-test' },
+        ip: '127.0.0.1',
+        get(name) {
+            return this.headers[name.toLowerCase()];
+        },
+        log: {
+            error(message, meta) {
+                logs.push({ message, meta });
+            },
+        },
+        _logs: logs,
+        ...overrides,
+    };
+}
+
+function makeRes() {
+    return {
+        statusCode: undefined,
+        body: undefined,
+        status(code) {
+            this.statusCode = code;
+            return this;
+        },
+        json(payload) {
+            this.body = payload;
+            return this;
+        },
+    };
+}
+
+describe('errorHandler', () => {
+    let errorHandler;
+
+    before(async () => {
+        const envModule = await import('../dist/config/env.js');
+        envModule.initEnv();
+        ({ errorHandler } = await import('../dist/middleware/error.middleware.js'));
+    });
+
+    it('logs request context, sanitized headers, and no user when unauthenticated', () => {
+        const req = makeReq();
+        const res = makeRes();
+
+        errorHandler(new Error('User 123 not found'), req, res, () => {});
+
+        assert.equal(req._logs.length, 1);
+        const { meta } = req._logs[0];
+        assert.equal(meta.method, 'GET');
+        assert.equal(meta.route, '/wallets/me');
+        assert.deepEqual(meta.query, { foo: 'bar' });
+        assert.equal(meta.headers.authorization, '[REDACTED]');
+        assert.equal(meta.headers['user-agent'], 'jest-test');
+        assert.equal(meta.ip, '127.0.0.1');
+        assert.equal(meta.correlationId, 'corr-1');
+        assert.equal(meta.user, undefined);
+        assert.ok(meta.stack, 'expected the full stack trace to be captured');
+        assert.ok(meta.errorFingerprint);
+    });
+
+    it('includes user id and role when the request is authenticated', () => {
+        const req = makeReq({ user: { id: 'user-42', role: 'ADMIN', email: 'a@b.com', username: 'a' } });
+        const res = makeRes();
+
+        errorHandler(new Error('boom'), req, res, () => {});
+
+        const { meta } = req._logs[0];
+        assert.deepEqual(meta.user, { id: 'user-42', role: 'ADMIN' });
+    });
+
+    it('produces the same fingerprint for the same error shape with different ids', () => {
+        const resA = makeRes();
+        const reqA = makeReq();
+        errorHandler(new Error('User 123 not found'), reqA, resA, () => {});
+
+        const resB = makeRes();
+        const reqB = makeReq();
+        errorHandler(new Error('User 987654 not found'), reqB, resB, () => {});
+
+        assert.equal(reqA._logs[0].meta.errorFingerprint, reqB._logs[0].meta.errorFingerprint);
+    });
+
+    it('produces a different fingerprint for a different route', () => {
+        const resA = makeRes();
+        const reqA = makeReq();
+        errorHandler(new Error('User 123 not found'), reqA, resA, () => {});
+
+        const resB = makeRes();
+        const reqB = makeReq({ path: '/matches/me', route: { path: '/matches/me' } });
+        errorHandler(new Error('User 123 not found'), reqB, resB, () => {});
+
+        assert.notEqual(reqA._logs[0].meta.errorFingerprint, reqB._logs[0].meta.errorFingerprint);
+    });
+});


### PR DESCRIPTION
## Summary

`errorHandler` (`src/middleware/error.middleware.ts`) already logged
`requestId`, `method`, `path`, `status`, `errorCode`, `message`, and
`stack` — but was missing exactly the context you actually need to
debug a production incident from the error log line alone:

- **Who hit it** — `req.user` was never included.
- **What the request looked like** — query params, headers, IP, user
  agent. Previously you had to cross-reference the separate "Incoming
  request" log line (from `request-logger.middleware.ts`) by
  `requestId` to see this.
- **Error correlation** — a request's `correlationId` ties together log
  lines *within one request*, but there was nothing tying together
  repeated occurrences of *the same underlying error* across different
  requests/users, which is what "error correlation" usually means for
  log aggregation/search.

## Changes

- Include `user: { id, role }` when the request is authenticated
  (omitting `email`/`username` to keep the error log's PII footprint
  minimal).
- Include sanitized `query`, sanitized `headers`, `ip`, `userAgent`, and
  an explicit `correlationId` field.
- Reuse the existing `sanitizeData`/`sanitizeHeaders` redaction helpers
  from `request-logger.middleware.ts` (already used for the
  request/response logs) so secrets are scrubbed the same way
  everywhere — no new redaction logic to keep in sync.
- Add `errorFingerprint`: `sha1(errorCode:route:normalizedMessage)`,
  where the message has IDs/numbers stripped out (e.g. `"User 123 not
  found"` and `"User 987654 not found"` on the same route produce the
  same fingerprint). This lets a log search/aggregation tool group
  recurring instances of the same error together, independent of which
  request or user triggered them.
- Full stack trace capture (`winston.format.errors({ stack: true })`)
  and JSON-structured, searchable logs were already in place from prior
  work — unchanged here.

## Test plan

- [x] `npx tsc --noEmit` — no new type errors (pre-existing errors in
  `compression.middleware.ts` are unrelated, present on `main`, and
  currently failing CI there too).
- [x] Added `test/error-middleware.test.js` (4 cases: request/header/user
  context is logged and headers are redacted; `user` is included with
  `id`/`role` when authenticated and omitted when not; fingerprints match
  across differing IDs on the same route; fingerprints differ across
  routes). Compiled the relevant files in isolation and ran the new
  tests against the compiled output — all 4 pass (this repo's `npm run
  build` is currently broken on `main` from an unrelated PR, which also
  blocks running this against `dist/` directly, same as the other PRs in
  this batch).
- [ ] Full `npm test` via CI once the unrelated build breakage on `main`
  is fixed.

Closes #826