### PR TITLE
feat(contracts): add price oracle integration (#961)

### DIFF
--- a/contracts/arenax-events/src/virtual_economy.rs
+++ b/contracts/arenax-events/src/virtual_economy.rs
@@ -266,7 +266,12 @@ pub fn emit_dutch_auction_created(
     .publish(env);
 }
 
-pub fn emit_dutch_auction_purchased(env: &Env, listing_id: &BytesN<32>, buyer: &Address, price: i128) {
+pub fn emit_dutch_auction_purchased(
+    env: &Env,
+    listing_id: &BytesN<32>,
+    buyer: &Address,
+    price: i128,
+) {
     DutchAuctionPurchased {
         listing_id: listing_id.clone(),
         buyer: buyer.clone(),

--- a/contracts/arenax-events/src/virtual_economy.rs
+++ b/contracts/arenax-events/src/virtual_economy.rs
@@ -345,3 +345,100 @@ pub fn emit_bonding_curve_drop_updated(env: &Env, drop_id: &BytesN<32>, active: 
     }
     .publish(env);
 }
+
+// ─── Price Oracle ─────────────────────────────────────────────────────────────
+
+#[contractevent(topics = ["ArenaXVirtualEconomy_v1", "ORACLE_CONFIGURED"])]
+pub struct OracleConfigured {
+    pub primary_oracle: Address,
+    pub update_interval: u64,
+    pub max_variance_bps: u32,
+}
+
+#[contractevent(topics = ["ArenaXVirtualEconomy_v1", "ORACLE_FALLBACK_SET"])]
+pub struct OracleFallbackSet {
+    pub fallback_oracle: Address,
+}
+
+#[contractevent(topics = ["ArenaXVirtualEconomy_v1", "ORACLE_PRICE_UPDATED"])]
+pub struct OraclePriceUpdated {
+    pub asset_pair: BytesN<32>,
+    pub price: i128,
+    pub timestamp: u64,
+    pub used_fallback: bool,
+}
+
+#[contractevent(topics = ["ArenaXVirtualEconomy_v1", "ORACLE_PRICE_REJECTED"])]
+pub struct OraclePriceRejected {
+    pub asset_pair: BytesN<32>,
+    pub submitted_price: i128,
+    pub last_accepted_price: i128,
+    pub variance_bps: u32,
+}
+
+#[contractevent(topics = ["ArenaXVirtualEconomy_v1", "ORACLE_PAIR_REGISTERED"])]
+pub struct OraclePairRegistered {
+    pub asset_pair: BytesN<32>,
+    pub update_interval: u64,
+}
+
+pub fn emit_oracle_configured(
+    env: &Env,
+    primary_oracle: &Address,
+    update_interval: u64,
+    max_variance_bps: u32,
+) {
+    OracleConfigured {
+        primary_oracle: primary_oracle.clone(),
+        update_interval,
+        max_variance_bps,
+    }
+    .publish(env);
+}
+
+pub fn emit_oracle_fallback_set(env: &Env, fallback_oracle: &Address) {
+    OracleFallbackSet {
+        fallback_oracle: fallback_oracle.clone(),
+    }
+    .publish(env);
+}
+
+pub fn emit_oracle_price_updated(
+    env: &Env,
+    asset_pair: &BytesN<32>,
+    price: i128,
+    timestamp: u64,
+    used_fallback: bool,
+) {
+    OraclePriceUpdated {
+        asset_pair: asset_pair.clone(),
+        price,
+        timestamp,
+        used_fallback,
+    }
+    .publish(env);
+}
+
+pub fn emit_oracle_price_rejected(
+    env: &Env,
+    asset_pair: &BytesN<32>,
+    submitted_price: i128,
+    last_accepted_price: i128,
+    variance_bps: u32,
+) {
+    OraclePriceRejected {
+        asset_pair: asset_pair.clone(),
+        submitted_price,
+        last_accepted_price,
+        variance_bps,
+    }
+    .publish(env);
+}
+
+pub fn emit_oracle_pair_registered(env: &Env, asset_pair: &BytesN<32>, update_interval: u64) {
+    OraclePairRegistered {
+        asset_pair: asset_pair.clone(),
+        update_interval,
+    }
+    .publish(env);
+}

--- a/contracts/virtual-economy/src/error.rs
+++ b/contracts/virtual-economy/src/error.rs
@@ -47,4 +47,21 @@ pub enum VirtualEconomyError {
     DropInactive = 71,
     DropSupplyExceeded = 72,
     InvalidCurveParams = 73,
+
+    // Price oracle errors
+    /// An oracle address has not been registered on the contract.
+    OracleNotConfigured = 80,
+    /// The oracle configuration values failed validation.
+    InvalidOracleConfig = 81,
+    /// Both the primary and fallback oracles returned stale data.
+    OraclePriceStale = 82,
+    /// The incoming price deviates from the last accepted price by more than
+    /// `max_variance_bps` and no valid fallback is available.
+    OraclePriceVarianceTooHigh = 83,
+    /// An update was attempted before `update_interval` seconds have elapsed.
+    OracleUpdateTooFrequent = 84,
+    /// The asset-pair identifier provided to the oracle is invalid.
+    InvalidAssetPair = 85,
+    /// The price submitted to the oracle is not positive.
+    OracleInvalidPrice = 86,
 }

--- a/contracts/virtual-economy/src/lib.rs
+++ b/contracts/virtual-economy/src/lib.rs
@@ -6,12 +6,14 @@ mod error;
 mod governance;
 mod marketplace;
 mod nft;
+mod oracle;
 mod rewards;
 mod storage;
 
 use arenax_events::virtual_economy as events;
 use marketplace::MarketplaceManager;
-use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, Map, String, Vec};
+use oracle::OracleManager;
+use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, String, Vec};
 
 pub use error::VirtualEconomyError;
 pub use storage::*;
@@ -1145,6 +1147,429 @@ impl VirtualEconomyContract {
     }
 
     // -------------------------------------------------------------------------
+    // Price Oracle Integration
+    // -------------------------------------------------------------------------
+
+    /// Configure the primary oracle address and global oracle settings.
+    ///
+    /// Only the contract admin may call this. Calling again overwrites the
+    /// previous configuration.
+    pub fn configure_oracle(
+        env: Env,
+        primary_oracle: Address,
+        config: OracleConfig,
+    ) -> Result<(), VirtualEconomyError> {
+        Self::require_admin(&env)?;
+        OracleManager::validate_config(&config)?;
+
+        env.storage()
+            .instance()
+            .set(&DataKey::PrimaryOracle, &primary_oracle);
+        env.storage()
+            .instance()
+            .set(&DataKey::OracleConfig, &config);
+
+        // Initialise analytics if not yet present.
+        if !env.storage().instance().has(&DataKey::OracleAnalytics) {
+            let analytics = OracleAnalytics {
+                primary_updates: 0,
+                fallback_updates: 0,
+                variance_rejections: 0,
+                stale_rejections: 0,
+                registered_pairs: 0,
+            };
+            env.storage()
+                .instance()
+                .set(&DataKey::OracleAnalytics, &analytics);
+        }
+
+        events::emit_oracle_configured(
+            &env,
+            &primary_oracle,
+            config.update_interval,
+            config.max_variance_bps,
+        );
+        Ok(())
+    }
+
+    /// Set (or replace) the fallback oracle address.
+    ///
+    /// The fallback oracle is consulted when the primary feed is stale or
+    /// outside the variance window. Only the admin may call this.
+    pub fn set_fallback_oracle(
+        env: Env,
+        fallback_oracle: Address,
+    ) -> Result<(), VirtualEconomyError> {
+        Self::require_admin(&env)?;
+
+        env.storage()
+            .instance()
+            .set(&DataKey::FallbackOracle, &fallback_oracle);
+
+        events::emit_oracle_fallback_set(&env, &fallback_oracle);
+        Ok(())
+    }
+
+    /// Register a new asset pair and optionally override its update interval.
+    ///
+    /// `asset_pair` — a 32-byte identifier for the trading pair (e.g. the
+    /// first 32 bytes of `sha256("XLM/USD")`).
+    ///
+    /// `update_interval_override` — when `Some`, overrides the global
+    /// `OracleConfig.update_interval` for this pair only.
+    pub fn register_oracle_pair(
+        env: Env,
+        asset_pair: BytesN<32>,
+        update_interval_override: Option<u64>,
+    ) -> Result<(), VirtualEconomyError> {
+        Self::require_admin(&env)?;
+
+        let global_config = Self::get_oracle_config(&env)?;
+
+        let pair_interval = update_interval_override.unwrap_or(global_config.update_interval);
+        if pair_interval == 0 {
+            return Err(VirtualEconomyError::InvalidOracleConfig);
+        }
+
+        // Build and store the per-pair config (inherits global settings,
+        // overrides only the interval).
+        let pair_config = OracleConfig {
+            update_interval: pair_interval,
+            max_variance_bps: global_config.max_variance_bps,
+            history_size: global_config.history_size,
+            stale_multiplier: global_config.stale_multiplier,
+        };
+        env.storage()
+            .persistent()
+            .set(&DataKey::OraclePairConfig(asset_pair.clone()), &pair_config);
+
+        // Initialise an empty history for this pair if none exists.
+        if !env
+            .storage()
+            .persistent()
+            .has(&DataKey::OraclePriceHistory(asset_pair.clone()))
+        {
+            let history = PriceHistory {
+                entries: Vec::new(&env),
+                last_price: 0,
+                last_updated: 0,
+                update_count: 0,
+            };
+            env.storage()
+                .persistent()
+                .set(&DataKey::OraclePriceHistory(asset_pair.clone()), &history);
+
+            // Increment registered-pair counter.
+            let mut analytics = Self::get_oracle_analytics(env.clone());
+            analytics.registered_pairs += 1;
+            env.storage()
+                .instance()
+                .set(&DataKey::OracleAnalytics, &analytics);
+        }
+
+        events::emit_oracle_pair_registered(&env, &asset_pair, pair_interval);
+        Ok(())
+    }
+
+    /// Push a new price for an asset pair from the primary oracle.
+    ///
+    /// The caller must be the registered primary oracle address.
+    ///
+    /// The contract:
+    /// 1. Checks the update frequency — rejects if too soon.
+    /// 2. Validates the price is positive.
+    /// 3. Checks variance against the last accepted price.
+    /// 4. Appends the accepted price to the history ring-buffer.
+    /// 5. Emits an event.
+    pub fn submit_primary_price(
+        env: Env,
+        asset_pair: BytesN<32>,
+        price: i128,
+    ) -> Result<(), VirtualEconomyError> {
+        let primary: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::PrimaryOracle)
+            .ok_or(VirtualEconomyError::OracleNotConfigured)?;
+        primary.require_auth();
+
+        if price <= 0 {
+            return Err(VirtualEconomyError::OracleInvalidPrice);
+        }
+
+        let config = Self::get_pair_config(&env, &asset_pair)?;
+        let now = env.ledger().timestamp();
+
+        let mut history: PriceHistory = env
+            .storage()
+            .persistent()
+            .get(&DataKey::OraclePriceHistory(asset_pair.clone()))
+            .ok_or(VirtualEconomyError::InvalidAssetPair)?;
+
+        // Frequency check.
+        if history.last_updated > 0
+            && !OracleManager::is_update_due(now, history.last_updated, config.update_interval)
+        {
+            return Err(VirtualEconomyError::OracleUpdateTooFrequent);
+        }
+
+        // Variance check against last accepted price.
+        if !OracleManager::is_within_variance(price, history.last_price, config.max_variance_bps) {
+            let variance =
+                OracleManager::price_variance_bps(price, history.last_price);
+
+            // Record the raw primary price even though we reject it.
+            env.storage().persistent().set(
+                &DataKey::OracleLastPrimaryPrice(asset_pair.clone()),
+                &(price, now),
+            );
+
+            let mut analytics = Self::get_oracle_analytics(env.clone());
+            analytics.variance_rejections += 1;
+            env.storage()
+                .instance()
+                .set(&DataKey::OracleAnalytics, &analytics);
+
+            events::emit_oracle_price_rejected(
+                &env,
+                &asset_pair,
+                price,
+                history.last_price,
+                variance,
+            );
+            return Err(VirtualEconomyError::OraclePriceVarianceTooHigh);
+        }
+
+        // Accept the price.
+        env.storage().persistent().set(
+            &DataKey::OracleLastPrimaryPrice(asset_pair.clone()),
+            &(price, now),
+        );
+        OracleManager::append_history(
+            &mut history,
+            price,
+            now,
+            primary.clone(),
+            false,
+            config.history_size,
+        );
+        env.storage()
+            .persistent()
+            .set(&DataKey::OraclePriceHistory(asset_pair.clone()), &history);
+
+        let mut analytics = Self::get_oracle_analytics(env.clone());
+        analytics.primary_updates += 1;
+        env.storage()
+            .instance()
+            .set(&DataKey::OracleAnalytics, &analytics);
+
+        events::emit_oracle_price_updated(&env, &asset_pair, price, now, false);
+        Ok(())
+    }
+
+    /// Push a new price for an asset pair from the fallback oracle.
+    ///
+    /// The caller must be the registered fallback oracle address. The fallback
+    /// price is stored separately and used automatically by
+    /// [`Self::resolve_oracle_price`] when the primary is stale or diverges.
+    pub fn submit_fallback_price(
+        env: Env,
+        asset_pair: BytesN<32>,
+        price: i128,
+    ) -> Result<(), VirtualEconomyError> {
+        let fallback: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::FallbackOracle)
+            .ok_or(VirtualEconomyError::OracleNotConfigured)?;
+        fallback.require_auth();
+
+        if price <= 0 {
+            return Err(VirtualEconomyError::OracleInvalidPrice);
+        }
+
+        // Pair must be registered.
+        if !env
+            .storage()
+            .persistent()
+            .has(&DataKey::OraclePriceHistory(asset_pair.clone()))
+        {
+            return Err(VirtualEconomyError::InvalidAssetPair);
+        }
+
+        let now = env.ledger().timestamp();
+        env.storage().persistent().set(
+            &DataKey::OracleLastFallbackPrice(asset_pair.clone()),
+            &(price, now),
+        );
+
+        events::emit_oracle_price_updated(&env, &asset_pair, price, now, true);
+        Ok(())
+    }
+
+    /// Resolve the best available price for an asset pair.
+    ///
+    /// 1. Loads the last primary and fallback raw prices.
+    /// 2. Delegates to [`OracleManager::resolve_price`] which applies
+    ///    freshness and variance checks.
+    /// 3. If the fallback price is selected it is written into the history
+    ///    ring-buffer and the analytics counter incremented.
+    /// 4. Returns the resolved price.
+    pub fn resolve_oracle_price(
+        env: Env,
+        asset_pair: BytesN<32>,
+    ) -> Result<i128, VirtualEconomyError> {
+        let config = Self::get_pair_config(&env, &asset_pair)?;
+        let now = env.ledger().timestamp();
+
+        let mut history: PriceHistory = env
+            .storage()
+            .persistent()
+            .get(&DataKey::OraclePriceHistory(asset_pair.clone()))
+            .ok_or(VirtualEconomyError::InvalidAssetPair)?;
+
+        let (primary_price, primary_ts): (i128, u64) = env
+            .storage()
+            .persistent()
+            .get(&DataKey::OracleLastPrimaryPrice(asset_pair.clone()))
+            .unwrap_or((0, 0));
+
+        let fallback_data: Option<(i128, u64)> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::OracleLastFallbackPrice(asset_pair.clone()));
+
+        let (fallback_price, fallback_ts) = match fallback_data {
+            Some((p, t)) => (Some(p), Some(t)),
+            None => (None, None),
+        };
+
+        match OracleManager::resolve_price(
+            primary_price,
+            primary_ts,
+            fallback_price,
+            fallback_ts,
+            history.last_price,
+            &config,
+            now,
+        ) {
+            Ok((price, used_fallback)) => {
+                if used_fallback {
+                    // Commit the fallback price to history.
+                    let fallback: Address = env
+                        .storage()
+                        .instance()
+                        .get(&DataKey::FallbackOracle)
+                        .ok_or(VirtualEconomyError::OracleNotConfigured)?;
+                    OracleManager::append_history(
+                        &mut history,
+                        price,
+                        now,
+                        fallback,
+                        true,
+                        config.history_size,
+                    );
+                    env.storage()
+                        .persistent()
+                        .set(&DataKey::OraclePriceHistory(asset_pair.clone()), &history);
+
+                    let mut analytics = Self::get_oracle_analytics(env.clone());
+                    analytics.fallback_updates += 1;
+                    env.storage()
+                        .instance()
+                        .set(&DataKey::OracleAnalytics, &analytics);
+                }
+                Ok(price)
+            }
+            Err(e) => {
+                let mut analytics = Self::get_oracle_analytics(env.clone());
+                analytics.stale_rejections += 1;
+                env.storage()
+                    .instance()
+                    .set(&DataKey::OracleAnalytics, &analytics);
+                Err(e)
+            }
+        }
+    }
+
+    /// Return the full price history for an asset pair.
+    pub fn get_price_history(
+        env: Env,
+        asset_pair: BytesN<32>,
+    ) -> Result<PriceHistory, VirtualEconomyError> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::OraclePriceHistory(asset_pair))
+            .ok_or(VirtualEconomyError::InvalidAssetPair)
+    }
+
+    /// Return the time-weighted average price (TWAP) for an asset pair.
+    pub fn get_twap(env: Env, asset_pair: BytesN<32>) -> Result<i128, VirtualEconomyError> {
+        let config = Self::get_pair_config(&env, &asset_pair)?;
+        let history: PriceHistory = env
+            .storage()
+            .persistent()
+            .get(&DataKey::OraclePriceHistory(asset_pair))
+            .ok_or(VirtualEconomyError::InvalidAssetPair)?;
+        Ok(OracleManager::calculate_twap(&history, config.update_interval))
+    }
+
+    /// Return the `(min, max)` price range seen in the stored history for a
+    /// given asset pair.
+    pub fn get_price_range(
+        env: Env,
+        asset_pair: BytesN<32>,
+    ) -> Result<(i128, i128), VirtualEconomyError> {
+        let history: PriceHistory = env
+            .storage()
+            .persistent()
+            .get(&DataKey::OraclePriceHistory(asset_pair))
+            .ok_or(VirtualEconomyError::InvalidAssetPair)?;
+        Ok(OracleManager::price_range(&history))
+    }
+
+    /// Return aggregated oracle analytics (primary/fallback update counts,
+    /// rejection counts, registered pair count).
+    pub fn get_oracle_analytics(env: Env) -> OracleAnalytics {
+        env.storage()
+            .instance()
+            .get(&DataKey::OracleAnalytics)
+            .unwrap_or(OracleAnalytics {
+                primary_updates: 0,
+                fallback_updates: 0,
+                variance_rejections: 0,
+                stale_rejections: 0,
+                registered_pairs: 0,
+            })
+    }
+
+    /// Update the per-pair oracle configuration (admin only).
+    ///
+    /// Allows changing the update frequency and variance threshold for a
+    /// single asset pair without touching global settings.
+    pub fn update_pair_oracle_config(
+        env: Env,
+        asset_pair: BytesN<32>,
+        new_config: OracleConfig,
+    ) -> Result<(), VirtualEconomyError> {
+        Self::require_admin(&env)?;
+        OracleManager::validate_config(&new_config)?;
+
+        if !env
+            .storage()
+            .persistent()
+            .has(&DataKey::OraclePriceHistory(asset_pair.clone()))
+        {
+            return Err(VirtualEconomyError::InvalidAssetPair);
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::OraclePairConfig(asset_pair), &new_config);
+        Ok(())
+    }
+
+    // -------------------------------------------------------------------------
     // Internal Helper Functions
     // -------------------------------------------------------------------------
 
@@ -1321,5 +1746,29 @@ impl VirtualEconomyContract {
             .ok_or(VirtualEconomyError::TokenNotFound)?;
 
         Ok(metadata.creator)
+    }
+
+    // -------------------------------------------------------------------------
+    // Private Oracle Helpers
+    // -------------------------------------------------------------------------
+
+    fn get_oracle_config(env: &Env) -> Result<OracleConfig, VirtualEconomyError> {
+        env.storage()
+            .instance()
+            .get(&DataKey::OracleConfig)
+            .ok_or(VirtualEconomyError::OracleNotConfigured)
+    }
+
+    /// Return the per-pair config if one exists, otherwise fall back to the
+    /// global config.
+    fn get_pair_config(env: &Env, asset_pair: &BytesN<32>) -> Result<OracleConfig, VirtualEconomyError> {
+        if let Some(pair_cfg) = env
+            .storage()
+            .persistent()
+            .get::<_, OracleConfig>(&DataKey::OraclePairConfig(asset_pair.clone()))
+        {
+            return Ok(pair_cfg);
+        }
+        Self::get_oracle_config(env)
     }
 }

--- a/contracts/virtual-economy/src/lib.rs
+++ b/contracts/virtual-economy/src/lib.rs
@@ -503,7 +503,11 @@ impl VirtualEconomyContract {
         let mut creator = None;
 
         if let MarketplaceAsset::NFT(token_id) = &order.asset {
-            if let Some(metadata) = env.storage().persistent().get::<_, NFTMetadata>(&DataKey::NFTMetadata(token_id.clone())) {
+            if let Some(metadata) = env
+                .storage()
+                .persistent()
+                .get::<_, NFTMetadata>(&DataKey::NFTMetadata(token_id.clone()))
+            {
                 creator = Some(metadata.creator.clone());
 
                 // Only pay royalty if seller != creator (not a primary sale)
@@ -685,7 +689,12 @@ impl VirtualEconomyContract {
             return Err(VirtualEconomyError::NotOwner);
         }
 
-        MarketplaceManager::validate_auction_params(start_price, floor_price, start_time, end_time)?;
+        MarketplaceManager::validate_auction_params(
+            start_price,
+            floor_price,
+            start_time,
+            end_time,
+        )?;
 
         let counter: u64 = env
             .storage()
@@ -746,7 +755,10 @@ impl VirtualEconomyContract {
     }
 
     /// Compute the current price of an active auction given the ledger time.
-    pub fn get_auction_price(env: Env, listing_id: BytesN<32>) -> Result<i128, VirtualEconomyError> {
+    pub fn get_auction_price(
+        env: Env,
+        listing_id: BytesN<32>,
+    ) -> Result<i128, VirtualEconomyError> {
         let listing = Self::get_dutch_auction(env.clone(), listing_id)?;
         Ok(MarketplaceManager::dutch_auction_price(&env, &listing))
     }
@@ -1315,8 +1327,7 @@ impl VirtualEconomyContract {
 
         // Variance check against last accepted price.
         if !OracleManager::is_within_variance(price, history.last_price, config.max_variance_bps) {
-            let variance =
-                OracleManager::price_variance_bps(price, history.last_price);
+            let variance = OracleManager::price_variance_bps(price, history.last_price);
 
             // Record the raw primary price even though we reject it.
             env.storage().persistent().set(
@@ -1511,7 +1522,10 @@ impl VirtualEconomyContract {
             .persistent()
             .get(&DataKey::OraclePriceHistory(asset_pair))
             .ok_or(VirtualEconomyError::InvalidAssetPair)?;
-        Ok(OracleManager::calculate_twap(&history, config.update_interval))
+        Ok(OracleManager::calculate_twap(
+            &history,
+            config.update_interval,
+        ))
     }
 
     /// Return the `(min, max)` price range seen in the stored history for a
@@ -1654,7 +1668,10 @@ impl VirtualEconomyContract {
         Ok(())
     }
 
-    pub fn get_nft_license(env: Env, token_id: BytesN<32>) -> Result<LicenseConfig, VirtualEconomyError> {
+    pub fn get_nft_license(
+        env: Env,
+        token_id: BytesN<32>,
+    ) -> Result<LicenseConfig, VirtualEconomyError> {
         env.storage()
             .persistent()
             .get(&DataKey::NFTLicense(token_id))
@@ -1761,7 +1778,10 @@ impl VirtualEconomyContract {
 
     /// Return the per-pair config if one exists, otherwise fall back to the
     /// global config.
-    fn get_pair_config(env: &Env, asset_pair: &BytesN<32>) -> Result<OracleConfig, VirtualEconomyError> {
+    fn get_pair_config(
+        env: &Env,
+        asset_pair: &BytesN<32>,
+    ) -> Result<OracleConfig, VirtualEconomyError> {
         if let Some(pair_cfg) = env
             .storage()
             .persistent()

--- a/contracts/virtual-economy/src/oracle.rs
+++ b/contracts/virtual-economy/src/oracle.rs
@@ -1,0 +1,253 @@
+// Price oracle integration for the ArenaX virtual economy.
+//
+// Architecture:
+//   - A **primary** oracle (Chainlink-style on-chain price feed) is queried
+//     first on every price update.
+//   - A **fallback** oracle is used when the primary is stale or reports a
+//     price outside the acceptable variance window.
+//   - Every accepted price is appended to an on-chain ring-buffer of
+//     `MAX_HISTORY` entries for historical queries.
+//   - The minimum seconds that must pass before a new push is accepted is
+//     configurable per asset pair (update frequency).
+//
+// All pure computation lives here; storage mutations happen through the keys
+// exported from `storage.rs`.
+
+use crate::error::VirtualEconomyError;
+use crate::storage::{OracleConfig, OraclePriceEntry, PriceHistory};
+use soroban_sdk::Address;
+
+/// Maximum variance (in basis points) allowed between two oracle reads before
+/// the fallback is preferred.  10 000 bp = 100 %.
+pub const MAX_VARIANCE_BPS: u32 = 10_000;
+
+/// Hard cap on stored history entries (ring-buffer size).
+pub const MAX_HISTORY: u32 = 100;
+
+pub struct OracleManager;
+
+impl OracleManager {
+    // -------------------------------------------------------------------------
+    // Configuration helpers
+    // -------------------------------------------------------------------------
+
+    /// Return `true` when the given update interval has elapsed since
+    /// `last_updated`.
+    pub fn is_update_due(now: u64, last_updated: u64, update_interval: u64) -> bool {
+        now >= last_updated.saturating_add(update_interval)
+    }
+
+    /// Validate an [`OracleConfig`] before it is persisted.
+    ///
+    /// Rules:
+    /// - `update_interval` must be ≥ 1 second (prevents spam).
+    /// - `max_variance_bps` must be in `(0, MAX_VARIANCE_BPS]`.
+    /// - `history_size` must be in `[1, MAX_HISTORY]`.
+    pub fn validate_config(config: &OracleConfig) -> Result<(), VirtualEconomyError> {
+        if config.update_interval == 0 {
+            return Err(VirtualEconomyError::InvalidOracleConfig);
+        }
+        if config.max_variance_bps == 0 || config.max_variance_bps > MAX_VARIANCE_BPS {
+            return Err(VirtualEconomyError::InvalidOracleConfig);
+        }
+        if config.history_size == 0 || config.history_size > MAX_HISTORY {
+            return Err(VirtualEconomyError::InvalidOracleConfig);
+        }
+        Ok(())
+    }
+
+    // -------------------------------------------------------------------------
+    // Variance / staleness checks
+    // -------------------------------------------------------------------------
+
+    /// Compute the absolute variance between `new_price` and `reference` in
+    /// basis points.  Returns `0` when `reference == 0` (no prior price).
+    ///
+    /// `variance_bps = |new - ref| * 10_000 / ref`
+    pub fn price_variance_bps(new_price: i128, reference: i128) -> u32 {
+        if reference <= 0 || new_price <= 0 {
+            return 0;
+        }
+        let diff = if new_price > reference {
+            new_price - reference
+        } else {
+            reference - new_price
+        };
+        // Cap at u32::MAX to avoid overflow in pathological inputs.
+        ((diff * 10_000) / reference).min(u32::MAX as i128) as u32
+    }
+
+    /// Return `true` when `price` is within the allowed variance window
+    /// relative to the last accepted price.  Always `true` when there is no
+    /// prior price.
+    pub fn is_within_variance(
+        new_price: i128,
+        last_price: i128,
+        max_variance_bps: u32,
+    ) -> bool {
+        if last_price <= 0 {
+            return true; // no reference — accept any non-negative price
+        }
+        Self::price_variance_bps(new_price, last_price) <= max_variance_bps
+    }
+
+    /// Return `true` when `timestamp` is not older than `max_age_secs` from
+    /// `now`.
+    pub fn is_fresh(now: u64, timestamp: u64, max_age_secs: u64) -> bool {
+        now.saturating_sub(timestamp) <= max_age_secs
+    }
+
+    // -------------------------------------------------------------------------
+    // Price resolution (primary → fallback)
+    // -------------------------------------------------------------------------
+
+    /// Determine which oracle price to accept for a given asset pair.
+    ///
+    /// Decision logic:
+    /// 1. Reject any price ≤ 0.
+    /// 2. If the primary price is fresh and within the variance window, use it.
+    /// 3. Otherwise fall back to the fallback oracle price (if configured and
+    ///    it passes freshness + variance).
+    /// 4. If neither passes, return `OraclePriceStale`.
+    ///
+    /// Returns the accepted price together with whether the fallback was used.
+    pub fn resolve_price(
+        primary_price: i128,
+        primary_timestamp: u64,
+        fallback_price: Option<i128>,
+        fallback_timestamp: Option<u64>,
+        last_accepted_price: i128,
+        config: &OracleConfig,
+        now: u64,
+    ) -> Result<(i128, bool), VirtualEconomyError> {
+        let max_age = config.update_interval.saturating_mul(3); // 3 × update interval = stale
+
+        let primary_ok = primary_price > 0
+            && Self::is_fresh(now, primary_timestamp, max_age)
+            && Self::is_within_variance(primary_price, last_accepted_price, config.max_variance_bps);
+
+        if primary_ok {
+            return Ok((primary_price, false));
+        }
+
+        // Try fallback
+        if let (Some(fb_price), Some(fb_ts)) = (fallback_price, fallback_timestamp) {
+            let fallback_ok = fb_price > 0
+                && Self::is_fresh(now, fb_ts, max_age)
+                && Self::is_within_variance(fb_price, last_accepted_price, config.max_variance_bps);
+
+            if fallback_ok {
+                return Ok((fb_price, true));
+            }
+        }
+
+        Err(VirtualEconomyError::OraclePriceStale)
+    }
+
+    // -------------------------------------------------------------------------
+    // History management
+    // -------------------------------------------------------------------------
+
+    /// Append a new price entry to the ring-buffer, respecting `history_size`.
+    /// Oldest entries are dropped when the buffer is full.
+    pub fn append_history(
+        history: &mut PriceHistory,
+        price: i128,
+        timestamp: u64,
+        source: Address,
+        is_fallback: bool,
+        history_size: u32,
+    ) {
+        let entry = OraclePriceEntry {
+            price,
+            timestamp,
+            source,
+            is_fallback,
+        };
+
+        // Ring-buffer eviction: remove oldest when full.
+        let cap = history_size.min(MAX_HISTORY) as usize;
+        while history.entries.len() >= cap as u32 {
+            history.entries.pop_front();
+        }
+
+        history.entries.push_back(entry);
+        history.last_price = price;
+        history.last_updated = timestamp;
+        history.update_count = history.update_count.saturating_add(1);
+    }
+
+    /// Compute the time-weighted average price (TWAP) over the stored history.
+    ///
+    /// Each entry is weighted by the seconds it was "valid" (the gap to the
+    /// next entry, or a `default_interval` for the most recent one).
+    /// Returns the simple average when there is only one entry.
+    pub fn calculate_twap(history: &PriceHistory, default_interval: u64) -> i128 {
+        let n = history.entries.len();
+        if n == 0 {
+            return 0;
+        }
+        if n == 1 {
+            return history.entries.get(0).map(|e| e.price).unwrap_or(0);
+        }
+
+        let mut weighted_sum: i128 = 0;
+        let mut total_weight: i128 = 0;
+
+        for i in 0..n {
+            let entry = match history.entries.get(i) {
+                Some(e) => e,
+                None => continue,
+            };
+            let weight = if i + 1 < n {
+                let next = history.entries.get(i + 1).unwrap();
+                (next.timestamp.saturating_sub(entry.timestamp)) as i128
+            } else {
+                default_interval as i128
+            };
+
+            let w = weight.max(1);
+            weighted_sum = weighted_sum.saturating_add(entry.price.saturating_mul(w));
+            total_weight = total_weight.saturating_add(w);
+        }
+
+        if total_weight == 0 {
+            return history.last_price;
+        }
+        weighted_sum / total_weight
+    }
+
+    /// Return the lowest and highest price in the stored history as
+    /// `(min, max)`.  Returns `(0, 0)` for an empty history.
+    pub fn price_range(history: &PriceHistory) -> (i128, i128) {
+        let n = history.entries.len();
+        if n == 0 {
+            return (0, 0);
+        }
+
+        let first = history.entries.get(0).map(|e| e.price).unwrap_or(0);
+        let mut min_price = first;
+        let mut max_price = first;
+
+        for i in 1..n {
+            if let Some(entry) = history.entries.get(i) {
+                if entry.price < min_price {
+                    min_price = entry.price;
+                }
+                if entry.price > max_price {
+                    max_price = entry.price;
+                }
+            }
+        }
+        (min_price, max_price)
+    }
+
+    /// Derive the ledger-time maximum age for a freshness check from the
+    /// configured `update_interval`.
+    ///
+    /// An entry that arrived within `update_interval * stale_multiplier`
+    /// seconds is considered fresh.
+    pub fn max_staleness(update_interval: u64, stale_multiplier: u64) -> u64 {
+        update_interval.saturating_mul(stale_multiplier)
+    }
+}

--- a/contracts/virtual-economy/src/oracle.rs
+++ b/contracts/virtual-economy/src/oracle.rs
@@ -80,11 +80,7 @@ impl OracleManager {
     /// Return `true` when `price` is within the allowed variance window
     /// relative to the last accepted price.  Always `true` when there is no
     /// prior price.
-    pub fn is_within_variance(
-        new_price: i128,
-        last_price: i128,
-        max_variance_bps: u32,
-    ) -> bool {
+    pub fn is_within_variance(new_price: i128, last_price: i128, max_variance_bps: u32) -> bool {
         if last_price <= 0 {
             return true; // no reference — accept any non-negative price
         }
@@ -124,7 +120,11 @@ impl OracleManager {
 
         let primary_ok = primary_price > 0
             && Self::is_fresh(now, primary_timestamp, max_age)
-            && Self::is_within_variance(primary_price, last_accepted_price, config.max_variance_bps);
+            && Self::is_within_variance(
+                primary_price,
+                last_accepted_price,
+                config.max_variance_bps,
+            );
 
         if primary_ok {
             return Ok((primary_price, false));

--- a/contracts/virtual-economy/src/storage.rs
+++ b/contracts/virtual-economy/src/storage.rs
@@ -44,6 +44,26 @@ pub enum DataKey {
     // Analytics
     EconomyAnalytics,
     PricingAnalytics,
+
+    // Price Oracle
+    /// Global oracle configuration shared across all asset pairs.
+    OracleConfig,
+    /// Per asset-pair oracle configuration override.  Key is the asset-pair
+    /// symbol string bytes hashed to a 32-byte identifier.
+    OraclePairConfig(BytesN<32>),
+    /// Address of the primary on-chain price-feed contract (Chainlink-style).
+    PrimaryOracle,
+    /// Address of the fallback oracle contract (used when primary is stale or
+    /// diverges beyond `max_variance_bps`).
+    FallbackOracle,
+    /// Stored price history ring-buffer for an asset pair.
+    OraclePriceHistory(BytesN<32>),
+    /// Last raw price reported by the primary oracle for an asset pair.
+    OracleLastPrimaryPrice(BytesN<32>),
+    /// Last raw price reported by the fallback oracle for an asset pair.
+    OracleLastFallbackPrice(BytesN<32>),
+    /// Aggregate statistics across all oracle updates.
+    OracleAnalytics,
 }
 
 #[contracttype]
@@ -222,4 +242,71 @@ pub struct PricingAnalytics {
     pub total_drops_created: u64,
     pub total_drop_mints: u64,
     pub total_drop_volume: i128,
+}
+
+// -----------------------------------------------------------------------------
+// Price Oracle
+// -----------------------------------------------------------------------------
+
+/// Global (and per-pair-overridable) oracle configuration.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OracleConfig {
+    /// Minimum seconds that must elapse between accepted price updates.
+    /// Prevents spam / too-frequent updates; configurable per pair.
+    pub update_interval: u64,
+    /// Maximum allowed variance in basis points between the incoming price and
+    /// the last accepted price before the fallback is preferred.
+    /// 500 = 5 %, 10 000 = 100 % (effectively disables the check).
+    pub max_variance_bps: u32,
+    /// Number of historic price entries to retain per asset pair (ring-buffer).
+    /// Must be in 1..=100.
+    pub history_size: u32,
+    /// Multiplier applied to `update_interval` to determine when a price feed
+    /// is considered stale.  E.g. `3` ⇒ stale after `3 × update_interval` s.
+    pub stale_multiplier: u64,
+}
+
+/// A single price observation stored in the history ring-buffer.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OraclePriceEntry {
+    /// Price in the smallest unit of the quote asset (e.g. stroops for XLM).
+    pub price: i128,
+    /// Ledger timestamp (seconds since Unix epoch) when the entry was accepted.
+    pub timestamp: u64,
+    /// Address of the oracle contract that provided this price.
+    pub source: Address,
+    /// `true` if this entry was sourced from the fallback oracle.
+    pub is_fallback: bool,
+}
+
+/// Ring-buffer of recent price observations for one asset pair.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PriceHistory {
+    /// Ordered oldest-to-newest list of price observations.
+    pub entries: Vec<OraclePriceEntry>,
+    /// Most recently accepted price (redundant but avoids a full scan).
+    pub last_price: i128,
+    /// Timestamp of the most recently accepted price.
+    pub last_updated: u64,
+    /// Total number of updates accepted since the pair was registered.
+    pub update_count: u64,
+}
+
+/// Aggregate statistics across all oracle price-feed activity.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OracleAnalytics {
+    /// Number of price updates accepted from the primary oracle.
+    pub primary_updates: u64,
+    /// Number of price updates accepted from the fallback oracle.
+    pub fallback_updates: u64,
+    /// Number of times an incoming price was rejected for excessive variance.
+    pub variance_rejections: u64,
+    /// Number of times both oracles were stale and no price could be accepted.
+    pub stale_rejections: u64,
+    /// Total number of distinct asset pairs registered.
+    pub registered_pairs: u32,
 }


### PR DESCRIPTION
closes #961

## Summary

Resolves #961 — adds a full decentralised price feed integration to the `virtual-economy` Soroban contract.

## Changes

### New file
- `contracts/virtual-economy/src/oracle.rs` — pure computation module containing:
  - Primary oracle (Chainlink-style) price acceptance logic
  - Fallback oracle resolution (used when primary is stale or exceeds variance)
  - Price variance check (configurable `max_variance_bps`)
  - Historical price tracking via a ring-buffer (`PriceHistory`)
  - TWAP (time-weighted average price) calculation
  - Price range (min/max) over stored history
  - Configurable update frequency per asset pair
  - Staleness helpers

### Modified files
| File | Change |
|------|--------|
| `storage.rs` | Added `OracleConfig`, `OraclePriceEntry`, `PriceHistory`, `OracleAnalytics` structs; `DataKey` variants for all oracle state |
| `error.rs` | Added 7 oracle error codes (80–86) |
| `lib.rs` | Exposed 11 oracle contract methods; added `mod oracle` declaration |
| `arenax-events/src/virtual_economy.rs` | Added 5 oracle event types + emit helpers |

## Acceptance Criteria

| Criterion | Implemented |
|-----------|-------------|
| Chainlink price feed integration | ✅ `submit_primary_price` / `configure_oracle` |
| Fallback oracle support | ✅ `set_fallback_oracle` / `submit_fallback_price` / `resolve_oracle_price` |
| Price variance check | ✅ `OracleManager::is_within_variance` + `OracleManager::price_variance_bps` |
| Historical price tracking | ✅ Ring-buffer in `PriceHistory`, `get_price_history`, `get_twap`, `get_price_range` |
| Configurable update frequency | ✅ Global `OracleConfig.update_interval` + per-pair override via `register_oracle_pair` / `update_pair_oracle_config` |

## Testing
Build and clippy verification deferred per issue instructions (no compile/test in this PR).