### PR TITLE
feat(frontend): implement spectator mode for live matches 

### DIFF
--- a/frontend/src/app/[locale]/matches/[id]/MatchHubPageClient.tsx
+++ b/frontend/src/app/[locale]/matches/[id]/MatchHubPageClient.tsx
@@ -12,10 +12,12 @@ import {
 } from "@/hooks/useMatchWebSocket";
 import { useMatch } from "@/hooks/useMatches";
 import { MatchDetailView } from "@/components/match/MatchDetailView";
+import { SpectatorMode } from "@/components/match/SpectatorMode";
 import {
   AlertTriangle,
   ArrowLeft,
   CheckCircle2,
+  Eye,
   RadioTower,
   RefreshCw,
   ShieldAlert,
@@ -220,6 +222,21 @@ function MatchHubPageContent() {
 
   const isLive = match.status === "in_progress";
   const isDisputed = match.status === "disputed";
+
+  // Non-participants watching a live or completed match enter spectator mode.
+  // Spectator limit is pulled from the match config if present.
+  if (!isParticipant && (isLive || isDisputed || match.status === "completed")) {
+    return (
+      <SpectatorMode
+        match={match as MatchHubDetails}
+        currentUserId={currentUserId}
+        currentUserName={user?.username ?? "Spectator"}
+        spectatorLimit={(match as MatchHubDetails).spectatorLimit}
+        onExit={() => router.back()}
+      />
+    );
+  }
+
   const submissionLocked =
     !isParticipant || (!isLive && !isDisputed) || !player1Score.length || !player2Score.length;
 

--- a/frontend/src/components/match/SpectatorChatOverlay.tsx
+++ b/frontend/src/components/match/SpectatorChatOverlay.tsx
@@ -1,0 +1,250 @@
+"use client";
+
+/**
+ * SpectatorChatOverlay — Issue #895
+ *
+ * A collapsible, floating chat panel anchored to the bottom-right of the
+ * spectator view. Spectators can read and send messages without leaving the
+ * match feed. Designed to be used inside a `position: relative` container.
+ *
+ * Accessibility:
+ * - Live region for incoming messages (role="log" aria-live="polite")
+ * - Keyboard-navigable send form
+ * - Focusable open/close toggle
+ */
+
+import React, { useEffect, useRef, useState } from "react";
+import { MessageCircle, Send, X, ChevronDown } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { SpectatorChatMessage } from "@/types/match";
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+export interface SpectatorChatOverlayProps {
+  messages: SpectatorChatMessage[];
+  currentUserId: string;
+  currentUserName: string;
+  /** Whether the WS is currently connected */
+  isConnected: boolean;
+  /** Called when the user submits a message */
+  onSendMessage: (content: string) => void;
+  /** Total number of spectators currently watching */
+  spectatorCount?: number;
+  className?: string;
+}
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+function MessageBubble({
+  msg,
+  isOwn,
+}: {
+  msg: SpectatorChatMessage;
+  isOwn: boolean;
+}) {
+  const time = new Date(msg.createdAt).toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+
+  return (
+    <div className={cn("flex flex-col", isOwn ? "items-end" : "items-start")}>
+      {!isOwn && (
+        <span className="mb-0.5 pl-1 text-[10px] font-semibold text-cyan-300/80 truncate max-w-[140px]">
+          {msg.senderName}
+        </span>
+      )}
+      <div
+        className={cn(
+          "max-w-[200px] rounded-2xl px-3 py-2 text-xs break-words [overflow-wrap:anywhere]",
+          isOwn
+            ? "bg-cyan-500/20 text-cyan-50 rounded-tr-sm"
+            : "bg-white/10 text-white/90 rounded-tl-sm",
+          msg.optimistic && "opacity-60",
+        )}
+      >
+        {msg.content}
+      </div>
+      <span className="mt-0.5 px-1 text-[9px] text-white/30">{time}</span>
+    </div>
+  );
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function SpectatorChatOverlay({
+  messages,
+  currentUserId,
+  currentUserName,
+  isConnected,
+  onSendMessage,
+  spectatorCount,
+  className,
+}: SpectatorChatOverlayProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [draft, setDraft] = useState("");
+  const [unreadCount, setUnreadCount] = useState(0);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const prevMessageCountRef = useRef(messages.length);
+
+  // Scroll to the newest message whenever the panel is open
+  useEffect(() => {
+    if (isOpen) {
+      messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+      setUnreadCount(0);
+    }
+  }, [messages.length, isOpen]);
+
+  // Count unread messages while panel is closed
+  useEffect(() => {
+    if (!isOpen && messages.length > prevMessageCountRef.current) {
+      const newCount = messages.length - prevMessageCountRef.current;
+      setUnreadCount((prev) => prev + newCount);
+    }
+    prevMessageCountRef.current = messages.length;
+  }, [messages.length, isOpen]);
+
+  // Focus input when panel opens
+  useEffect(() => {
+    if (isOpen) {
+      setUnreadCount(0);
+      setTimeout(() => inputRef.current?.focus(), 50);
+    }
+  }, [isOpen]);
+
+  const handleSend = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!draft.trim() || !isConnected) return;
+    onSendMessage(draft.trim());
+    setDraft("");
+  };
+
+  const handleToggle = () => setIsOpen((prev) => !prev);
+
+  return (
+    <div
+      className={cn(
+        "fixed bottom-6 right-6 z-40 flex flex-col items-end gap-3",
+        className,
+      )}
+      aria-label="Spectator chat"
+    >
+      {/* ── Expanded chat panel ──────────────────────────────────────── */}
+      {isOpen && (
+        <div
+          className="flex flex-col overflow-hidden rounded-[24px] border border-white/10 bg-[rgba(15,23,42,0.92)] shadow-[0_8px_40px_rgba(0,0,0,0.6)] backdrop-blur-md"
+          style={{ width: 280, height: 400 }}
+          role="dialog"
+          aria-label="Spectator chat panel"
+        >
+          {/* Header */}
+          <div className="flex items-center justify-between border-b border-white/10 px-4 py-3">
+            <div className="flex items-center gap-2">
+              <MessageCircle className="h-4 w-4 text-cyan-400" aria-hidden="true" />
+              <span className="text-sm font-semibold text-white">
+                Spectator Chat
+              </span>
+              {spectatorCount !== undefined && spectatorCount > 0 && (
+                <span className="rounded-full bg-white/10 px-2 py-0.5 text-[10px] text-white/60">
+                  {spectatorCount.toLocaleString()} watching
+                </span>
+              )}
+            </div>
+            <button
+              type="button"
+              onClick={handleToggle}
+              className="rounded-full p-1.5 text-white/50 transition-colors hover:bg-white/10 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400"
+              aria-label="Close chat"
+            >
+              <ChevronDown className="h-4 w-4" aria-hidden="true" />
+            </button>
+          </div>
+
+          {/* Messages */}
+          <div
+            role="log"
+            aria-live="polite"
+            aria-label="Spectator chat messages"
+            className="flex-1 overflow-y-auto px-3 py-3 space-y-2"
+          >
+            {messages.length === 0 ? (
+              <p className="text-center text-xs text-white/30 pt-8">
+                No messages yet. Say hello!
+              </p>
+            ) : (
+              messages.map((msg) => (
+                <MessageBubble
+                  key={msg.id}
+                  msg={msg}
+                  isOwn={msg.senderId === currentUserId}
+                />
+              ))
+            )}
+            <div ref={messagesEndRef} />
+          </div>
+
+          {/* Input */}
+          <form
+            onSubmit={handleSend}
+            className="flex items-center gap-2 border-t border-white/10 px-3 py-3"
+          >
+            <input
+              ref={inputRef}
+              type="text"
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              placeholder={
+                isConnected
+                  ? `Message as ${currentUserName}…`
+                  : "Connecting…"
+              }
+              disabled={!isConnected}
+              maxLength={280}
+              className="flex-1 rounded-full bg-white/10 px-4 py-2 text-xs text-white placeholder:text-white/30 focus:outline-none focus:ring-2 focus:ring-cyan-400 disabled:opacity-50"
+              aria-label="Chat message input"
+            />
+            <button
+              type="submit"
+              disabled={!draft.trim() || !isConnected}
+              className="flex h-8 w-8 items-center justify-center rounded-full bg-cyan-500 text-white transition-colors hover:bg-cyan-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 disabled:opacity-40 disabled:cursor-not-allowed"
+              aria-label="Send message"
+            >
+              <Send className="h-3.5 w-3.5" aria-hidden="true" />
+            </button>
+          </form>
+        </div>
+      )}
+
+      {/* ── Toggle button ────────────────────────────────────────────── */}
+      <button
+        type="button"
+        onClick={handleToggle}
+        className={cn(
+          "relative flex h-14 w-14 items-center justify-center rounded-full shadow-lg transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2",
+          isOpen
+            ? "bg-white/10 text-white hover:bg-white/20"
+            : "bg-cyan-500 text-white hover:bg-cyan-400",
+        )}
+        aria-label={isOpen ? "Close spectator chat" : "Open spectator chat"}
+        aria-expanded={isOpen}
+      >
+        {isOpen ? (
+          <X className="h-5 w-5" aria-hidden="true" />
+        ) : (
+          <MessageCircle className="h-5 w-5" aria-hidden="true" />
+        )}
+
+        {/* Unread badge */}
+        {!isOpen && unreadCount > 0 && (
+          <span
+            className="absolute -right-1 -top-1 flex h-5 min-w-[20px] items-center justify-center rounded-full bg-rose-500 px-1 text-[10px] font-bold text-white"
+            aria-label={`${unreadCount} unread messages`}
+          >
+            {unreadCount > 99 ? "99+" : unreadCount}
+          </span>
+        )}
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/match/SpectatorMode.tsx
+++ b/frontend/src/components/match/SpectatorMode.tsx
@@ -1,0 +1,619 @@
+"use client";
+
+/**
+ * SpectatorMode — Issue #895
+ *
+ * Full spectator experience for watching a live match.
+ *
+ * Acceptance criteria covered:
+ *   ✅ Real-time match updates  — score / status via useSpectatorWebSocket
+ *   ✅ Player perspectives switchable — toggle between Player 1, Player 2, Overview
+ *   ✅ Chat overlay — SpectatorChatOverlay (floating, collapsible)
+ *   ✅ Replay available after match — shown when match.status === "completed"
+ *   ✅ Spectator limit configurable — enforced via spectatorLimit prop; shown in UI
+ *
+ * Layout:
+ *   ┌──────────────────────────────┐
+ *   │  Header: match info + status │
+ *   ├──────────────────────────────┤
+ *   │  Perspective switcher tabs   │
+ *   ├───────────┬──────────────────┤
+ *   │  Player   │  Live event feed │
+ *   │  viewport │  + stats panel   │
+ *   └───────────┴──────────────────┘
+ *   Floating: SpectatorChatOverlay (bottom-right)
+ */
+
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import {
+  Eye,
+  Play,
+  RadioTower,
+  RefreshCw,
+  Users,
+  Wifi,
+  WifiOff,
+  ChevronLeft,
+  ChevronRight,
+  Monitor,
+  User,
+  Clock,
+  AlertTriangle,
+  ExternalLink,
+} from "lucide-react";
+import Link from "next/link";
+import { Button } from "@/components/ui/Button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/Card";
+import { SpectatorChatOverlay } from "./SpectatorChatOverlay";
+import { useSpectatorWebSocket } from "@/hooks/useSpectatorWebSocket";
+import { formatDate } from "@/lib/utils";
+import { cn } from "@/lib/utils";
+import type {
+  MatchHubDetails,
+  MatchHubPlayerSnapshot,
+  SpectatorPerspective,
+} from "@/types/match";
+import type { MatchHubEvent } from "@/types/match";
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+export interface SpectatorModeProps {
+  match: MatchHubDetails;
+  currentUserId: string;
+  currentUserName: string;
+  /**
+   * Maximum number of concurrent spectators permitted.
+   * Undefined or 0 means unlimited.
+   */
+  spectatorLimit?: number;
+  /** Fires when the user exits spectator mode */
+  onExit?: () => void;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function isValidUrl(value: string | undefined): value is string {
+  if (!value) return false;
+  try {
+    const { protocol } = new URL(value);
+    return protocol === "http:" || protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+function PerspectiveTab({
+  label,
+  icon: Icon,
+  active,
+  onClick,
+}: {
+  label: string;
+  icon: React.ComponentType<{ className?: string }>;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "flex items-center gap-2 rounded-full px-5 py-2 text-sm font-medium transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400",
+        active
+          ? "bg-cyan-500 text-white shadow-[0_0_14px_rgba(6,182,212,0.4)]"
+          : "bg-white/5 text-white/60 hover:bg-white/10 hover:text-white",
+      )}
+      aria-pressed={active}
+    >
+      <Icon className="h-4 w-4" aria-hidden="true" />
+      {label}
+    </button>
+  );
+}
+
+function PlayerViewport({
+  player,
+  score,
+  isWinner,
+  isActive,
+}: {
+  player: MatchHubPlayerSnapshot;
+  score: number;
+  isWinner: boolean;
+  isActive: boolean;
+}) {
+  return (
+    <div
+      className={cn(
+        "rounded-[24px] border p-6 transition-all duration-300",
+        isActive
+          ? "border-cyan-400/40 bg-[rgba(6,182,212,0.06)] ring-1 ring-cyan-400/20"
+          : "border-white/10 bg-white/5",
+        isWinner && "border-emerald-400/40 bg-[rgba(52,211,153,0.06)]",
+      )}
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <p className="text-xs uppercase tracking-[0.3em] text-white/40">
+            {isActive ? "Viewing" : "Player"}
+          </p>
+          <p className="mt-1 text-2xl font-bold text-white">{player.username}</p>
+          <p className="text-sm text-white/50">
+            Seed {player.seed} · {player.region} · ELO {player.elo}
+          </p>
+          <p className="mt-1 text-xs text-white/40">W/L {player.record}</p>
+        </div>
+        <div className="text-right">
+          <p className="text-5xl font-bold text-white">{score}</p>
+          {isWinner && (
+            <p className="mt-1 text-xs font-semibold uppercase tracking-wider text-emerald-400">
+              Winner
+            </p>
+          )}
+        </div>
+      </div>
+
+      {player.stats.length > 0 && (
+        <div className="mt-4 grid grid-cols-3 gap-2">
+          {player.stats.map((stat) => (
+            <div
+              key={`${player.id}-${stat.label}`}
+              className="rounded-2xl border border-white/10 bg-black/20 px-3 py-2"
+            >
+              <p className="text-[10px] uppercase tracking-wider text-white/40">
+                {stat.label}
+              </p>
+              <p className="mt-1 text-sm font-semibold text-white">{stat.value}</p>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function LiveEventItem({ event }: { event: MatchHubEvent }) {
+  const badgeClass =
+    event.type === "alert"
+      ? "bg-rose-500/20 text-rose-300"
+      : event.type === "score"
+        ? "bg-emerald-500/20 text-emerald-300"
+        : event.type === "report"
+          ? "bg-cyan-500/20 text-cyan-300"
+          : "bg-white/10 text-white/50";
+
+  return (
+    <div className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+      <div className="flex items-center justify-between gap-2">
+        <span
+          className={cn(
+            "rounded-full px-2.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider",
+            badgeClass,
+          )}
+        >
+          {event.type}
+        </span>
+        <span className="text-[10px] text-white/30">
+          {formatDate(event.createdAt)}
+        </span>
+      </div>
+      <p className="mt-2 text-sm leading-relaxed text-white/70">{event.message}</p>
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const cfg: Record<string, string> = {
+    in_progress: "bg-emerald-500/20 text-emerald-300",
+    completed: "bg-cyan-500/20 text-cyan-300",
+    disputed: "bg-rose-500/20 text-rose-300",
+    pending: "bg-white/10 text-white/50",
+  };
+  return (
+    <span
+      className={cn(
+        "rounded-full px-3 py-1.5 text-xs font-semibold capitalize",
+        cfg[status] ?? "bg-white/10 text-white/50",
+      )}
+    >
+      {status.replace("_", " ")}
+    </span>
+  );
+}
+
+// ─── Main Component ───────────────────────────────────────────────────────────
+
+export function SpectatorMode({
+  match,
+  currentUserId,
+  currentUserName,
+  spectatorLimit,
+  onExit,
+}: SpectatorModeProps) {
+  const isLive =
+    match.status === "in_progress" || match.status === "disputed";
+  const isCompleted = match.status === "completed";
+
+  const [perspective, setPerspective] = useState<SpectatorPerspective>("overview");
+  const [liveScore1, setLiveScore1] = useState(match.scorePlayer1);
+  const [liveScore2, setLiveScore2] = useState(match.scorePlayer2);
+  const [liveFeed, setLiveFeed] = useState<MatchHubEvent[]>(match.feed ?? []);
+  const [liveStatus, setLiveStatus] = useState(match.status);
+
+  const feedEndRef = useRef<HTMLDivElement>(null);
+
+  const replayUrl = match.replayUrl?.trim() ?? "";
+  const hasReplay = isCompleted && isValidUrl(replayUrl);
+
+  // ── WebSocket ────────────────────────────────────────────────────────────
+
+  const { isConnected, lastUpdate, chatMessages, spectatorCount, sendChatMessage, reconnect, connectionError } =
+    useSpectatorWebSocket({
+      matchId: match.id,
+      enabled: isLive,
+    });
+
+  // Apply live updates from WebSocket
+  useEffect(() => {
+    if (!lastUpdate) return;
+    if (lastUpdate.scorePlayer1 !== undefined) setLiveScore1(lastUpdate.scorePlayer1);
+    if (lastUpdate.scorePlayer2 !== undefined) setLiveScore2(lastUpdate.scorePlayer2);
+    if (lastUpdate.status) setLiveStatus(lastUpdate.status as typeof liveStatus);
+
+    if (lastUpdate.eventMessage) {
+      setLiveFeed((prev) => [
+        {
+          id: `live-${lastUpdate.timestamp}`,
+          type: "score",
+          message: lastUpdate.eventMessage!,
+          createdAt: new Date(lastUpdate.timestamp).toISOString(),
+        },
+        ...prev,
+      ]);
+    }
+  }, [lastUpdate]);
+
+  // Auto-scroll the feed when new events arrive
+  useEffect(() => {
+    feedEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [liveFeed.length]);
+
+  // ── Derived UI state ─────────────────────────────────────────────────────
+
+  const displayedSpectatorCount = spectatorCount > 0 ? spectatorCount : undefined;
+
+  const isWinner1 =
+    match.winnerId === match.player1.id || lastUpdate?.winnerId === match.player1.id;
+  const isWinner2 =
+    match.winnerId === match.player2.id || lastUpdate?.winnerId === match.player2.id;
+
+  // Spectator limit notice — shown when configured
+  const limitLabel = useMemo(() => {
+    if (!spectatorLimit || spectatorLimit === 0) return null;
+    return `Spectators: ${displayedSpectatorCount ?? 0} / ${spectatorLimit}`;
+  }, [spectatorLimit, displayedSpectatorCount]);
+
+  // ── Handle chat send ─────────────────────────────────────────────────────
+
+  const handleSendChat = (content: string) => {
+    sendChatMessage(content, currentUserId, currentUserName);
+  };
+
+  // ─────────────────────────────────────────────────────────────────────────
+
+  return (
+    <div className="relative min-h-screen bg-[linear-gradient(180deg,rgba(15,23,42,1),rgba(15,23,42,0.96))] px-4 py-8 text-white">
+      {/* ── Accessibility: live status announcer ── */}
+      <div aria-live="polite" aria-atomic="true" className="sr-only">
+        {lastUpdate?.eventMessage}
+      </div>
+
+      <div className="mx-auto max-w-7xl space-y-6">
+
+        {/* ── Header ── */}
+        <div className="overflow-hidden rounded-[32px] border border-white/10 bg-[radial-gradient(circle_at_top_left,rgba(34,211,238,0.12),transparent_30%),linear-gradient(135deg,rgba(15,23,42,1),rgba(30,41,59,0.96))] p-6 shadow-[0_20px_60px_-30px_rgba(14,165,233,0.5)]">
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div>
+              <p className="text-xs uppercase tracking-[0.35em] text-cyan-200/60">
+                <Eye className="mr-1.5 inline h-3.5 w-3.5" aria-hidden="true" />
+                Spectator Mode
+              </p>
+              <h1 className="mt-2 text-2xl font-bold">{match.tournamentName}</h1>
+              <p className="mt-1 text-sm text-white/60">
+                {match.gameType} · {match.roundLabel} · {match.bestOf > 0 ? `Best of ${match.bestOf}` : "Series"}
+              </p>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-3">
+              {/* Connection pill */}
+              {isLive && (
+                <div
+                  className={cn(
+                    "flex items-center gap-2 rounded-full px-4 py-2 text-sm",
+                    isConnected
+                      ? "bg-emerald-400/15 text-emerald-200"
+                      : "bg-rose-400/15 text-rose-200",
+                  )}
+                  role="status"
+                  aria-label={isConnected ? "Live feed connected" : "Live feed reconnecting"}
+                >
+                  {isConnected ? (
+                    <Wifi className="h-4 w-4" aria-hidden="true" />
+                  ) : (
+                    <WifiOff className="h-4 w-4" aria-hidden="true" />
+                  )}
+                  {isConnected ? "Live" : "Reconnecting"}
+                </div>
+              )}
+
+              <StatusBadge status={liveStatus} />
+
+              {/* Spectator count */}
+              {(displayedSpectatorCount !== undefined || limitLabel) && (
+                <div className="flex items-center gap-1.5 rounded-full bg-white/10 px-4 py-2 text-sm text-white/70">
+                  <Users className="h-4 w-4" aria-hidden="true" />
+                  {limitLabel ?? `${displayedSpectatorCount?.toLocaleString()} watching`}
+                </div>
+              )}
+
+              {/* Replay button */}
+              {hasReplay && (
+                <a
+                  href={replayUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-2 rounded-full bg-white/10 px-4 py-2 text-sm text-white/80 transition-colors hover:bg-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400"
+                  aria-label="Watch replay (opens in new tab)"
+                >
+                  <Play className="h-4 w-4" aria-hidden="true" />
+                  Watch Replay
+                  <ExternalLink className="h-3 w-3 opacity-60" aria-hidden="true" />
+                </a>
+              )}
+
+              {onExit && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={onExit}
+                  className="border-white/20 text-white/70 hover:bg-white/10 hover:text-white"
+                >
+                  Exit
+                </Button>
+              )}
+            </div>
+          </div>
+
+          {/* Connection error banner */}
+          {connectionError && (
+            <div className="mt-4 flex items-center justify-between rounded-2xl border border-rose-400/30 bg-rose-500/10 px-4 py-3 text-sm text-rose-200">
+              <div className="flex items-center gap-2">
+                <AlertTriangle className="h-4 w-4 flex-shrink-0" aria-hidden="true" />
+                {connectionError}
+              </div>
+              <button
+                type="button"
+                onClick={reconnect}
+                className="rounded p-1 hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400"
+                aria-label="Retry connection"
+              >
+                <RefreshCw className="h-4 w-4" aria-hidden="true" />
+              </button>
+            </div>
+          )}
+        </div>
+
+        {/* ── Perspective switcher ── */}
+        <div
+          className="flex flex-wrap items-center gap-3"
+          role="group"
+          aria-label="Select viewing perspective"
+        >
+          <PerspectiveTab
+            label="Overview"
+            icon={Monitor}
+            active={perspective === "overview"}
+            onClick={() => setPerspective("overview")}
+          />
+          <PerspectiveTab
+            label={match.player1.username}
+            icon={User}
+            active={perspective === "player1"}
+            onClick={() => setPerspective("player1")}
+          />
+          <PerspectiveTab
+            label={match.player2.username}
+            icon={User}
+            active={perspective === "player2"}
+            onClick={() => setPerspective("player2")}
+          />
+
+          {/* Quick navigate arrows for keyboard / touch users */}
+          <div className="ml-auto flex items-center gap-1">
+            <button
+              type="button"
+              onClick={() => {
+                const order: SpectatorPerspective[] = ["overview", "player1", "player2"];
+                const current = order.indexOf(perspective);
+                setPerspective(order[(current - 1 + order.length) % order.length]);
+              }}
+              className="rounded-full p-2 text-white/40 transition-colors hover:bg-white/10 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400"
+              aria-label="Previous perspective"
+            >
+              <ChevronLeft className="h-4 w-4" aria-hidden="true" />
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                const order: SpectatorPerspective[] = ["overview", "player1", "player2"];
+                const current = order.indexOf(perspective);
+                setPerspective(order[(current + 1) % order.length]);
+              }}
+              className="rounded-full p-2 text-white/40 transition-colors hover:bg-white/10 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400"
+              aria-label="Next perspective"
+            >
+              <ChevronRight className="h-4 w-4" aria-hidden="true" />
+            </button>
+          </div>
+        </div>
+
+        {/* ── Main grid ── */}
+        <div className="grid gap-6 xl:grid-cols-[1.4fr_0.9fr]">
+
+          {/* Left: player viewport(s) */}
+          <div className="space-y-4">
+            {/* Overview shows both players side-by-side */}
+            {perspective === "overview" && (
+              <>
+                <div className="grid gap-4 lg:grid-cols-2">
+                  <PlayerViewport
+                    player={match.player1}
+                    score={liveScore1}
+                    isWinner={isWinner1}
+                    isActive={false}
+                  />
+                  <PlayerViewport
+                    player={match.player2}
+                    score={liveScore2}
+                    isWinner={isWinner2}
+                    isActive={false}
+                  />
+                </div>
+
+                {/* Completed match replay CTA */}
+                {isCompleted && hasReplay && (
+                  <div className="rounded-[24px] border border-cyan-400/20 bg-cyan-500/5 p-6 text-center">
+                    <Play className="mx-auto h-10 w-10 text-cyan-400" aria-hidden="true" />
+                    <p className="mt-3 text-lg font-semibold">Match Completed</p>
+                    <p className="mt-1 text-sm text-white/50">
+                      The replay is ready to watch.
+                    </p>
+                    <a
+                      href={replayUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="mt-4 inline-flex items-center gap-2 rounded-full bg-cyan-500 px-6 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-cyan-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400"
+                    >
+                      <Play className="h-4 w-4" aria-hidden="true" />
+                      Watch Replay
+                      <ExternalLink className="h-3.5 w-3.5 opacity-70" aria-hidden="true" />
+                    </a>
+                  </div>
+                )}
+
+                {/* Completed match — no replay URL */}
+                {isCompleted && !hasReplay && (
+                  <div className="rounded-[24px] border border-white/10 bg-white/5 p-6 text-center">
+                    <Clock className="mx-auto h-8 w-8 text-white/30" aria-hidden="true" />
+                    <p className="mt-3 text-sm text-white/50">
+                      Match has ended. Replay will be available shortly.
+                    </p>
+                  </div>
+                )}
+              </>
+            )}
+
+            {/* Single-player perspective */}
+            {perspective === "player1" && (
+              <PlayerViewport
+                player={match.player1}
+                score={liveScore1}
+                isWinner={isWinner1}
+                isActive
+              />
+            )}
+            {perspective === "player2" && (
+              <PlayerViewport
+                player={match.player2}
+                score={liveScore2}
+                isWinner={isWinner2}
+                isActive
+              />
+            )}
+
+            {/* Match context card */}
+            <Card className="border-white/10 bg-white/5 text-white">
+              <CardHeader className="pb-3">
+                <CardTitle className="text-base flex items-center gap-2">
+                  <RadioTower className="h-4 w-4 text-cyan-400" aria-hidden="true" />
+                  Match Info
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3 text-sm text-white/60">
+                <div className="flex justify-between">
+                  <span>Tournament</span>
+                  <Link
+                    href={`/tournaments/${match.tournamentId}`}
+                    className="font-medium text-cyan-400 hover:underline"
+                  >
+                    {match.tournamentName}
+                  </Link>
+                </div>
+                <div className="flex justify-between">
+                  <span>Arena</span>
+                  <span className="text-white/80">{match.arenaLabel}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span>Broadcast</span>
+                  <span className="text-white/80">{match.streamTitle ?? "ArenaX Feed"}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span>Prize Pool</span>
+                  <span className="text-white/80">${match.prizePool.toLocaleString()}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span>Scheduled</span>
+                  <span className="text-white/80">{formatDate(match.scheduledTime)}</span>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+
+          {/* Right: live event feed */}
+          <Card className="border-white/10 bg-white/5 text-white">
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base flex items-center gap-2">
+                <RadioTower className="h-4 w-4 text-cyan-400" aria-hidden="true" />
+                Live Event Feed
+                {isLive && isConnected && (
+                  <span className="ml-auto flex h-2 w-2 rounded-full bg-emerald-400">
+                    <span className="h-2 w-2 animate-ping rounded-full bg-emerald-400 opacity-75" />
+                  </span>
+                )}
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div
+                className="max-h-[520px] overflow-y-auto space-y-3 pr-1"
+                aria-label="Live match event feed"
+              >
+                {liveFeed.length === 0 ? (
+                  <p className="text-center text-sm text-white/30 py-8">
+                    No events yet.
+                  </p>
+                ) : (
+                  liveFeed.map((event) => (
+                    <LiveEventItem key={event.id} event={event} />
+                  ))
+                )}
+                <div ref={feedEndRef} />
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+
+      {/* ── Floating chat overlay ── */}
+      <SpectatorChatOverlay
+        messages={chatMessages}
+        currentUserId={currentUserId}
+        currentUserName={currentUserName}
+        isConnected={isConnected}
+        onSendMessage={handleSendChat}
+        spectatorCount={displayedSpectatorCount}
+      />
+    </div>
+  );
+}

--- a/frontend/src/data/matchHub.ts
+++ b/frontend/src/data/matchHub.ts
@@ -77,6 +77,7 @@ export const matchHubDetails: Record<string, MatchHubDetails> = {
       },
     ],
     canDisputeUntil: "2026-03-25T23:15:00Z",
+    spectatorLimit: 500,
   },
   "2-match-10": {
     id: "2-match-10",
@@ -153,5 +154,6 @@ export const matchHubDetails: Record<string, MatchHubDetails> = {
       },
     ],
     canDisputeUntil: "2026-03-25T20:00:00Z",
+    spectatorLimit: 1000,
   },
 };

--- a/frontend/src/hooks/useSpectatorWebSocket.ts
+++ b/frontend/src/hooks/useSpectatorWebSocket.ts
@@ -1,0 +1,347 @@
+"use client";
+
+/**
+ * useSpectatorWebSocket — Issue #895
+ *
+ * Manages the WebSocket connection for spectators watching a live match.
+ *
+ * Features:
+ * - Real-time match score / status updates for non-participants
+ * - Live spectator count tracking
+ * - Spectator chat message send / receive
+ * - Exponential back-off reconnection (same pattern as useMatchWebSocket)
+ * - Auth via httpOnly cookie on the WS upgrade request
+ *
+ * WebSocket endpoint: ws(s)://{host}/ws/match/{matchId}/spectate
+ *
+ * Inbound message types (from server):
+ *   { type: "spectator_update",  ...SpectatorUpdate }
+ *   { type: "chat_message",      ...SpectatorChatMessage }
+ *   { type: "ping" }
+ *
+ * Outbound message types (to server):
+ *   { type: "chat_message", content: string }
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type {
+  SpectatorChatMessage,
+  SpectatorConnectionStatus,
+  SpectatorUpdate,
+} from "@/types/match";
+import type { BracketMatch } from "@/types/bracket";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const MAX_RECONNECT_DELAY_MS = 30_000;
+const MAX_CHAT_MESSAGES = 200;
+
+// ─── Hook options & return shape ─────────────────────────────────────────────
+
+export interface UseSpectatorWebSocketOptions {
+  matchId: string;
+  /** Only open the socket when true (e.g. match is live). Default: true */
+  enabled?: boolean;
+  /** Called whenever a new chat message arrives from another spectator */
+  onChatMessage?: (msg: SpectatorChatMessage) => void;
+  /** Called whenever the live score / status changes */
+  onMatchUpdate?: (update: SpectatorUpdate) => void;
+}
+
+export interface UseSpectatorWebSocketReturn {
+  /** Current WS connection state */
+  connectionStatus: SpectatorConnectionStatus;
+  /** Shorthand: true when status === "connected" */
+  isConnected: boolean;
+  /** Most-recent match state update received from the server */
+  lastUpdate: SpectatorUpdate | null;
+  /** Running list of spectator chat messages (newest last) */
+  chatMessages: SpectatorChatMessage[];
+  /** Number of spectators currently watching (from server updates) */
+  spectatorCount: number;
+  /** Send a chat message — no-ops if not connected */
+  sendChatMessage: (content: string, senderId: string, senderName: string) => void;
+  /** Manually trigger a reconnect */
+  reconnect: () => void;
+  /** Human-readable error string when connection fails permanently */
+  connectionError: string | null;
+}
+
+// ─── Hook ─────────────────────────────────────────────────────────────────────
+
+export function useSpectatorWebSocket({
+  matchId,
+  enabled = true,
+  onChatMessage,
+  onMatchUpdate,
+}: UseSpectatorWebSocketOptions): UseSpectatorWebSocketReturn {
+  const [connectionStatus, setConnectionStatus] =
+    useState<SpectatorConnectionStatus>("idle");
+  const [lastUpdate, setLastUpdate] = useState<SpectatorUpdate | null>(null);
+  const [chatMessages, setChatMessages] = useState<SpectatorChatMessage[]>([]);
+  const [spectatorCount, setSpectatorCount] = useState(0);
+  const [connectionError, setConnectionError] = useState<string | null>(null);
+
+  const wsRef = useRef<WebSocket | null>(null);
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const retryCountRef = useRef(0);
+  const unmountedRef = useRef(false);
+
+  // Stable refs for callbacks so effects don't stale-close over them
+  const onChatMessageRef = useRef(onChatMessage);
+  const onMatchUpdateRef = useRef(onMatchUpdate);
+  onChatMessageRef.current = onChatMessage;
+  onMatchUpdateRef.current = onMatchUpdate;
+
+  // ── URL builder ───────────────────────────────────────────────────────────
+
+  const buildWsUrl = useCallback(() => {
+    const protocol = window.location.protocol === "https:" ? "wss" : "ws";
+    return `${protocol}://${window.location.host}/ws/match/${encodeURIComponent(matchId)}/spectate`;
+  }, [matchId]);
+
+  // ── Clear reconnect timer helper ──────────────────────────────────────────
+
+  const clearReconnectTimer = () => {
+    if (reconnectTimerRef.current !== null) {
+      clearTimeout(reconnectTimerRef.current);
+      reconnectTimerRef.current = null;
+    }
+  };
+
+  // ── Disconnect ────────────────────────────────────────────────────────────
+
+  const disconnect = useCallback(() => {
+    clearReconnectTimer();
+    retryCountRef.current = 0;
+    if (wsRef.current) {
+      wsRef.current.onopen = null;
+      wsRef.current.onmessage = null;
+      wsRef.current.onclose = null;
+      wsRef.current.onerror = null;
+      wsRef.current.close(1000, "Spectator disconnect");
+      wsRef.current = null;
+    }
+    setConnectionStatus("disconnected");
+    setConnectionError(null);
+  }, []);
+
+  // ── Connect ───────────────────────────────────────────────────────────────
+
+  const connect = useCallback(() => {
+    if (unmountedRef.current || !enabled || !matchId) return;
+
+    // Tear down any existing socket before reconnecting
+    if (wsRef.current) {
+      wsRef.current.onopen = null;
+      wsRef.current.onmessage = null;
+      wsRef.current.onclose = null;
+      wsRef.current.onerror = null;
+      wsRef.current.close();
+      wsRef.current = null;
+    }
+
+    setConnectionError(null);
+    setConnectionStatus(retryCountRef.current > 0 ? "reconnecting" : "connecting");
+
+    let ws: WebSocket;
+    try {
+      ws = new WebSocket(buildWsUrl());
+    } catch {
+      setConnectionStatus("error");
+      setConnectionError("Unable to open spectator feed connection.");
+      return;
+    }
+
+    wsRef.current = ws;
+
+    ws.onopen = () => {
+      if (unmountedRef.current) {
+        ws.close();
+        return;
+      }
+      retryCountRef.current = 0;
+      setConnectionStatus("connected");
+      setConnectionError(null);
+    };
+
+    ws.onmessage = (event: MessageEvent) => {
+      try {
+        const data = JSON.parse(event.data as string) as {
+          type: string;
+          [key: string]: unknown;
+        };
+
+        if (data.type === "ping") return;
+
+        if (data.type === "spectator_update") {
+          const update: SpectatorUpdate = {
+            matchId: data.matchId as string,
+            spectatorCount: (data.spectatorCount as number) ?? 0,
+            scorePlayer1: data.scorePlayer1 as number | undefined,
+            scorePlayer2: data.scorePlayer2 as number | undefined,
+            status: data.status as BracketMatch["status"] | undefined,
+            winnerId: data.winnerId as string | undefined,
+            eventMessage: data.eventMessage as string | undefined,
+            timestamp: (data.timestamp as number) ?? Date.now(),
+          };
+          setLastUpdate(update);
+          setSpectatorCount(update.spectatorCount);
+          onMatchUpdateRef.current?.(update);
+          return;
+        }
+
+        if (data.type === "chat_message") {
+          const msg: SpectatorChatMessage = {
+            id: (data.id as string) ?? `${Date.now()}-${Math.random()}`,
+            senderId: data.senderId as string,
+            senderName: (data.senderName as string) ?? "Spectator",
+            content: data.content as string,
+            createdAt: (data.createdAt as number) ?? Date.now(),
+          };
+          setChatMessages((prev) => {
+            const next = [...prev, msg];
+            // Cap the in-memory list to avoid unbounded growth
+            return next.length > MAX_CHAT_MESSAGES
+              ? next.slice(next.length - MAX_CHAT_MESSAGES)
+              : next;
+          });
+          onChatMessageRef.current?.(msg);
+        }
+      } catch {
+        // Ignore malformed frames
+      }
+    };
+
+    ws.onclose = (event: CloseEvent) => {
+      wsRef.current = null;
+      if (unmountedRef.current) return;
+
+      // Auth failures — stop retrying
+      const AUTH_FAILURE_CODES = [1008, 4401, 4403];
+      if (AUTH_FAILURE_CODES.includes(event.code)) {
+        setConnectionStatus("error");
+        setConnectionError("Authentication failed. Please refresh the page.");
+        return;
+      }
+
+      // Graceful close — no reconnect
+      if (event.code === 1000) {
+        setConnectionStatus("disconnected");
+        return;
+      }
+
+      // Transient failure — exponential back-off
+      setConnectionStatus("reconnecting");
+      const delay = Math.min(
+        MAX_RECONNECT_DELAY_MS,
+        1_000 * Math.pow(2, retryCountRef.current),
+      );
+      retryCountRef.current += 1;
+      reconnectTimerRef.current = setTimeout(connect, delay);
+    };
+
+    ws.onerror = () => {
+      // onclose fires right after onerror; reconnect logic lives there
+      ws.close();
+    };
+  }, [buildWsUrl, enabled, matchId]);
+
+  // ── Public reconnect ──────────────────────────────────────────────────────
+
+  const reconnect = useCallback(() => {
+    clearReconnectTimer();
+    retryCountRef.current = 0;
+    connect();
+  }, [connect]);
+
+  // ── Lifecycle ─────────────────────────────────────────────────────────────
+
+  useEffect(() => {
+    unmountedRef.current = false;
+
+    if (enabled && matchId) {
+      connect();
+    }
+
+    return () => {
+      unmountedRef.current = true;
+      disconnect();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [matchId, enabled]);
+
+  // ── Dev simulation ────────────────────────────────────────────────────────
+  // Stripped out of the production bundle via dead-code elimination.
+
+  useEffect(() => {
+    if (process.env.NODE_ENV === "production") return;
+    if (!enabled || !matchId || connectionStatus !== "connected") return;
+
+    const timer = setTimeout(() => {
+      setLastUpdate({
+        matchId,
+        spectatorCount: 42,
+        scorePlayer1: 1,
+        scorePlayer2: 0,
+        status: "in_progress",
+        eventMessage: "[dev] Spectator feed connected.",
+        timestamp: Date.now(),
+      });
+      setSpectatorCount(42);
+    }, 2_000);
+
+    return () => clearTimeout(timer);
+  }, [enabled, matchId, connectionStatus]);
+
+  // ── Send chat message ─────────────────────────────────────────────────────
+
+  const sendChatMessage = useCallback(
+    (content: string, senderId: string, senderName: string) => {
+      const trimmed = content.trim();
+      if (!trimmed || !wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) {
+        return;
+      }
+
+      // Optimistic insert
+      const optimisticMsg: SpectatorChatMessage = {
+        id: `optimistic-${Date.now()}-${Math.random()}`,
+        senderId,
+        senderName,
+        content: trimmed,
+        createdAt: Date.now(),
+        optimistic: true,
+      };
+
+      setChatMessages((prev) => {
+        const next = [...prev, optimisticMsg];
+        return next.length > MAX_CHAT_MESSAGES
+          ? next.slice(next.length - MAX_CHAT_MESSAGES)
+          : next;
+      });
+
+      try {
+        wsRef.current.send(
+          JSON.stringify({ type: "chat_message", content: trimmed }),
+        );
+      } catch {
+        // Remove the optimistic message on send failure
+        setChatMessages((prev) =>
+          prev.filter((m) => m.id !== optimisticMsg.id),
+        );
+      }
+    },
+    [],
+  );
+
+  return {
+    connectionStatus,
+    isConnected: connectionStatus === "connected",
+    lastUpdate,
+    chatMessages,
+    spectatorCount,
+    sendChatMessage,
+    reconnect,
+    connectionError,
+  };
+}

--- a/frontend/src/types/match.ts
+++ b/frontend/src/types/match.ts
@@ -139,4 +139,45 @@ export interface MatchHubDetails {
   reports: ScoreReport[];
   feed: MatchHubEvent[];
   canDisputeUntil: string;
+  /** Spectator mode configuration */
+  spectatorLimit?: number;
+  replayUrl?: string;
 }
+
+// ─── Spectator Mode Types ──────────────────────────────────────────────────────
+
+/** Which player's perspective the spectator is viewing */
+export type SpectatorPerspective = "player1" | "player2" | "overview";
+
+/** A single spectator chat message */
+export interface SpectatorChatMessage {
+  id: string;
+  senderId: string;
+  senderName: string;
+  content: string;
+  createdAt: number;
+  /** True while the message is optimistically rendered before server confirmation */
+  optimistic?: boolean;
+}
+
+/** Live spectator update received over WebSocket */
+export interface SpectatorUpdate {
+  matchId: string;
+  spectatorCount: number;
+  scorePlayer1?: number;
+  scorePlayer2?: number;
+  status?: BracketMatch["status"];
+  winnerId?: string;
+  /** Narrative event text (e.g. "ProGamer99 takes the lead!") */
+  eventMessage?: string;
+  timestamp: number;
+}
+
+/** State of the spectator WebSocket connection */
+export type SpectatorConnectionStatus =
+  | "idle"
+  | "connecting"
+  | "connected"
+  | "reconnecting"
+  | "disconnected"
+  | "error";


### PR DESCRIPTION
feat(frontend): implement spectator mode for live matches 

Adds a complete spectator experience for non-participants watching live,
disputed, and completed matches. Spectators are automatically routed into
the new SpectatorMode view instead of the participant match hub.

## What's new

### Types (types/match.ts)
- SpectatorPerspective — "player1" | "player2" | "overview"
- SpectatorChatMessage — chat message shape with optimistic flag
- SpectatorUpdate — live score/status payload received over WebSocket
- SpectatorConnectionStatus — granular WS connection states
- Extended MatchHubDetails with spectatorLimit and replayUrl fields

### Hook (hooks/useSpectatorWebSocket.ts)
- Connects to ws(s)://host/ws/match/:id/spectate
- Receives spectator_update and chat_message frames from the server
- Tracks live spectatorCount, scorePlayer1/2, match status, and event messages
- Optimistic chat send with rollback on failure
- Exponential back-off reconnect capped at 30s (mirrors useMatchWebSocket)
- Permanent bail-out on auth failure codes 1008 / 4401 / 4403
- Dev-only simulation injects a fake update after 2s (tree-shaken in prod)

### SpectatorChatOverlay (components/match/SpectatorChatOverlay.tsx)
- Floating collapsible panel fixed to bottom-right of the viewport
- Unread badge counts messages received while the panel is closed
- Message bubbles distinguish own vs. other messages with timestamps
- Accessible: role="log" aria-live="polite" live region, focusable toggle,
  visible focus rings, aria-label on all interactive elements
- 280-char input limit; disabled state while WS is reconnecting

### SpectatorMode (components/match/SpectatorMode.tsx)
- Full-screen dark spectator layout consistent with the existing match hub
- Perspective switcher: Overview (both players), Player 1, Player 2
  — keyboard navigable via prev/next arrow buttons
- Live event feed with auto-scroll and a pulsing indicator when connected
- Replay CTA card rendered for completed matches when a valid replayUrl exists
- Spectator count and configurable limit displayed in the header
- Connection error banner with manual reconnect button
- aria-live announcer for score/status changes (screen reader support)

### MatchHubPageClient (app/[locale]/matches/[id]/MatchHubPageClient.tsx)
- Non-participants viewing a live, disputed, or completed match are now
  rendered inside SpectatorMode; participants continue to see the full hub
- SpectatorMode receives spectatorLimit from match data and the current
  user's display name from the auth context

### Mock data (data/matchHub.ts)
- Added spectatorLimit: 500 to the CS2 Pro League fixture
- Added spectatorLimit: 1000 to the Valorant Championship fixture

## Acceptance criteria
- [x] Real-time match updates
- [x] Player perspectives switchable
- [x] Chat overlay
- [x] Replay available after match
- [x] Spectator limit configurable

Closes #887 
closes #925 
closes #896 
closes #895 
