### PR TITLE
fix(server): API versioning, sliding-window rate limits, Prometheus/Grafana, error log context

### DIFF
--- a/server/METRICS_DASHBOARD.md
+++ b/server/METRICS_DASHBOARD.md
@@ -126,6 +126,12 @@ scrape_configs:
     metrics_path: '/api/metrics'
 ```
 
+A ready-to-run Prometheus + Grafana stack (scrape config, alerting
+rules, and a provisioned Grafana dashboard) is bundled under
+`server/infra/monitoring/` — see
+[`docs/PROMETHEUS_GRAFANA_MONITORING.md`](docs/PROMETHEUS_GRAFANA_MONITORING.md)
+instead of hand-rolling the config above.
+
 ## Usage in Code
 
 ### Recording HTTP Metrics
@@ -221,8 +227,8 @@ METRICS_ENABLED="false"
 
 ## Future Enhancements
 
-- Add Grafana dashboard templates
-- Implement alerting rules
+- ~~Add Grafana dashboard templates~~ / ~~Implement alerting rules~~ —
+  done, see [`docs/PROMETHEUS_GRAFANA_MONITORING.md`](docs/PROMETHEUS_GRAFANA_MONITORING.md)
 - Add custom metric labels
 - Support for histogram quantiles
 - Real-time WebSocket updates for dashboard

--- a/server/docs/PROMETHEUS_GRAFANA_MONITORING.md
+++ b/server/docs/PROMETHEUS_GRAFANA_MONITORING.md
@@ -1,0 +1,92 @@
+# Monitoring — Prometheus + Grafana
+
+Closes #661.
+
+`arenax-server` already instruments itself with `prom-client`
+(`src/services/metrics.service.ts`) and exposes it at `GET /api/metrics`
+(see `METRICS_DASHBOARD.md` for what's recorded and how to record more).
+This change adds the **collection, storage, visualization, and alerting**
+side around that existing instrumentation — Prometheus scrapes the
+endpoint, Grafana visualizes it, and Prometheus's Alertmanager-compatible
+rule engine evaluates alert conditions — without changing how the app
+itself records metrics.
+
+## Architecture
+
+```
+prom-client (app process)
+  -> GET /api/metrics                       (already existed)
+       -> Prometheus (scrapes every 15s, evaluates infra/monitoring/alert.rules.yml)
+            -> Grafana (dashboards, provisioned from infra/monitoring/grafana/)
+```
+
+The app has **no runtime dependency on Prometheus or Grafana being up** —
+`/api/metrics` just serves whatever `prom-client`'s in-process registry
+currently holds; if nothing scrapes it, the app behaves exactly as
+before. This mirrors the same "app never depends on the observability
+stack" principle used for logging (see `docs/ELK_LOGGING.md`).
+
+## Components
+
+All under `server/infra/monitoring/`:
+
+- **`docker-compose.yml`** — Prometheus + Grafana.
+- **`prometheus.yml`** — scrape config. Scrapes `arenax-server` at
+  `host.docker.internal:3001/api/metrics` (the app runs on the host, not
+  in this compose network — see the comments in the file for the Linux
+  equivalent of `host.docker.internal`) and loads `alert.rules.yml`.
+- **`alert.rules.yml`** — alerting rules: scrape target down, 5xx error
+  rate > 5%, p95 HTTP latency > 1s, resident memory > 1.5GB, elevated
+  high/critical `errors_total`.
+- **`grafana/provisioning/datasources/prometheus.yml`** — auto-provisions
+  the Prometheus datasource (uid `arenax-prometheus`) so Grafana needs no
+  manual setup.
+- **`grafana/provisioning/dashboards/dashboards.yml`** +
+  **`grafana/dashboards/arenax-server-overview.json`** — auto-provisions
+  the "ArenaX Server Overview" dashboard: HTTP request rate by status
+  class, 5xx error ratio, HTTP latency p50/p95/p99, active connections,
+  DB query rate/latency by table, application errors by severity, cache
+  hit ratio, and process memory/CPU.
+
+## Running locally
+
+```bash
+# 1. Start the app so there's something to scrape
+cd server && npm run dev
+
+# 2. Start the monitoring stack
+docker compose -f server/infra/monitoring/docker-compose.yml up -d
+
+open http://localhost:9090   # Prometheus — check Status > Targets to confirm the scrape is up
+open http://localhost:3002   # Grafana — admin / admin (change the password on first login)
+```
+
+The "ArenaX Server Overview" dashboard is provisioned automatically
+under the **ArenaX** folder — no manual datasource or dashboard import
+needed.
+
+## Alerting
+
+`alert.rules.yml` is loaded by Prometheus's own rule engine
+(`ALERTS`/`ALERTS_FOR_STATE` are queryable directly in Prometheus, and
+firing alerts show under **Alerts** in the Prometheus UI). To actually
+route them to Slack/PagerDuty/email, point Prometheus at an
+Alertmanager instance (`alerting.alertmanagers` in `prometheus.yml`) —
+that's intentionally not bundled here since the routing destinations are
+environment-specific credentials, matching how `docs/ELK_LOGGING.md`
+handles Kibana alerting.
+
+## Production notes
+
+The bundled compose file is for local development:
+
+- Grafana ships with the default `admin/admin` credentials — set
+  `GF_SECURITY_ADMIN_PASSWORD` from a secret in any shared environment.
+- Prometheus's local TSDB (`--storage.tsdb.retention.time=15d`) is fine
+  for a single box; for HA or longer retention, use Thanos/Cortex/Mimir
+  or a managed Prometheus-compatible backend.
+- The `host.docker.internal` scrape target assumes the app runs on the
+  same host as the compose stack. If `arenax-server` is containerized
+  and joined to a shared network (or run in Kubernetes), replace the
+  static target with the container/service DNS name (or a Kubernetes
+  `ServiceMonitor` if using the Prometheus Operator).

--- a/server/infra/monitoring/alert.rules.yml
+++ b/server/infra/monitoring/alert.rules.yml
@@ -1,0 +1,55 @@
+groups:
+  - name: arenax-server
+    rules:
+      - alert: ArenaXServerDown
+        expr: up{job="arenax-server"} == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "arenax-server is not being scraped"
+          description: "Prometheus has not been able to scrape /api/metrics on arenax-server for 1 minute."
+
+      - alert: HighHttpErrorRate
+        expr: |
+          sum(rate(http_requests_total{status_code=~"5.."}[5m]))
+          /
+          sum(rate(http_requests_total[5m]))
+          > 0.05
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "5xx error rate above 5%"
+          description: "More than 5% of HTTP responses have been 5xx over the last 5 minutes."
+
+      - alert: HighHttpLatencyP95
+        expr: |
+          histogram_quantile(
+            0.95,
+            sum(rate(http_request_duration_seconds_bucket[5m])) by (le)
+          ) > 1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "p95 HTTP latency above 1s"
+          description: "95th percentile request duration has been above 1 second for 5 minutes."
+
+      - alert: HighProcessMemory
+        expr: process_resident_memory_bytes{job="arenax-server"} > 1.5e9
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "arenax-server resident memory above 1.5GB"
+          description: "Process RSS has been above 1.5GB for 10 minutes — check for leaks or scale up."
+
+      - alert: ElevatedApplicationErrors
+        expr: sum(rate(errors_total{severity=~"high|critical"}[5m])) > 1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High/critical application errors trending up"
+          description: "More than 1/s of high or critical severity errors recorded via errors_total over the last 5 minutes."

--- a/server/infra/monitoring/docker-compose.yml
+++ b/server/infra/monitoring/docker-compose.yml
@@ -1,0 +1,60 @@
+version: '3.8'
+
+# Prometheus + Grafana monitoring stack for #661.
+#
+# arenax-server already exposes Prometheus-format metrics at
+# `/api/metrics` via prom-client (src/services/metrics.service.ts,
+# src/routes/metrics.routes.ts) — this adds the scraping/storage/
+# visualization/alerting side around that existing instrumentation,
+# without changing how the app itself records metrics.
+#
+# Usage:
+#   docker compose -f server/infra/monitoring/docker-compose.yml up -d
+#   open http://localhost:9090   # Prometheus
+#   open http://localhost:3002   # Grafana (admin / admin, change on first login)
+services:
+  prometheus:
+    image: prom/prometheus:v2.54.1
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./alert.rules.yml:/etc/prometheus/alert.rules.yml:ro
+      - prometheus_data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--storage.tsdb.retention.time=15d'
+    ports:
+      - "9090:9090"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:9090/-/healthy || exit 1"]
+      interval: 15s
+      timeout: 10s
+      retries: 10
+    networks:
+      - monitoring-network
+
+  grafana:
+    image: grafana/grafana:11.2.0
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_USERS_ALLOW_SIGN_UP: "false"
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/etc/grafana/dashboards:ro
+    ports:
+      - "3002:3000"
+    depends_on:
+      prometheus:
+        condition: service_healthy
+    networks:
+      - monitoring-network
+
+networks:
+  monitoring-network:
+    driver: bridge
+
+volumes:
+  prometheus_data:
+  grafana_data:

--- a/server/infra/monitoring/grafana/dashboards/arenax-server-overview.json
+++ b/server/infra/monitoring/grafana/dashboards/arenax-server-overview.json
@@ -1,0 +1,172 @@
+{
+  "title": "ArenaX Server Overview",
+  "uid": "arenax-server-overview",
+  "tags": ["arenax", "server"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-6h", "to": "now" },
+  "panels": [
+    {
+      "id": 1,
+      "title": "HTTP Request Rate (by status class)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "arenax-prometheus" },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total[5m])) by (status_code)",
+          "legendFormat": "{{status_code}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "5xx Error Rate",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "arenax-prometheus" },
+      "fieldConfig": { "defaults": { "unit": "percentunit" }, "overrides": [] },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{status_code=~\"5..\"}[5m])) / sum(rate(http_requests_total[5m]))",
+          "legendFormat": "5xx ratio",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "HTTP Latency (p50 / p95 / p99)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "arenax-prometheus" },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Active Connections",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "arenax-prometheus" },
+      "targets": [
+        {
+          "expr": "active_connections",
+          "legendFormat": "active connections",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "DB Query Rate (by table)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "datasource": { "type": "prometheus", "uid": "arenax-prometheus" },
+      "targets": [
+        {
+          "expr": "sum(rate(db_queries_total[5m])) by (table, status)",
+          "legendFormat": "{{table}} ({{status}})",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "title": "DB Query Latency p95 (by table)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "datasource": { "type": "prometheus", "uid": "arenax-prometheus" },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(db_query_duration_seconds_bucket[5m])) by (le, table))",
+          "legendFormat": "{{table}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "title": "Application Errors (by severity)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
+      "datasource": { "type": "prometheus", "uid": "arenax-prometheus" },
+      "targets": [
+        {
+          "expr": "sum(rate(errors_total[5m])) by (severity)",
+          "legendFormat": "{{severity}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "title": "Cache Hit Ratio",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
+      "datasource": { "type": "prometheus", "uid": "arenax-prometheus" },
+      "fieldConfig": { "defaults": { "unit": "percentunit" }, "overrides": [] },
+      "targets": [
+        {
+          "expr": "sum(rate(cache_hits_total[5m])) / (sum(rate(cache_hits_total[5m])) + sum(rate(cache_misses_total[5m])))",
+          "legendFormat": "hit ratio",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "title": "Process Memory (RSS)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 32 },
+      "datasource": { "type": "prometheus", "uid": "arenax-prometheus" },
+      "fieldConfig": { "defaults": { "unit": "bytes" }, "overrides": [] },
+      "targets": [
+        {
+          "expr": "process_resident_memory_bytes{job=\"arenax-server\"}",
+          "legendFormat": "RSS",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "title": "Process CPU",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 32 },
+      "datasource": { "type": "prometheus", "uid": "arenax-prometheus" },
+      "targets": [
+        {
+          "expr": "rate(process_cpu_user_seconds_total{job=\"arenax-server\"}[5m])",
+          "legendFormat": "user cpu",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(process_cpu_system_seconds_total{job=\"arenax-server\"}[5m])",
+          "legendFormat": "system cpu",
+          "refId": "B"
+        }
+      ]
+    }
+  ]
+}

--- a/server/infra/monitoring/grafana/provisioning/dashboards/dashboards.yml
+++ b/server/infra/monitoring/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: arenax-server
+    orgId: 1
+    folder: ArenaX
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    options:
+      path: /etc/grafana/dashboards

--- a/server/infra/monitoring/grafana/provisioning/datasources/prometheus.yml
+++ b/server/infra/monitoring/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    uid: arenax-prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true

--- a/server/infra/monitoring/prometheus.yml
+++ b/server/infra/monitoring/prometheus.yml
@@ -1,0 +1,24 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+rule_files:
+  - /etc/prometheus/alert.rules.yml
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets: ['localhost:9090']
+
+  # arenax-server runs on the host (npm run dev / npm start), not inside
+  # this compose network — same pattern as infra/elk's bind-mounted log
+  # tailing. `host.docker.internal` reaches the host from a container on
+  # Docker Desktop (Mac/Windows). On Linux, either run Docker with
+  # `--add-host=host.docker.internal:host-gateway` (Docker Engine 20.10+)
+  # or replace the target below with the host's actual IP/hostname.
+  - job_name: arenax-server
+    metrics_path: /api/metrics
+    static_configs:
+      - targets: ['host.docker.internal:3001']
+        labels:
+          service: arenax-server

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,5 +1,5 @@
 import cors from 'cors';
-import express, { Express, Request, Response } from 'express';
+import express, { Express, NextFunction, Request, Response } from 'express';
 import helmet from 'helmet';
 import passport from 'passport';
 import Redis from 'ioredis';
@@ -10,6 +10,8 @@ import { localeMiddleware } from './middleware/locale.middleware';
 import { correlationMiddleware } from './middleware/correlation.middleware';
 import { requestLogger } from './middleware/request-logger.middleware';
 import { metricsMiddleware } from './middleware/metrics.middleware';
+import { apiVersionMiddleware } from './middleware/api-version.middleware';
+import { apiVersionRegistry } from './config/api-versions';
 import routes from './routes/index';
 import { getEnv } from './config/env';
 import { getGraphQLExecutor } from './graphql/server';
@@ -157,6 +159,17 @@ export const createApp = (): Express => {
     app.use(localeMiddleware);
     app.use(passport.initialize());
     app.use(metricsMiddleware);
+
+    // Resolves the requested API version from the URL (`/api/v1/...`) or
+    // `Accept` header, attaches it to `res.locals.apiVersion`, and sets
+    // RFC 8594 Deprecation/Sunset headers once a version is deprecated.
+    app.use(apiVersionMiddleware(apiVersionRegistry));
+    app.use((req: Request, res: Response, next: NextFunction) => {
+        const apiVersion = (res.locals as { apiVersion?: { name: string } }).apiVersion;
+        if (apiVersion) res.setHeader('X-API-Version', apiVersion.name);
+        next();
+    });
+
     app.use('/api', routes);
 
     const graphql = getGraphQLExecutor();

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -15,7 +15,7 @@ import { getEnv } from './config/env';
 import { getGraphQLExecutor } from './graphql/server';
 import rateLimit from 'express-rate-limit';
 import { MemoryStore } from 'express-rate-limit';
-import { RedisRateLimitStore } from './middleware/rate-limit-redis.store';
+import { SlidingWindowRateLimitStore } from './middleware/sliding-window-rate-limit.store';
 import { FailoverStore } from './middleware/rate-limit-failover';
 import { createRateLimitHealthCheck, registerRateLimitMetricsProvider, getRateLimitMetrics } from './middleware/rate-limit-monitoring';
 import { initAdaptiveRateLimitRedis } from './middleware/adaptiveRateLimit.middleware';
@@ -100,12 +100,13 @@ export const createApp = (): Express => {
     app.use(xss()); // Prevent XSS attacks
     app.use(hpp()); // Prevent HTTP Parameter Pollution
 
-    // Global API rate limiter with Redis-backed store and in-memory failover
+    // Global API rate limiter with a sliding-window Redis-backed store and
+    // in-memory failover
     const globalRateLimitWindowMs = 15 * 60 * 1000;
     const redis = getRateLimitRedisClient();
     let apiLimiterStore: any;
     if (redis) {
-        const redisStore = new RedisRateLimitStore({
+        const redisStore = new SlidingWindowRateLimitStore({
             redis,
             prefix: 'rl:global:',
             windowMs: globalRateLimitWindowMs,

--- a/server/src/config/api-versions.ts
+++ b/server/src/config/api-versions.ts
@@ -1,0 +1,17 @@
+import { InMemoryApiVersionRegistry } from '../middleware/api-version.middleware';
+
+/**
+ * Single source of truth for which API versions exist and their status.
+ * Consumed by `apiVersionMiddleware` (deprecation/sunset headers) and the
+ * `GET /api/versions` discovery endpoint.
+ */
+export const apiVersionRegistry = new InMemoryApiVersionRegistry();
+
+apiVersionRegistry.register(
+    {
+        name: 'v1',
+        status: 'live',
+        introducedAt: '2026-02-19T00:00:00.000Z',
+    },
+    { default: true },
+);

--- a/server/src/middleware/error.middleware.ts
+++ b/server/src/middleware/error.middleware.ts
@@ -1,9 +1,25 @@
+import { createHash } from 'node:crypto';
 import { Request, Response, NextFunction } from 'express';
 import { BaseError, InternalServerError, isBaseError } from '../errors';
 import { logger } from '../services/logger.service';
 import { captureException } from '../services/telemetry.service';
 import { HttpError } from '../utils/http-error';
 import { getEnv } from '../config/env';
+import { sanitizeData, sanitizeHeaders } from './request-logger.middleware';
+
+/**
+ * Groups repeated occurrences of "the same" error together for log
+ * search/aggregation, independent of the per-request correlation ID
+ * (which only ties together logs from a single request). IDs and
+ * numbers in the message are normalized out first so e.g. "User 123 not
+ * found" and "User 456 not found" produce the same fingerprint.
+ */
+const ID_LIKE_PATTERN = /[0-9a-fA-F-]{6,}|\d+/g;
+
+const buildErrorFingerprint = (route: string, code: string, message: string): string => {
+    const normalizedMessage = message.replace(ID_LIKE_PATTERN, '#');
+    return createHash('sha1').update(`${code}:${route}:${normalizedMessage}`).digest('hex').slice(0, 12);
+};
 
 const normalizeError = (err: unknown): BaseError => {
     if (isBaseError(err)) {
@@ -36,14 +52,24 @@ export const errorHandler = (
     const { isProductionLike } = getEnv();
     const requestId = req.requestId ?? 'unknown';
     const requestLogger = req.log ?? logger;
+    const route = req.route?.path ? `${req.baseUrl}${req.route.path}` : req.path;
+    const rawMessage = err instanceof Error ? err.message : String(err);
 
     requestLogger.error('Unhandled request error', {
         requestId,
+        correlationId: req.correlationId ?? requestId,
         method: req.method,
         path: req.originalUrl,
+        route,
+        query: sanitizeData(req.query || {}),
+        headers: sanitizeHeaders(req.headers || {}),
+        ip: req.ip,
+        userAgent: req.get('user-agent'),
+        user: req.user ? { id: req.user.id, role: req.user.role } : undefined,
         status: normalizedError.statusCode,
         errorCode: normalizedError.code,
-        message: err instanceof Error ? err.message : String(err),
+        errorFingerprint: buildErrorFingerprint(route, normalizedError.code, rawMessage),
+        message: rawMessage,
         stack: err instanceof Error ? err.stack : undefined,
         details: isBaseError(err) ? err.details : undefined
     });

--- a/server/src/middleware/rate-limit.middleware.ts
+++ b/server/src/middleware/rate-limit.middleware.ts
@@ -1,7 +1,7 @@
 import rateLimit, { MemoryStore, Store } from 'express-rate-limit';
 import { Request, Response } from 'express';
 import Redis from 'ioredis';
-import { RedisRateLimitStore } from './rate-limit-redis.store';
+import { SlidingWindowRateLimitStore } from './sliding-window-rate-limit.store';
 import { FailoverStore } from './rate-limit-failover';
 import { logger } from '../services/logger.service';
 
@@ -54,10 +54,13 @@ function getRateLimitRedis(): Redis | null {
 function createRateLimitStore(windowMs: number, prefix: string): Store {
     const redis = getRateLimitRedis();
     if (!redis) {
+        // No Redis configured: fall back to express-rate-limit's in-process
+        // fixed-window MemoryStore. Sliding-window accuracy requires the
+        // shared Redis counters below.
         return new MemoryStore();
     }
 
-    const redisStore = new RedisRateLimitStore({ redis, prefix, windowMs });
+    const redisStore = new SlidingWindowRateLimitStore({ redis, prefix, windowMs });
     const memoryStore = new MemoryStore();
 
     return new FailoverStore(redisStore, memoryStore, {

--- a/server/src/middleware/sliding-window-rate-limit.store.ts
+++ b/server/src/middleware/sliding-window-rate-limit.store.ts
@@ -1,0 +1,145 @@
+import { Redis } from 'ioredis';
+import type { Store, IncrementResponse } from 'express-rate-limit';
+import { logger } from '../services/logger.service';
+
+/**
+ * Redis-backed sliding-window-counter store for express-rate-limit.
+ *
+ * The previous store (`RedisRateLimitStore`) used a fixed-window counter
+ * (INCR + EXPIRE), which lets clients burst up to 2x the limit around a
+ * window boundary (e.g. limit=100/min lets 100 requests at 0:59 and
+ * another 100 at 1:01). This store approximates a true sliding window
+ * without the memory cost of a sliding log (one Redis entry per request):
+ * it keeps a counter for the current fixed window and the previous one,
+ * and weights the previous window's count by how much of it still
+ * overlaps the trailing `windowMs` interval.
+ *
+ * `estimatedCount = currentWindowCount + previousWindowCount * overlap`
+ * where `overlap` is the fraction of the previous window still inside
+ * the sliding lookback (1.0 right at the boundary, decaying to 0.0 as
+ * the current window fills up). This is the same algorithm Cloudflare
+ * and Kong document for their sliding-window limiters — O(1) per
+ * request, two keys per window, and accurate to within the granularity
+ * of the underlying fixed window.
+ *
+ * @example
+ * ```ts
+ * const store = new SlidingWindowRateLimitStore({ redis, windowMs: 60_000 });
+ * const limiter = rateLimit({ store, windowMs: 60_000, limit: 100 });
+ * ```
+ */
+export class SlidingWindowRateLimitStore implements Store {
+  private redis: Redis;
+  private keyPrefix: string;
+  private windowMs: number;
+
+  constructor(options: { redis: Redis; prefix?: string; windowMs: number }) {
+    this.redis = options.redis;
+    this.keyPrefix = options.prefix ?? 'rlsw:';
+    this.windowMs = options.windowMs;
+  }
+
+  private windowKeys(now: number): { currentKey: string; previousKey: string; windowId: number } {
+    const windowId = Math.floor(now / this.windowMs);
+    return {
+      windowId,
+      currentKey: `w:${windowId}`,
+      previousKey: `w:${windowId - 1}`,
+    };
+  }
+
+  /**
+   * Atomically increments the current window's counter and reads the
+   * previous window's counter in a single round trip, so concurrent
+   * requests can't race between the two reads.
+   */
+  private async incrementAndReadPrevious(
+    currentRedisKey: string,
+    previousRedisKey: string,
+    ttlMs: number,
+  ): Promise<{ current: number; previous: number }> {
+    const script = `
+      local current = redis.call('INCR', KEYS[1])
+      if current == 1 then
+        redis.call('PEXPIRE', KEYS[1], ARGV[1])
+      end
+      local previous = tonumber(redis.call('GET', KEYS[2]) or '0')
+      return {current, previous}
+    `;
+    const result = (await this.redis.eval(
+      script,
+      2,
+      currentRedisKey,
+      previousRedisKey,
+      ttlMs,
+    )) as [number, number];
+
+    return { current: result[0], previous: result[1] };
+  }
+
+  async increment(key: string): Promise<IncrementResponse> {
+    const now = Date.now();
+    const { currentKey, previousKey, windowId } = this.windowKeys(now);
+    const currentRedisKey = `${this.keyPrefix}${key}:${currentKey}`;
+    const previousRedisKey = `${this.keyPrefix}${key}:${previousKey}`;
+    // Keep the "current" bucket alive for two windows so it can serve as
+    // the "previous" bucket for the next window without a second write.
+    const ttlMs = this.windowMs * 2;
+
+    try {
+      const { current, previous } = await this.incrementAndReadPrevious(
+        currentRedisKey,
+        previousRedisKey,
+        ttlMs,
+      );
+
+      const elapsedInCurrentWindow = now - windowId * this.windowMs;
+      const overlap = Math.max(0, (this.windowMs - elapsedInCurrentWindow) / this.windowMs);
+      const totalHits = Math.ceil(current + previous * overlap);
+      const resetTimeMs = (windowId + 1) * this.windowMs;
+
+      return { totalHits, resetTime: new Date(resetTimeMs) };
+    } catch (error) {
+      logger.error('Sliding window rate limit store increment failed', { key, error });
+      // On failure, treat as first hit so the request is allowed through.
+      return { totalHits: 1, resetTime: new Date(now + this.windowMs) };
+    }
+  }
+
+  async decrement(key: string): Promise<void> {
+    const now = Date.now();
+    const { currentKey } = this.windowKeys(now);
+    const currentRedisKey = `${this.keyPrefix}${key}:${currentKey}`;
+
+    try {
+      const count = await this.redis.decr(currentRedisKey);
+      if (count <= 0) {
+        await this.redis.del(currentRedisKey);
+      }
+    } catch (error) {
+      logger.error('Sliding window rate limit store decrement failed', { key, error });
+    }
+  }
+
+  async resetKey(key: string): Promise<void> {
+    const now = Date.now();
+    const { currentKey, previousKey } = this.windowKeys(now);
+
+    try {
+      await this.redis.del(`${this.keyPrefix}${key}:${currentKey}`, `${this.keyPrefix}${key}:${previousKey}`);
+    } catch (error) {
+      logger.error('Sliding window rate limit store resetKey failed', { key, error });
+    }
+  }
+
+  async resetAll(): Promise<void> {
+    try {
+      const keys = await this.redis.keys(`${this.keyPrefix}*`);
+      if (keys.length > 0) {
+        await this.redis.del(...keys);
+      }
+    } catch (error) {
+      logger.error('Sliding window rate limit store resetAll failed', { error });
+    }
+  }
+}

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -24,6 +24,7 @@ import { publicRateLimiter } from '../middleware/rate-limit.middleware';
 import { auditMiddleware } from '../middleware/audit.middleware';
 import { maintenanceMiddleware } from '../middleware/maintenance.middleware';
 import { MaintenanceService } from '../services/maintenance.service';
+import { apiVersionRegistry } from '../config/api-versions';
 
 const router: Router = Router();
 
@@ -35,28 +36,49 @@ router.get('/maintenance/status', (req, res) => {
     res.status(200).json(MaintenanceService.getInstance().getStatus());
 });
 
+router.get('/versions', (req, res) => {
+    res.status(200).json({
+        current: apiVersionRegistry.getDefault().name,
+        versions: apiVersionRegistry.list(),
+    });
+});
+
 router.use(maintenanceMiddleware);
 
-router.use('/api/v1/auth', authRoutes);
-router.use('/profiles', profileRoutes);
-router.use('/matches', matchRoutes);
-router.use('/api/v1/admin', adminRoutes);
-router.use('/governance', governanceRoutes);
-router.use('/soroban', sorobanRoutes);
-router.use('/wallets', walletRoutes);
-router.use('/wallet', walletRoutes);
+// This router is mounted at `/api` in app.ts, so a canonical v1 route only
+// needs a `/v1/...` prefix here — mounting `/api/v1/...` under it produced
+// unreachable `/api/api/v1/...` paths (see #657). Routes that previously
+// had that double prefix, or none at all, are given a single `/v1/...`
+// mount here. `mountVersioned` additionally keeps the pre-versioning
+// unversioned path alive as a deprecated alias for clients/tests that
+// haven't migrated yet, so both `/api/v1/<resource>` and `/api/<resource>`
+// keep working during the transition.
+const mountVersioned = (base: string, handler: Router) => {
+    router.use(`/v1${base}`, handler);
+    router.use(base, handler);
+};
+
+mountVersioned('/auth', authRoutes);
+mountVersioned('/profiles', profileRoutes);
+mountVersioned('/matches', matchRoutes);
+mountVersioned('/admin', adminRoutes);
+mountVersioned('/governance', governanceRoutes);
+mountVersioned('/soroban', sorobanRoutes);
+mountVersioned('/wallets', walletRoutes);
+mountVersioned('/wallet', walletRoutes);
+mountVersioned('/analytics', analyticsRoutes);
 router.use('/v1/achievements', achievementRoutes);
 router.use('/v1/tournaments', tournamentRoutes);
-router.use('/api/v1/analytics', analyticsRoutes);
+router.use('/v1/search', searchRoutes);
+router.use('/v1/cache', cacheRoutes);
+router.use('/v1/gateway', apiGatewayRoutes);
+router.use('/v1/queue', queueRoutes);
+router.use('/v1/access-control', accessControlRoutes);
+router.use('/v1/assets', crossGameAssetRoutes);
+router.use('/v1/i18n', i18nRoutes);
+
+// Unversioned infrastructure endpoints — not part of the public API surface.
 router.use('/metrics', metricsRoutes);
 router.use('/dashboard', dashboardRoutes);
-router.use('/v1/search', searchRoutes);
-router.use('/api/v1/cache', cacheRoutes);
-router.use('/api/v1/gateway', apiGatewayRoutes);
-router.use('/api/v1/queue', queueRoutes);
-router.use('/api/v1/access-control', accessControlRoutes);
-router.use('/api/v1/assets', crossGameAssetRoutes);
-router.use('/api/v1/i18n', i18nRoutes);
-
 
 export default router;

--- a/server/test/error-middleware.test.js
+++ b/server/test/error-middleware.test.js
@@ -1,0 +1,112 @@
+const { describe, it, before } = require('node:test');
+const assert = require('node:assert/strict');
+
+process.env.DATABASE_URL = process.env.DATABASE_URL || 'postgresql://user:pass@localhost:5432/arenax_test';
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'test-secret-at-least-32-characters-long-ok';
+
+// Minimal req/res/next doubles — no supertest/express app needed since
+// errorHandler only touches a handful of req/res members.
+function makeReq(overrides = {}) {
+    const logs = [];
+    return {
+        requestId: 'req-1',
+        correlationId: 'corr-1',
+        method: 'GET',
+        originalUrl: '/api/v1/wallets/me?foo=bar',
+        path: '/wallets/me',
+        baseUrl: '',
+        route: { path: '/wallets/me' },
+        query: { foo: 'bar' },
+        headers: { authorization: 'Bearer secret-token', 'user-agent': 'jest-test' },
+        ip: '127.0.0.1',
+        get(name) {
+            return this.headers[name.toLowerCase()];
+        },
+        log: {
+            error(message, meta) {
+                logs.push({ message, meta });
+            },
+        },
+        _logs: logs,
+        ...overrides,
+    };
+}
+
+function makeRes() {
+    return {
+        statusCode: undefined,
+        body: undefined,
+        status(code) {
+            this.statusCode = code;
+            return this;
+        },
+        json(payload) {
+            this.body = payload;
+            return this;
+        },
+    };
+}
+
+describe('errorHandler', () => {
+    let errorHandler;
+
+    before(async () => {
+        const envModule = await import('../dist/config/env.js');
+        envModule.initEnv();
+        ({ errorHandler } = await import('../dist/middleware/error.middleware.js'));
+    });
+
+    it('logs request context, sanitized headers, and no user when unauthenticated', () => {
+        const req = makeReq();
+        const res = makeRes();
+
+        errorHandler(new Error('User 123 not found'), req, res, () => {});
+
+        assert.equal(req._logs.length, 1);
+        const { meta } = req._logs[0];
+        assert.equal(meta.method, 'GET');
+        assert.equal(meta.route, '/wallets/me');
+        assert.deepEqual(meta.query, { foo: 'bar' });
+        assert.equal(meta.headers.authorization, '[REDACTED]');
+        assert.equal(meta.headers['user-agent'], 'jest-test');
+        assert.equal(meta.ip, '127.0.0.1');
+        assert.equal(meta.correlationId, 'corr-1');
+        assert.equal(meta.user, undefined);
+        assert.ok(meta.stack, 'expected the full stack trace to be captured');
+        assert.ok(meta.errorFingerprint);
+    });
+
+    it('includes user id and role when the request is authenticated', () => {
+        const req = makeReq({ user: { id: 'user-42', role: 'ADMIN', email: 'a@b.com', username: 'a' } });
+        const res = makeRes();
+
+        errorHandler(new Error('boom'), req, res, () => {});
+
+        const { meta } = req._logs[0];
+        assert.deepEqual(meta.user, { id: 'user-42', role: 'ADMIN' });
+    });
+
+    it('produces the same fingerprint for the same error shape with different ids', () => {
+        const resA = makeRes();
+        const reqA = makeReq();
+        errorHandler(new Error('User 123 not found'), reqA, resA, () => {});
+
+        const resB = makeRes();
+        const reqB = makeReq();
+        errorHandler(new Error('User 987654 not found'), reqB, resB, () => {});
+
+        assert.equal(reqA._logs[0].meta.errorFingerprint, reqB._logs[0].meta.errorFingerprint);
+    });
+
+    it('produces a different fingerprint for a different route', () => {
+        const resA = makeRes();
+        const reqA = makeReq();
+        errorHandler(new Error('User 123 not found'), reqA, resA, () => {});
+
+        const resB = makeRes();
+        const reqB = makeReq({ path: '/matches/me', route: { path: '/matches/me' } });
+        errorHandler(new Error('User 123 not found'), reqB, resB, () => {});
+
+        assert.notEqual(reqA._logs[0].meta.errorFingerprint, reqB._logs[0].meta.errorFingerprint);
+    });
+});

--- a/server/test/rate-limit-redis.test.js
+++ b/server/test/rate-limit-redis.test.js
@@ -69,6 +69,15 @@ class MockRedis {
   async exec() { return []; }
   on() { return this; }
   async connect() { return this; }
+
+  // Mirrors the increment-and-read-previous Lua script used by
+  // SlidingWindowRateLimitStore: INCR key[0], PEXPIRE on first write, GET key[1].
+  async eval(_script, _numkeys, currentKey, previousKey) {
+    const current = (this.store.get(currentKey) || 0) + 1;
+    this.store.set(currentKey, current);
+    const previous = Number(this.store.get(previousKey) || 0);
+    return [current, previous];
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -118,6 +127,96 @@ describe('RedisRateLimitStore', () => {
     const redis = new MockRedis();
     redis.incr = () => { throw new Error('ECONNREFUSED'); };
     const store = new RedisRateLimitStore({ redis, windowMs: 60000 });
+
+    const result = await store.increment('k');
+    assert.equal(result.totalHits, 1);
+    assert.ok(result.resetTime instanceof Date);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: SlidingWindowRateLimitStore
+// ---------------------------------------------------------------------------
+
+describe('SlidingWindowRateLimitStore', () => {
+  it('increments counter and returns totalHits + resetTime', async () => {
+    const { SlidingWindowRateLimitStore } = await import('../dist/middleware/sliding-window-rate-limit.store.js');
+    const redis = new MockRedis();
+    const store = new SlidingWindowRateLimitStore({ redis, windowMs: 60000 });
+
+    const result1 = await store.increment('user:123');
+    assert.equal(result1.totalHits, 1);
+    assert.ok(result1.resetTime instanceof Date);
+    assert.ok(result1.resetTime.getTime() > Date.now());
+
+    const result2 = await store.increment('user:123');
+    assert.equal(result2.totalHits, 2);
+  });
+
+  it('smooths bursts across a fixed-window boundary', async () => {
+    const { SlidingWindowRateLimitStore } = await import('../dist/middleware/sliding-window-rate-limit.store.js');
+    const redis = new MockRedis();
+    const windowMs = 60000;
+    const store = new SlidingWindowRateLimitStore({ redis, windowMs });
+
+    const realNow = Date.now;
+    try {
+      // Fill the first window with 100 hits.
+      Date.now = () => 0;
+      for (let i = 0; i < 100; i++) {
+        await store.increment('burst');
+      }
+
+      // A fixed-window counter would reset to 1 here, allowing another
+      // full burst. The sliding window should still see ~100 hits.
+      Date.now = () => windowMs + 1;
+      const rightAfterBoundary = await store.increment('burst');
+      assert.ok(
+        rightAfterBoundary.totalHits > 90,
+        `expected sliding window to carry over most of the previous window's hits, got ${rightAfterBoundary.totalHits}`,
+      );
+
+      // Well past the boundary, the previous window's weight should have
+      // decayed to (close to) nothing.
+      Date.now = () => windowMs * 2 + 5000;
+      const farFromBoundary = await store.increment('burst');
+      assert.ok(
+        farFromBoundary.totalHits < 10,
+        `expected the previous window's influence to have decayed, got ${farFromBoundary.totalHits}`,
+      );
+    } finally {
+      Date.now = realNow;
+    }
+  });
+
+  it('decrements counter', async () => {
+    const { SlidingWindowRateLimitStore } = await import('../dist/middleware/sliding-window-rate-limit.store.js');
+    const redis = new MockRedis();
+    const store = new SlidingWindowRateLimitStore({ redis, windowMs: 60000 });
+
+    await store.increment('k');
+    await store.increment('k');
+    await store.decrement('k');
+    const result = await store.increment('k');
+    assert.equal(result.totalHits, 2);
+  });
+
+  it('resets a single key', async () => {
+    const { SlidingWindowRateLimitStore } = await import('../dist/middleware/sliding-window-rate-limit.store.js');
+    const redis = new MockRedis();
+    const store = new SlidingWindowRateLimitStore({ redis, windowMs: 60000 });
+
+    await store.increment('k');
+    await store.resetKey('k');
+    const result = await store.increment('k');
+    assert.equal(result.totalHits, 1);
+  });
+
+  it('handles Redis errors gracefully', async () => {
+    const { SlidingWindowRateLimitStore } = await import('../dist/middleware/sliding-window-rate-limit.store.js');
+    const redis = new MockRedis();
+    redis.eval = () => { throw new Error('ECONNREFUSED'); };
+    const store = new SlidingWindowRateLimitStore({ redis, windowMs: 60000 });
 
     const result = await store.increment('k');
     assert.equal(result.totalHits, 1);


### PR DESCRIPTION
## Summary

Combined PR for four assigned server issues (previously opened as
separate PRs #833, #834, #835, #836 — closing those in favor of this
one, per request).

### #657 — API versioning was broken
Most routes were mounted as `router.use('/api/v1/x', handler)` on a
router that `app.ts` already mounts at `/api`, producing unreachable
`/api/api/v1/x` paths (confirmed against the Postman collections, which
expect `/api/v1/...`). Normalized every route to a single `/v1/<resource>`
mount, kept the pre-versioning unversioned path alive as a deprecated
alias for existing clients/tests, wired the existing (but previously
unused) `apiVersionMiddleware` into `app.ts` via a new
`src/config/api-versions.ts` registry, and added `GET /api/versions` for
discovery.

### #658 — Rate limiting used a fixed window
The tiered and global rate limiters used a Redis fixed-window counter
(`INCR`+`EXPIRE`), which lets a client burst up to 2x the limit around a
window boundary. Added `SlidingWindowRateLimitStore`, a Redis-backed
sliding-window-counter store (atomic Lua script, O(1) per request) and
swapped it in, keeping the existing in-memory failover for when Redis is
down.

### #661 — No Prometheus/Grafana deployment
`arenax-server` already exposed Prometheus metrics at `/api/metrics` via
`prom-client`, but nothing scraped/stored/visualized/alerted on them.
Added `server/infra/monitoring/` (matching the existing `infra/elk` /
`infra/redis-cluster` standalone-compose pattern): Prometheus + Grafana,
a scrape config, 5 alert rules, and a provisioned "ArenaX Server
Overview" dashboard.

### #826 — Error logs missing context
The global error handler didn't log which user hit an error, the
request's query/headers/IP/user-agent, or any way to group repeated
occurrences of the same underlying error. Enriched `errorHandler` with
sanitized request context (reusing the existing redaction helpers from
`request-logger.middleware.ts`), `user: { id, role }` when authenticated,
and a stable `errorFingerprint` for log-aggregation grouping.

## Test plan

- [x] `npx tsc --noEmit` — no new type errors introduced by any of the
  four changes (pre-existing errors in `compression.middleware.ts` are
  unrelated, present on `main`, and already failing CI there).
- [x] Unit tests for the sliding-window store (5 cases, including a
  boundary-smoothing assertion) and the enriched error handler (4 cases)
  — compiled the relevant files in isolation and ran the new tests
  against the compiled output, since this repo's `npm run build` is
  currently broken on `main` from an unrelated recent PR (#824), which
  also blocks running `node --test` against `dist/` directly.
- [x] Manually traced Express route resolution for the versioning fix to
  confirm `/api/v1/auth/...` and `/api/auth/...` both resolve and the
  previous `/api/api/v1/...` dead paths are gone.
- [x] `docker compose -f server/infra/monitoring/docker-compose.yml
  config` validates cleanly; all new YAML/JSON validated for syntax.
- [ ] Full `npm test` / `docker compose up` end-to-end via CI once the
  unrelated build breakage on `main` is fixed (no reachable Docker
  daemon or working `npm run build` in the environment this was built
  in).

Closes #657
Closes #658
Closes #661
Closes #826