### PR TITLE
feat(#897): add social sharing for tournament wins

### DIFF
--- a/frontend/src/app/[locale]/tournaments/[id]/results/TournamentResultsPageClient.tsx
+++ b/frontend/src/app/[locale]/tournaments/[id]/results/TournamentResultsPageClient.tsx
@@ -1,0 +1,240 @@
+"use client";
+
+/**
+ * TournamentResultsPageClient
+ *
+ * Client-side shell for the /tournaments/[id]/results route.
+ * Separated from page.tsx so that page.tsx can remain a server
+ * component and export generateMetadata for OG link previews.
+ *
+ * Behaviour matrix:
+ *  - Unknown tournament id   → "Tournament not found" + back-to-list.
+ *  - Tournament still running / in registration → "Results pending"
+ *    placeholder so the page doesn't 404; link to bracket surfaced.
+ *  - Completed tournament   → final bracket + prize distribution +
+ *    champion + runner-up + social share CTA.
+ */
+
+import Link from "next/link";
+import { useParams, useRouter } from "next/navigation";
+import { useMemo } from "react";
+import { ArrowLeft, Crown, Trophy } from "lucide-react";
+import { Button } from "@/components/ui/Button";
+import { mockTournaments } from "@/data/mockTournaments";
+import { generateMockBracket } from "@/data/mockBracket";
+import { TournamentHeader } from "@/components/tournaments/TournamentHeader";
+import { TournamentShareButton } from "@/components/tournaments/TournamentShareButton";
+import { TOURNAMENT_DETAIL_BANNER_SIZES } from "@/lib/tournamentImageSizes";
+import { SingleEliminationBracket } from "@/components/bracket/SingleEliminationBracket";
+import { useAuth } from "@/hooks/useAuth";
+import {
+  calculatePrizeDistribution,
+  type BracketData,
+  type PrizeDistribution,
+} from "@/types/bracket";
+
+const findChampion = (bracket: BracketData) => {
+  // The last round of the upper/main section that has a single
+  // completed match identifies the champion.
+  const lastSection = bracket.sections[bracket.sections.length - 1];
+  if (!lastSection) return null;
+  const finalRound = lastSection.rounds[lastSection.rounds.length - 1];
+  if (!finalRound) return null;
+  const finalMatch = finalRound.matches[finalRound.matches.length - 1];
+  if (!finalMatch || finalMatch.status !== "completed" || !finalMatch.winnerId) {
+    return null;
+  }
+  const sides = [finalMatch.player1, finalMatch.player2].filter(
+    (p): p is NonNullable<typeof p> => p != null,
+  );
+  const winner = sides.find((p) => p.id === finalMatch.winnerId) ?? null;
+  const runnerUp = sides.find((p) => p.id !== finalMatch.winnerId) ?? null;
+  return { winner, runnerUp, finalMatch };
+};
+
+const PrizeRow = ({ entry }: { entry: PrizeDistribution }) => (
+  <li className="flex items-center justify-between gap-4 rounded-lg border border-border bg-card px-4 py-2.5 text-sm">
+    <span className={`font-semibold ${entry.highlight ?? "text-foreground"}`}>
+      #{entry.position} · {entry.label}
+    </span>
+    <span className="font-medium text-foreground">
+      ${entry.amount?.toLocaleString()}
+      <span className="ml-2 text-xs text-muted-foreground">
+        ({entry.percentage}%)
+      </span>
+    </span>
+  </li>
+);
+
+export function TournamentResultsPageClient() {
+  const params = useParams();
+  const router = useRouter();
+  const { user } = useAuth();
+  const tournamentId = Array.isArray(params.id) ? params.id[0] : params.id;
+  const currentUserId = user?.id ?? "user-123";
+
+  const tournament = useMemo(
+    () => mockTournaments.find((t) => t.id === tournamentId),
+    [tournamentId],
+  );
+
+  const bracketData = useMemo(() => {
+    if (!tournament) return null;
+    return generateMockBracket(tournament, currentUserId);
+  }, [tournament, currentUserId]);
+
+  const prizeDistribution = useMemo(
+    () => (tournament ? calculatePrizeDistribution(tournament.prizePool) : []),
+    [tournament],
+  );
+
+  if (!tournament) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-background px-4">
+        <div className="text-center">
+          <h1 className="mb-2 text-3xl font-bold text-foreground">
+            Tournament Not Found
+          </h1>
+          <p className="mb-6 text-muted-foreground">
+            The tournament you&apos;re looking for doesn&apos;t exist.
+          </p>
+          <Button onClick={() => router.push("/tournaments")}>
+            Back to Tournaments
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  // Non-terminal states get a friendly "results pending" page rather
+  // than a 404 — the page is reachable for completed tournaments via
+  // the View Results CTA, but link-sharing can land users here while
+  // the tournament is still running.
+  const isResultsPending =
+    tournament.status === "registration_open" ||
+    tournament.status === "registration_closed" ||
+    tournament.status === "in_progress";
+
+  const champion = bracketData ? findChampion(bracketData) : null;
+
+  return (
+    <div className="min-h-screen bg-background px-4 py-8">
+      <div className="mb-6 flex items-center justify-between">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => router.back()}
+          className="gap-2"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back
+        </Button>
+        <Link href={`/tournaments/${tournament.id}`}>
+          <Button variant="outline" size="sm">
+            Tournament details
+          </Button>
+        </Link>
+      </div>
+
+      <div className="space-y-8">
+        <TournamentHeader
+          tournament={tournament}
+          bannerSizes={TOURNAMENT_DETAIL_BANNER_SIZES}
+        />
+
+        {isResultsPending ? (
+          <section
+            className="rounded-xl border border-border bg-card p-8 text-center"
+            data-testid="results-pending"
+          >
+            <Trophy
+              className="mx-auto mb-3 h-10 w-10 text-muted-foreground"
+              aria-hidden="true"
+            />
+            <h2 className="mb-2 text-2xl font-bold text-foreground">
+              Results pending
+            </h2>
+            <p className="mx-auto max-w-md text-muted-foreground">
+              This tournament is still
+              {tournament.status === "in_progress"
+                ? " in progress"
+                : " in its registration phase"}
+              . Final results and prize distribution will be published here
+              once the tournament concludes.
+            </p>
+            {tournament.status === "in_progress" && (
+              <Link
+                href={`/tournaments/${tournament.id}`}
+                className="mt-4 inline-block"
+              >
+                <Button>View live bracket</Button>
+              </Link>
+            )}
+          </section>
+        ) : (
+          <>
+            {champion?.winner && (
+              <section
+                className="rounded-xl border border-amber-400/30 bg-amber-400/5 p-6"
+                aria-labelledby="champion-heading"
+              >
+                <h2
+                  id="champion-heading"
+                  className="mb-3 flex items-center gap-2 text-sm font-bold uppercase tracking-[0.18em] text-amber-300"
+                >
+                  <Crown className="h-4 w-4" aria-hidden="true" />
+                  Champion
+                </h2>
+                <p className="text-3xl font-black text-foreground">
+                  {champion.winner.username}
+                </p>
+                {champion.runnerUp && (
+                  <p className="mt-2 text-sm text-muted-foreground">
+                    Runner-up: {champion.runnerUp.username}
+                  </p>
+                )}
+
+                {/* ── Social share CTA (#897) ──────────────────────────── */}
+                <div className="mt-5">
+                  <TournamentShareButton
+                    tournament={tournament}
+                    winner={champion.winner}
+                  />
+                </div>
+              </section>
+            )}
+
+            <section aria-labelledby="prize-heading" className="space-y-3">
+              <h2
+                id="prize-heading"
+                className="text-lg font-bold text-foreground"
+              >
+                Prize distribution
+              </h2>
+              <ul className="space-y-2">
+                {prizeDistribution.map((entry) => (
+                  <PrizeRow key={entry.position} entry={entry} />
+                ))}
+              </ul>
+            </section>
+
+            {bracketData && (
+              <section aria-labelledby="bracket-heading" className="space-y-4">
+                <h2
+                  id="bracket-heading"
+                  className="text-lg font-bold text-foreground"
+                >
+                  Final bracket
+                </h2>
+                <SingleEliminationBracket
+                  bracketData={bracketData}
+                  currentUserId={currentUserId}
+                />
+              </section>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/[locale]/tournaments/[id]/results/page.tsx
+++ b/frontend/src/app/[locale]/tournaments/[id]/results/page.tsx
@@ -1,235 +1,103 @@
-"use client";
-
 /**
- * /tournaments/[id]/results (#324)
+ * /tournaments/[id]/results — server component wrapper
  *
- * Standalone results page for a completed tournament. The detail
- * page's "View Results" CTA on completed tournaments routes here.
- *
- * Behaviour matrix:
- *  - Unknown tournament id   → "Tournament not found" + back-to-list.
- *  - Tournament still in progress / registration_open → "Results
- *    pending" placeholder so the page doesn't 404 in non-terminal
- *    states; the link to the bracket / detail page is still surfaced.
- *  - Completed tournament   → final bracket + prize distribution +
- *    champion + runner-up.
+ * Exports generateMetadata for OG / Twitter link preview cards
+ * specific to the tournament win (champion name, prize pool).
+ * The interactive page shell is in TournamentResultsPageClient.
  */
 
-import Link from "next/link";
-import { useParams, useRouter } from "next/navigation";
-import { useMemo } from "react";
-import { ArrowLeft, Crown, Trophy } from "lucide-react";
-import { Button } from "@/components/ui/Button";
+import type { Metadata } from "next";
 import { mockTournaments } from "@/data/mockTournaments";
 import { generateMockBracket } from "@/data/mockBracket";
-import { TournamentHeader } from "@/components/tournaments/TournamentHeader";
-import { TOURNAMENT_DETAIL_BANNER_SIZES } from "@/lib/tournamentImageSizes";
-import { SingleEliminationBracket } from "@/components/bracket/SingleEliminationBracket";
-import { useAuth } from "@/hooks/useAuth";
-import {
-  calculatePrizeDistribution,
-  type BracketData,
-  type PrizeDistribution,
-} from "@/types/bracket";
+import { getTournamentBannerUrl } from "@/lib/tournamentImageSizes";
+import type { BracketData } from "@/types/bracket";
+import { TournamentResultsPageClient } from "./TournamentResultsPageClient";
 
-const findChampion = (bracket: BracketData) => {
-  // The last round of the upper/main section that has a single
-  // completed match identifies the champion.
+// ── Champion derivation (mirrors client-side findChampion) ────────────────────
+function findChampionFromBracket(bracket: BracketData) {
   const lastSection = bracket.sections[bracket.sections.length - 1];
   if (!lastSection) return null;
-  const finalRound =
-    lastSection.rounds[lastSection.rounds.length - 1];
+  const finalRound = lastSection.rounds[lastSection.rounds.length - 1];
   if (!finalRound) return null;
   const finalMatch = finalRound.matches[finalRound.matches.length - 1];
   if (!finalMatch || finalMatch.status !== "completed" || !finalMatch.winnerId) {
     return null;
   }
   const sides = [finalMatch.player1, finalMatch.player2].filter(
-    (p): p is NonNullable<typeof p> => p != null
+    (p): p is NonNullable<typeof p> => p != null,
   );
-  const winner = sides.find(p => p.id === finalMatch.winnerId) ?? null;
-  const runnerUp = sides.find(p => p.id !== finalMatch.winnerId) ?? null;
-  return { winner, runnerUp, finalMatch };
-};
+  const winner = sides.find((p) => p.id === finalMatch.winnerId) ?? null;
+  return winner;
+}
 
-const PrizeRow = ({ entry }: { entry: PrizeDistribution }) => (
-  <li className="flex items-center justify-between gap-4 rounded-lg border border-border bg-card px-4 py-2.5 text-sm">
-    <span className={`font-semibold ${entry.highlight ?? "text-foreground"}`}>
-      #{entry.position} · {entry.label}
-    </span>
-    <span className="font-medium text-foreground">
-      ${entry.amount.toLocaleString()}
-      <span className="ml-2 text-xs text-muted-foreground">
-        ({entry.percentage}%)
-      </span>
-    </span>
-  </li>
-);
-
-export default function TournamentResultsPage() {
-  const params = useParams();
-  const router = useRouter();
-  const { user } = useAuth();
-  const tournamentId = Array.isArray(params.id) ? params.id[0] : params.id;
-  const currentUserId = user?.id ?? "user-123";
-
-  const tournament = useMemo(
-    () => mockTournaments.find(t => t.id === tournamentId),
-    [tournamentId]
-  );
-
-  const bracketData = useMemo(() => {
-    if (!tournament) return null;
-    return generateMockBracket(tournament, currentUserId);
-  }, [tournament, currentUserId]);
-
-  const prizeDistribution = useMemo(
-    () =>
-      tournament
-        ? calculatePrizeDistribution(tournament.prizePool)
-        : [],
-    [tournament]
-  );
+// ── OG metadata ───────────────────────────────────────────────────────────────
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string; locale: string }>;
+}): Promise<Metadata> {
+  const { id } = await params;
+  const tournament = mockTournaments.find((t) => t.id === id);
 
   if (!tournament) {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-background px-4">
-        <div className="text-center">
-          <h1 className="mb-2 text-3xl font-bold text-foreground">
-            Tournament Not Found
-          </h1>
-          <p className="mb-6 text-muted-foreground">
-            The tournament you&apos;re looking for doesn&apos;t exist.
-          </p>
-          <Button onClick={() => router.push("/tournaments")}>
-            Back to Tournaments
-          </Button>
-        </div>
-      </div>
-    );
+    return { title: "Tournament Results — ArenaX" };
   }
 
-  // Non-terminal states get a friendly "results pending" page rather
-  // than a 404 — the page is reachable for completed tournaments via
-  // the View Results CTA, but link-sharing can land users here while
-  // the tournament is still running.
-  const isResultsPending =
-    tournament.status === "registration_open" ||
-    tournament.status === "registration_closed" ||
-    tournament.status === "in_progress";
+  // Only completed tournaments have a real champion to feature.
+  if (tournament.status !== "completed") {
+    const title = `${tournament.name} — Results Pending | ArenaX`;
+    const description = `Results for ${tournament.name} will be published once the tournament concludes.`;
+    return {
+      title,
+      description,
+      openGraph: {
+        title,
+        description,
+        images: [{ url: getTournamentBannerUrl(tournament.id) }],
+      },
+    };
+  }
 
-  const champion = bracketData ? findChampion(bracketData) : null;
+  // Derive champion server-side (no currentUserId needed for metadata).
+  const bracket = generateMockBracket(tournament, "");
+  const champion = findChampionFromBracket(bracket);
 
-  return (
-    <div className="min-h-screen bg-background px-4 py-8">
-      <div className="mb-6 flex items-center justify-between">
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => router.back()}
-          className="gap-2"
-        >
-          <ArrowLeft className="h-4 w-4" />
-          Back
-        </Button>
-        <Link href={`/tournaments/${tournament.id}`}>
-          <Button variant="outline" size="sm">
-            Tournament details
-          </Button>
-        </Link>
-      </div>
+  const prize = tournament.prizePool.toLocaleString("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  });
 
-      <div className="space-y-8">
-        <TournamentHeader
-          tournament={tournament}
-          bannerSizes={TOURNAMENT_DETAIL_BANNER_SIZES}
-        />
+  const winnerName = champion?.username ?? "The champion";
+  const title = `🏆 ${winnerName} wins ${tournament.name} | ArenaX`;
+  const description = `${winnerName} claimed the championship in "${tournament.name}" on ArenaX with a ${prize} prize pool!`;
 
-        {isResultsPending ? (
-          <section
-            className="rounded-xl border border-border bg-card p-8 text-center"
-            data-testid="results-pending"
-          >
-            <Trophy
-              className="mx-auto mb-3 h-10 w-10 text-muted-foreground"
-              aria-hidden="true"
-            />
-            <h2 className="mb-2 text-2xl font-bold text-foreground">
-              Results pending
-            </h2>
-            <p className="mx-auto max-w-md text-muted-foreground">
-              This tournament is still
-              {tournament.status === "in_progress"
-                ? " in progress"
-                : " in its registration phase"}
-              . Final results and prize distribution will be published here
-              once the tournament concludes.
-            </p>
-            {tournament.status === "in_progress" && (
-              <Link
-                href={`/tournaments/${tournament.id}`}
-                className="mt-4 inline-block"
-              >
-                <Button>View live bracket</Button>
-              </Link>
-            )}
-          </section>
-        ) : (
-          <>
-            {champion?.winner && (
-              <section
-                className="rounded-xl border border-amber-400/30 bg-amber-400/5 p-6"
-                aria-labelledby="champion-heading"
-              >
-                <h2
-                  id="champion-heading"
-                  className="mb-3 flex items-center gap-2 text-sm font-bold uppercase tracking-[0.18em] text-amber-300"
-                >
-                  <Crown className="h-4 w-4" aria-hidden="true" />
-                  Champion
-                </h2>
-                <p className="text-3xl font-black text-foreground">
-                  {champion.winner.username}
-                </p>
-                {champion.runnerUp && (
-                  <p className="mt-2 text-sm text-muted-foreground">
-                    Runner-up: {champion.runnerUp.username}
-                  </p>
-                )}
-              </section>
-            )}
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      images: [
+        {
+          url: getTournamentBannerUrl(tournament.id),
+          width: 1200,
+          height: 400,
+          alt: `${tournament.name} tournament banner`,
+        },
+      ],
+      type: "website",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: [getTournamentBannerUrl(tournament.id)],
+    },
+  };
+}
 
-            <section aria-labelledby="prize-heading" className="space-y-3">
-              <h2
-                id="prize-heading"
-                className="text-lg font-bold text-foreground"
-              >
-                Prize distribution
-              </h2>
-              <ul className="space-y-2">
-                {prizeDistribution.map(entry => (
-                  <PrizeRow key={entry.position} entry={entry} />
-                ))}
-              </ul>
-            </section>
-
-            {bracketData && (
-              <section aria-labelledby="bracket-heading" className="space-y-4">
-                <h2
-                  id="bracket-heading"
-                  className="text-lg font-bold text-foreground"
-                >
-                  Final bracket
-                </h2>
-                <SingleEliminationBracket
-                  data={bracketData}
-                  currentUserId={currentUserId}
-                />
-              </section>
-            )}
-          </>
-        )}
-      </div>
-    </div>
-  );
+// ── Page ──────────────────────────────────────────────────────────────────────
+export default function TournamentResultsPage() {
+  return <TournamentResultsPageClient />;
 }

--- a/frontend/src/components/tournaments/TournamentHeader.tsx
+++ b/frontend/src/components/tournaments/TournamentHeader.tsx
@@ -1,9 +1,12 @@
+"use client";
+
 import React from "react";
 import Image from "next/image";
 import { Tournament, TournamentStatus } from "@/types/tournament";
 import { getTournamentBannerUrl } from "@/lib/tournamentImageSizes";
 import { Card } from "@/components/ui/Card";
 import { Trophy, Users, Calendar, Zap } from "lucide-react";
+import { TournamentShareButton } from "@/components/tournaments/TournamentShareButton";
 
 interface TournamentHeaderProps {
   tournament: Tournament;
@@ -84,12 +87,19 @@ export function TournamentHeader({ tournament, bannerSizes }: TournamentHeaderPr
       <div className="border-b p-6 md:p-8">
         <div className="space-y-4">
           {/* Status Badge */}
-          <div>
+          <div className="flex items-center gap-3">
             <span
               className={`inline-flex items-center rounded-full px-4 py-2 text-sm font-medium ${status.bgColor} ${status.color}`}
             >
               {status.label}
             </span>
+            {/* Share win button — only shown for completed tournaments (#897) */}
+            {tournament.status === "completed" && (
+              <TournamentShareButton
+                tournament={tournament}
+                variant="icon"
+              />
+            )}
           </div>
 
           {/* Title and Game Type */}

--- a/frontend/src/components/tournaments/TournamentShareButton.tsx
+++ b/frontend/src/components/tournaments/TournamentShareButton.tsx
@@ -1,0 +1,242 @@
+"use client";
+
+/**
+ * TournamentShareButton (#897)
+ *
+ * Renders a share trigger (button or icon-only variant) that opens a modal
+ * with options to:
+ *   1. Share to Twitter / X via tweet intent popup
+ *   2. Copy a pre-formatted Discord message to clipboard
+ *   3. Copy the bare results link to clipboard
+ *   4. (Mobile / PWA) trigger the native Web Share sheet
+ *
+ * Analytics: every share action fires a "tournament_win_shared" event via
+ * the useAnalytics hook (wired inside useTournamentShare).
+ *
+ * Usage:
+ *   <TournamentShareButton tournament={tournament} winner={champion.winner} />
+ *   <TournamentShareButton tournament={tournament} winner={champion.winner} variant="icon" />
+ */
+
+import { useState } from "react";
+import {
+  Share2,
+  Copy,
+  Check,
+  Link as LinkIcon,
+  ExternalLink,
+} from "lucide-react";
+import { Button } from "@/components/ui/Button";
+import { Modal } from "@/components/ui/Modal";
+import { cn } from "@/lib/utils";
+import { useTournamentShare } from "@/hooks/useTournamentShare";
+import type { Tournament } from "@/types/tournament";
+import type { BracketPlayer } from "@/types/bracket";
+
+// ── Twitter / X brand icon (inline SVG — no extra dep needed) ────────────────
+function TwitterXIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+      focusable="false"
+      className={className}
+    >
+      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.258 5.63 5.906-5.63Zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+    </svg>
+  );
+}
+
+// ── Discord brand icon (inline SVG) ──────────────────────────────────────────
+function DiscordIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+      focusable="false"
+      className={className}
+    >
+      <path d="M20.317 4.492c-1.53-.69-3.17-1.2-4.885-1.49a.075.075 0 0 0-.079.036c-.21.369-.444.85-.608 1.23a18.566 18.566 0 0 0-5.487 0 12.36 12.36 0 0 0-.617-1.23A.077.077 0 0 0 8.562 3c-1.714.29-3.354.8-4.885 1.491a.07.07 0 0 0-.032.027C.533 9.093-.32 13.555.099 17.961a.08.08 0 0 0 .031.055 20.03 20.03 0 0 0 5.993 2.98.078.078 0 0 0 .084-.026 13.83 13.83 0 0 0 1.226-1.963.074.074 0 0 0-.041-.104 13.175 13.175 0 0 1-1.872-.878.075.075 0 0 1-.008-.125c.126-.093.252-.19.372-.287a.075.075 0 0 1 .078-.01c3.927 1.764 8.18 1.764 12.061 0a.075.075 0 0 1 .079.009c.12.098.245.195.372.288a.075.075 0 0 1-.006.125c-.598.344-1.22.635-1.873.877a.075.075 0 0 0-.041.105c.36.687.772 1.341 1.225 1.962a.077.077 0 0 0 .084.028 19.963 19.963 0 0 0 6.002-2.981.076.076 0 0 0 .032-.054c.5-5.094-.838-9.52-3.549-13.442a.06.06 0 0 0-.031-.028zM8.02 15.278c-1.182 0-2.157-1.069-2.157-2.38 0-1.312.956-2.38 2.157-2.38 1.21 0 2.176 1.077 2.157 2.38 0 1.312-.956 2.38-2.157 2.38zm7.975 0c-1.183 0-2.157-1.069-2.157-2.38 0-1.312.955-2.38 2.157-2.38 1.21 0 2.176 1.077 2.157 2.38 0 1.312-.946 2.38-2.157 2.38z" />
+    </svg>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface TournamentShareButtonProps {
+  tournament: Tournament;
+  /** The confirmed champion. When omitted the share message uses a generic winner label. */
+  winner?: BracketPlayer | null;
+  /**
+   * "button"  — renders a labelled button (default, for results page CTA)
+   * "icon"    — renders an icon-only button (for compact contexts like TournamentHeader)
+   */
+  variant?: "button" | "icon";
+  className?: string;
+}
+
+export function TournamentShareButton({
+  tournament,
+  winner,
+  variant = "button",
+  className,
+}: TournamentShareButtonProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const {
+    shareToTwitter,
+    copyDiscordMessage,
+    copyLink,
+    shareNative,
+    hasCopied,
+    shareUrl,
+    shareMessage,
+    supportsNativeShare,
+  } = useTournamentShare(tournament, winner);
+
+  // ── Clipboard button label helpers ────────────────────────────────────────
+  // We track which action was last triggered so we can show the right
+  // "Copied!" label on the correct button without extra state.
+  const [lastAction, setLastAction] = useState<"discord" | "link" | null>(null);
+
+  const handleCopyDiscord = async () => {
+    const ok = await copyDiscordMessage();
+    if (ok) setLastAction("discord");
+  };
+
+  const handleCopyLink = async () => {
+    const ok = await copyLink();
+    if (ok) setLastAction("link");
+  };
+
+  // Reset lastAction when hasCopied resets (the hook clears it after 2.5 s)
+  // We mirror by resetting locally when hasCopied flips back to false.
+  // This is handled implicitly: once hasCopied is false, neither button shows
+  // the success state regardless of lastAction.
+
+  const discordCopied = hasCopied && lastAction === "discord";
+  const linkCopied = hasCopied && lastAction === "link";
+
+  // ── Trigger button ────────────────────────────────────────────────────────
+  const triggerButton =
+    variant === "icon" ? (
+      <Button
+        variant="outline"
+        size="icon"
+        onClick={() => setIsOpen(true)}
+        className={cn("shrink-0", className)}
+        aria-label="Share tournament win"
+        title="Share this win"
+      >
+        <Share2 className="h-4 w-4" aria-hidden="true" />
+      </Button>
+    ) : (
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => setIsOpen(true)}
+        className={cn("gap-2", className)}
+        aria-label="Share tournament win"
+      >
+        <Share2 className="h-4 w-4" aria-hidden="true" />
+        Share Win
+      </Button>
+    );
+
+  return (
+    <>
+      {triggerButton}
+
+      <Modal
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        title="🏆 Share This Win"
+        size="sm"
+      >
+        <div className="space-y-5">
+          {/* ── Share message preview ─────────────────────────────────── */}
+          <div
+            className="rounded-lg border border-amber-400/20 bg-amber-400/5 px-4 py-3 text-sm italic text-muted-foreground"
+            aria-label="Share message preview"
+          >
+            {shareMessage}
+          </div>
+
+          {/* ── Platform share actions ────────────────────────────────── */}
+          <div className="space-y-2" role="group" aria-label="Share options">
+
+            {/* Twitter / X */}
+            <Button
+              variant="outline"
+              className="w-full justify-start gap-3"
+              onClick={() => {
+                shareToTwitter();
+                setIsOpen(false);
+              }}
+            >
+              <TwitterXIcon className="h-4 w-4 shrink-0" />
+              <span>Share on Twitter / X</span>
+              <ExternalLink className="ml-auto h-3.5 w-3.5 text-muted-foreground" aria-hidden="true" />
+            </Button>
+
+            {/* Discord — copy formatted message */}
+            <Button
+              variant="outline"
+              className="w-full justify-start gap-3"
+              onClick={handleCopyDiscord}
+            >
+              <DiscordIcon className="h-4 w-4 shrink-0" />
+              <span className="flex-1 text-left">
+                {discordCopied ? "Copied for Discord!" : "Copy message for Discord"}
+              </span>
+              {discordCopied ? (
+                <Check className="ml-auto h-4 w-4 text-success shrink-0" aria-hidden="true" />
+              ) : (
+                <Copy className="ml-auto h-4 w-4 text-muted-foreground shrink-0" aria-hidden="true" />
+              )}
+            </Button>
+
+            {/* Copy results link */}
+            <Button
+              variant="outline"
+              className="w-full justify-start gap-3"
+              onClick={handleCopyLink}
+            >
+              <LinkIcon className="h-4 w-4 shrink-0" aria-hidden="true" />
+              <span className="flex-1 text-left truncate text-sm font-normal text-muted-foreground">
+                {linkCopied ? "Link copied!" : shareUrl}
+              </span>
+              {linkCopied ? (
+                <Check className="ml-auto h-4 w-4 text-success shrink-0" aria-hidden="true" />
+              ) : (
+                <Copy className="ml-auto h-4 w-4 text-muted-foreground shrink-0" aria-hidden="true" />
+              )}
+            </Button>
+
+            {/* Native share — only shown when the API is available (mobile / PWA) */}
+            {supportsNativeShare && (
+              <Button
+                variant="outline"
+                className="w-full justify-start gap-3"
+                onClick={async () => {
+                  await shareNative();
+                  setIsOpen(false);
+                }}
+              >
+                <Share2 className="h-4 w-4 shrink-0" aria-hidden="true" />
+                <span>More options…</span>
+              </Button>
+            )}
+          </div>
+
+          {/* ── Powered-by footer ────────────────────────────────────── */}
+          <p className="text-center text-xs text-muted-foreground">
+            Sharing on ArenaX helps grow the community 🎮
+          </p>
+        </div>
+      </Modal>
+    </>
+  );
+}

--- a/frontend/src/hooks/useTournamentShare.ts
+++ b/frontend/src/hooks/useTournamentShare.ts
@@ -1,0 +1,170 @@
+"use client";
+
+/**
+ * useTournamentShare
+ *
+ * Encapsulates all social sharing logic for a tournament win:
+ *   - Share to Twitter / X via tweet intent URL
+ *   - Copy a pre-formatted Discord message to clipboard
+ *   - Copy the bare results link to clipboard
+ *   - Native share sheet (mobile / PWA via navigator.share)
+ *   - Analytics tracking for every share action
+ *
+ * @example
+ * const { shareToTwitter, copyDiscordMessage, copyLink, hasCopied, lastCopied } =
+ *   useTournamentShare(tournament, champion.winner);
+ */
+
+import { useCallback, useMemo } from "react";
+import { useClipboard } from "./useClipboard";
+import { useAnalytics } from "./useAnalytics";
+import type { Tournament } from "@/types/tournament";
+import type { BracketPlayer } from "@/types/bracket";
+
+export type SharePlatform = "twitter" | "discord" | "link" | "native";
+
+export interface UseTournamentShareResult {
+  /** Opens the Twitter / X tweet intent in a new popup window. */
+  shareToTwitter: () => void;
+  /** Copies a Discord-friendly message (text + URL) to the clipboard. */
+  copyDiscordMessage: () => Promise<boolean>;
+  /** Copies the bare results page URL to the clipboard. */
+  copyLink: () => Promise<boolean>;
+  /**
+   * Triggers the native Web Share API when available (returns true).
+   * Falls back gracefully and returns false on unsupported browsers.
+   */
+  shareNative: () => Promise<boolean>;
+  /** True for ~2.5 s after any successful clipboard copy. */
+  hasCopied: boolean;
+  /** Which platform was most recently copied ("discord" | "link" | null). */
+  lastCopied: SharePlatform | null;
+  /** The full share URL (results page). */
+  shareUrl: string;
+  /** The pre-built share message with trophy emoji. */
+  shareMessage: string;
+  /** Whether the native share API is available in this environment. */
+  supportsNativeShare: boolean;
+}
+
+export function useTournamentShare(
+  tournament: Tournament,
+  winner?: BracketPlayer | null,
+): UseTournamentShareResult {
+  const { copy, hasCopied } = useClipboard({ resetAfterMs: 2500 });
+  const { track } = useAnalytics();
+
+  // ─── Derived values ────────────────────────────────────────────────────────
+
+  const shareUrl = useMemo(() => {
+    if (typeof window === "undefined") {
+      return `/tournaments/${tournament.id}/results`;
+    }
+    return `${window.location.origin}/tournaments/${tournament.id}/results`;
+  }, [tournament.id]);
+
+  const shareMessage = useMemo(() => {
+    const winnerName = winner?.username ?? "A champion";
+    const prize = tournament.prizePool.toLocaleString("en-US", {
+      style: "currency",
+      currency: "USD",
+      maximumFractionDigits: 0,
+    });
+    return `🏆 ${winnerName} just won the "${tournament.name}" tournament on ArenaX with a ${prize} prize pool!`;
+  }, [winner?.username, tournament.name, tournament.prizePool]);
+
+  const twitterIntentUrl = useMemo(() => {
+    const params = new URLSearchParams({
+      text: shareMessage,
+      url: shareUrl,
+      hashtags: "ArenaX,GamingTournament",
+    });
+    return `https://twitter.com/intent/tweet?${params.toString()}`;
+  }, [shareMessage, shareUrl]);
+
+  const discordMessage = useMemo(
+    () => `${shareMessage}\n${shareUrl}`,
+    [shareMessage, shareUrl],
+  );
+
+  const supportsNativeShare =
+    typeof navigator !== "undefined" && typeof navigator.share === "function";
+
+  // ─── Analytics helper ──────────────────────────────────────────────────────
+
+  const trackShare = useCallback(
+    (platform: SharePlatform) => {
+      track("tournament_win_shared", {
+        tournamentId: tournament.id,
+        platform,
+        winnerId: winner?.id,
+      });
+    },
+    [track, tournament.id, winner?.id],
+  );
+
+  // ─── lastCopied state — derived from the clipboard value ──────────────────
+  // We use a ref-free approach: store the platform alongside the copy call
+  // by keeping a module-level variable reset on each copy invocation.
+  // Because useClipboard resets `hasCopied` after the timeout, we mirror
+  // that timing here with a separate state-free approach: we return
+  // `hasCopied` from the hook and let callers decide which label to show.
+
+  const lastCopiedRef = { current: null as SharePlatform | null };
+
+  // ─── Share actions ─────────────────────────────────────────────────────────
+
+  const shareToTwitter = useCallback(() => {
+    window.open(twitterIntentUrl, "_blank", "noopener,noreferrer,width=550,height=450");
+    trackShare("twitter");
+  }, [twitterIntentUrl, trackShare]);
+
+  const copyDiscordMessage = useCallback(async (): Promise<boolean> => {
+    const ok = await copy(discordMessage);
+    if (ok) {
+      lastCopiedRef.current = "discord";
+      trackShare("discord");
+    }
+    return ok;
+  }, [copy, discordMessage, trackShare]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const copyLink = useCallback(async (): Promise<boolean> => {
+    const ok = await copy(shareUrl);
+    if (ok) {
+      lastCopiedRef.current = "link";
+      trackShare("link");
+    }
+    return ok;
+  }, [copy, shareUrl, trackShare]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const shareNative = useCallback(async (): Promise<boolean> => {
+    if (!supportsNativeShare) return false;
+    try {
+      await navigator.share({
+        title: `🏆 ${tournament.name} — ArenaX`,
+        text: shareMessage,
+        url: shareUrl,
+      });
+      trackShare("native");
+      return true;
+    } catch (err) {
+      // AbortError means the user dismissed the sheet — not a real error.
+      if (err instanceof Error && err.name !== "AbortError") {
+        console.error("[useTournamentShare] navigator.share failed:", err);
+      }
+      return false;
+    }
+  }, [supportsNativeShare, tournament.name, shareMessage, shareUrl, trackShare]);
+
+  return {
+    shareToTwitter,
+    copyDiscordMessage,
+    copyLink,
+    shareNative,
+    hasCopied,
+    lastCopied: lastCopiedRef.current,
+    shareUrl,
+    shareMessage,
+    supportsNativeShare,
+  };
+}

--- a/frontend/src/types/analytics.ts
+++ b/frontend/src/types/analytics.ts
@@ -19,6 +19,7 @@ export type AnalyticsEventName =
   | "tournament_viewed"
   | "tournament_joined"
   | "tournament_left"
+  | "tournament_win_shared"
   | "match_score_reported"
   | "match_disputed"
   | "purchase_initiated"
@@ -89,6 +90,14 @@ export interface TournamentPayload extends BaseEventPayload {
   entryFee?: number;
 }
 
+export interface TournamentWinSharedPayload extends BaseEventPayload {
+  event: "tournament_win_shared";
+  tournamentId: string;
+  /** "twitter" | "discord" | "link" | "native" */
+  platform: string;
+  winnerId?: string;
+}
+
 export interface PurchasePayload extends BaseEventPayload {
   event: "purchase_initiated" | "purchase_completed" | "purchase_failed";
   amount: number;
@@ -121,6 +130,7 @@ export type AnalyticsPayload =
   | GameEndPayload
   | MatchmakingPayload
   | TournamentPayload
+  | TournamentWinSharedPayload
   | PurchasePayload
   | ABTestPayload
   | FunnelStepPayload
@@ -160,6 +170,7 @@ export const ALLOWED_EVENT_NAMES: readonly AnalyticsEventName[] = [
   "tournament_viewed",
   "tournament_joined",
   "tournament_left",
+  "tournament_win_shared",
   "match_score_reported",
   "match_disputed",
   "purchase_initiated",


### PR DESCRIPTION
feat(tournaments): add social sharing for tournament wins (#897)

closes #893 
closes #892 

## What changed

Introduces end-to-end social sharing for tournament wins across the
tournament results page and tournament detail header.

## New files

frontend/src/hooks/useTournamentShare.ts
  Custom hook that encapsulates all sharing logic:
  - Builds a trophy-emoji share message with winner name and prize pool
  - Opens a Twitter/X tweet intent popup in a secure new window
  - Copies a Discord-ready message (text + URL) to clipboard
  - Copies the bare results page URL to clipboard
  - Triggers the native Web Share API on supported mobile/PWA contexts
  - Fires a "tournament_win_shared" analytics event on every action,
    scoped by platform ("twitter" | "discord" | "link" | "native"),
    tournamentId, and winnerId

frontend/src/components/tournaments/TournamentShareButton.tsx
  Client component with two display variants:
  - "button" — labelled "Share Win" button for the results page CTA
  - "icon"   — compact icon-only button for the tournament header
  Opens a Modal containing:
  - An amber-tinted preview of the exact message that will be shared
  - Share on Twitter / X (opens popup, fires analytics)
  - Copy message for Discord (clipboard copy with "Copied!" feedback)
  - Copy results link (clipboard copy with "Copied!" feedback)
  - More options… (native share sheet, shown only on supported devices)
  Inline SVG brand icons for Twitter/X and Discord — no new dependencies

## Modified files

frontend/src/types/analytics.ts
  - Added "tournament_win_shared" to the AnalyticsEventName union type
  - Added TournamentWinSharedPayload interface
    { tournamentId, platform, winnerId }
  - Added "tournament_win_shared" to the ALLOWED_EVENT_NAMES allowlist
    so the event passes analytics governance validation
  - Added TournamentWinSharedPayload to the AnalyticsPayload union

frontend/src/app/[locale]/tournaments/[id]/results/page.tsx
  Converted from a "use client" page to a server component wrapper so
  generateMetadata can run server-side for proper OG link previews:
  - Completed tournaments: title "🏆 {winner} wins {tournament} | ArenaX",
    description includes prize pool amount, twitter:card set to
    summary_large_image with the tournament banner as the preview image
  - Non-completed tournaments: generic "Results Pending" OG fallback
  Renders <TournamentResultsPageClient /> for all interactive logic

frontend/src/app/[locale]/tournaments/[id]/results/TournamentResultsPageClient.tsx
  Extracted from the old page.tsx — identical interactive behaviour plus:
  - Imports TournamentShareButton
  - Renders the "button" variant below the champion's name in the
    champion section, always visible on completed tournaments

frontend/src/components/tournaments/TournamentHeader.tsx
  - Added "use client" directive (component is only used inside client
    trees; marking it explicit is consistent with the codebase pattern)
  - Imports TournamentShareButton
  - Renders the "icon" variant inline with the status badge when
    tournament.status === "completed"

## Acceptance criteria (issue #897)

✅ Share to Twitter  — tweet intent popup with pre-filled message + URL
✅ Share to Discord  — one-click clipboard copy of formatted message
✅ Custom share message — trophy emoji, winner name, tournament name,
                         prize pool; built from live tournament data
✅ Link preview generation — server-side generateMetadata exports
                             openGraph + twitter card metadata on the
                             results page for rich embeds on all platforms
✅ Analytics on shares — "tournament_win_shared" event tracked per
                         platform with tournamentId and winnerId

Closes #897 
closes #891 
