### PR TITLE
feat(frontend): implement progressive image loading (#927)

### DIFF
--- a/frontend/src/__tests__/progressive-image.test.tsx
+++ b/frontend/src/__tests__/progressive-image.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * Tests for the progressive <ProgressiveImage /> component (#927).
+ */
+import React from "react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import {
+  ProgressiveImage,
+  LQIP_WIDTH,
+  LQIP_QUALITY,
+} from "@/components/common/Image";
+
+// ─── IntersectionObserver mock ────────────────────────────────────────────────
+type IOEntryish = { isIntersecting: boolean };
+let ioInstances: MockIO[] = [];
+
+class MockIO {
+  callback: IntersectionObserverCallback;
+  element: Element | null = null;
+  constructor(cb: IntersectionObserverCallback) {
+    this.callback = cb;
+    ioInstances.push(this);
+  }
+  observe = (el: Element) => {
+    this.element = el;
+  };
+  unobserve = jest.fn();
+  disconnect = jest.fn();
+  trigger(isIntersecting: boolean) {
+    this.callback(
+      [{ isIntersecting } as unknown as IntersectionObserverEntry],
+      this as unknown as IntersectionObserver
+    );
+  }
+}
+
+beforeEach(() => {
+  ioInstances = [];
+  (global as unknown as { IntersectionObserver: unknown }).IntersectionObserver =
+    jest.fn((cb: IntersectionObserverCallback) => new MockIO(cb));
+});
+
+const REMOTE = "https://cdn.example.com/hero.jpg";
+
+describe("ProgressiveImage", () => {
+  it("loads immediately when priority is set (no lazy wait)", () => {
+    render(<ProgressiveImage src={REMOTE} alt="Hero banner" priority />);
+    const img = screen.getByAltText("Hero banner") as HTMLImageElement;
+    expect(img).toBeInTheDocument();
+    expect(img.getAttribute("loading")).toBe("eager");
+  });
+
+  it("defers loading until the element scrolls into view", () => {
+    render(<ProgressiveImage src={REMOTE} alt="Lazy image" />);
+    // Nothing loaded yet.
+    expect(screen.queryByAltText("Lazy image")).not.toBeInTheDocument();
+    // Scroll into view.
+    act(() => ioInstances[0].trigger(true));
+    const img = screen.getByAltText("Lazy image") as HTMLImageElement;
+    expect(img).toBeInTheDocument();
+    expect(img.getAttribute("loading")).toBe("lazy");
+  });
+
+  it("emits a WebP <source> with a fallback for remote images", () => {
+    const { container } = render(
+      <ProgressiveImage src={REMOTE} alt="Pic" priority />
+    );
+    const sources = container.querySelectorAll("picture source");
+    expect(sources.length).toBeGreaterThanOrEqual(2);
+    const webp = container.querySelector('source[type="image/webp"]');
+    expect(webp).not.toBeNull();
+    expect(webp?.getAttribute("srcSet")).toContain("f=webp");
+    // Responsive srcset carries width descriptors.
+    expect(webp?.getAttribute("srcSet")).toMatch(/\d+w/);
+  });
+
+  it("derives a small, cheap LQIP within the size budget", () => {
+    const { container } = render(
+      <ProgressiveImage src={REMOTE} alt="Pic" priority />
+    );
+    const lqip = container.querySelector('img[aria-hidden="true"]') as HTMLImageElement;
+    expect(lqip).not.toBeNull();
+    expect(lqip.src).toContain(`w=${LQIP_WIDTH}`);
+    expect(lqip.src).toContain(`q=${LQIP_QUALITY}`);
+  });
+
+  it("respects an explicit lqip override", () => {
+    const tiny = "data:image/webp;base64,AAAA";
+    const { container } = render(
+      <ProgressiveImage src={REMOTE} alt="Pic" lqip={tiny} priority />
+    );
+    const lqip = container.querySelector('img[aria-hidden="true"]') as HTMLImageElement;
+    expect(lqip.getAttribute("src")).toBe(tiny);
+  });
+
+  it("blurs-up: full image is transparent until it fires onLoad", () => {
+    const onLoad = jest.fn();
+    render(<ProgressiveImage src={REMOTE} alt="Fade" priority onLoad={onLoad} />);
+    const img = screen.getByAltText("Fade");
+    expect(img.className).toContain("opacity-0");
+    fireEvent.load(img);
+    expect(img.className).toContain("opacity-100");
+    expect(onLoad).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to fallbackSrc on error, then shows a broken state", () => {
+    render(
+      <ProgressiveImage
+        src={REMOTE}
+        alt="Broken"
+        fallbackSrc="https://cdn.example.com/fallback.jpg"
+        priority
+      />
+    );
+    const img = screen.getByAltText("Broken");
+    // First error → switch to fallback.
+    fireEvent.error(img);
+    const fallback = screen.getByAltText("Broken") as HTMLImageElement;
+    expect(fallback.src).toContain("fallback.jpg");
+    // Second error on the fallback → broken placeholder.
+    fireEvent.error(fallback);
+    expect(screen.getByRole("img", { name: "Broken" })).toBeInTheDocument();
+  });
+
+  it("marks the wrapper busy until the image loads", () => {
+    render(<ProgressiveImage src={REMOTE} alt="Busy" priority />);
+    const img = screen.getByAltText("Busy");
+    const wrapper = img.closest("[aria-busy]");
+    expect(wrapper?.getAttribute("aria-busy")).toBe("true");
+    fireEvent.load(img);
+    expect(wrapper?.getAttribute("aria-busy")).toBe("false");
+  });
+});

--- a/frontend/src/components/common/Image.tsx
+++ b/frontend/src/components/common/Image.tsx
@@ -1,0 +1,311 @@
+"use client";
+
+/*
+ * This component is a hand-rolled <picture> progressive loader (LQIP + blur-up +
+ * WebP/fallback + IntersectionObserver lazy-loading). It intentionally uses raw
+ * <img> elements — next/image cannot express the explicit <source> fallback and
+ * blur-up sequence we need here — so the next/no-img-element rule is disabled.
+ */
+/* eslint-disable @next/next/no-img-element */
+
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { ImageOff } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useReducedMotion } from "@/hooks/useReducedMotion";
+import { generateImageSizes } from "@/lib/imageLoader";
+
+/**
+ * Progressive <Image /> — issue #927.
+ *
+ * Large images should never block page rendering. This component:
+ *  - renders a Low Quality Image Placeholder (LQIP) first, then blurs-up to the
+ *    full asset once it has decoded (see {@link LQIP_WIDTH} / {@link LQIP_QUALITY});
+ *  - defers the real network request until the image scrolls near the viewport
+ *    (IntersectionObserver based lazy-loading, bypassable with `priority`);
+ *  - serves modern WebP with an automatic original-format fallback via <picture>;
+ *  - reserves layout space (aspect-ratio / width+height) to avoid layout shift.
+ *
+ * The LQIP is requested at 32px / q20 which keeps it comfortably under the 50KB
+ * budget from the acceptance criteria, and can be overridden with an explicit
+ * `lqip` data URL when the caller already has one.
+ */
+
+/** Width (px) used to derive the LQIP from a remote source. */
+export const LQIP_WIDTH = 32;
+/** Quality (1-100) used to derive the LQIP from a remote source. */
+export const LQIP_QUALITY = 20;
+/** Default responsive widths generated for the srcset. */
+const DEFAULT_WIDTHS = [320, 420, 768, 1024, 1280, 1536];
+
+export interface ProgressiveImageProps
+  extends Omit<
+    React.ImgHTMLAttributes<HTMLImageElement>,
+    "src" | "srcSet" | "placeholder" | "onLoad" | "loading"
+  > {
+  /** Image source. Remote (http/https) sources get responsive/WebP treatment. */
+  src: string;
+  /** Alternative text. Pass "" for decorative images. */
+  alt: string;
+  /** Explicit tiny placeholder (data URL or url). Overrides the derived LQIP. */
+  lqip?: string;
+  /** Shown if the main image fails to load. */
+  fallbackSrc?: string;
+  /** `sizes` attribute; defaults to a sensible responsive value. */
+  sizes?: string;
+  /** Quality for the full asset (1-100). Default 75. */
+  quality?: number;
+  /** Candidate widths for the generated srcset. */
+  widths?: number[];
+  /** Skip lazy-loading and fetch immediately (above-the-fold images). */
+  priority?: boolean;
+  /** IntersectionObserver rootMargin for lazy-loading. Default preloads 200px early. */
+  rootMargin?: string;
+  /** CSS aspect-ratio (e.g. "16 / 9") used to reserve space and prevent CLS. */
+  aspectRatio?: string;
+  /** object-fit for the rendered image. Default "cover". */
+  objectFit?: "cover" | "contain" | "fill" | "none" | "scale-down";
+  /** Extra classes for the wrapper element. */
+  wrapperClassName?: string;
+  /** Called once the full image has loaded. */
+  onLoad?: () => void;
+}
+
+const isRemote = (src: string) => /^https?:\/\//i.test(src);
+
+// Literal class names so Tailwind's JIT scanner keeps them (dynamic
+// `object-${fit}` strings would be purged from the production build).
+const OBJECT_FIT_CLASS: Record<
+  NonNullable<ProgressiveImageProps["objectFit"]>,
+  string
+> = {
+  cover: "object-cover",
+  contain: "object-contain",
+  fill: "object-fill",
+  none: "object-none",
+  "scale-down": "object-scale-down",
+};
+
+/** Append CDN optimisation params to a remote URL. Mirrors lib/imageLoader. */
+function withParams(
+  url: string,
+  { w, q, format }: { w?: number; q?: number; format?: "webp" | "auto" }
+): string {
+  try {
+    const parsed = new URL(url);
+    if (w) parsed.searchParams.set("w", String(w));
+    if (q) parsed.searchParams.set("q", String(q));
+    if (format) parsed.searchParams.set("f", format);
+    return parsed.toString();
+  } catch {
+    return url;
+  }
+}
+
+function buildSrcSet(
+  src: string,
+  widths: number[],
+  quality: number,
+  format: "webp" | "auto"
+): string {
+  return widths
+    .map((w) => `${withParams(src, { w, q: quality, format })} ${w}w`)
+    .join(", ");
+}
+
+export function ProgressiveImage({
+  src,
+  alt,
+  lqip,
+  fallbackSrc,
+  sizes,
+  quality = 75,
+  widths = DEFAULT_WIDTHS,
+  priority = false,
+  rootMargin = "200px",
+  aspectRatio,
+  objectFit = "cover",
+  className,
+  wrapperClassName,
+  onLoad,
+  style,
+  width,
+  height,
+  ...imgProps
+}: ProgressiveImageProps) {
+  const prefersReducedMotion = useReducedMotion();
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  // Start "in view" for priority images, or when IntersectionObserver is
+  // unavailable (SSR / old browsers) so the image always eventually loads.
+  const [inView, setInView] = useState(priority);
+  const [loaded, setLoaded] = useState(false);
+  // The currently-rendered source. Starts at `src`, may fall back once.
+  const [currentSrc, setCurrentSrc] = useState(src);
+  const [broken, setBroken] = useState(false);
+
+  // Reset transient state whenever the caller swaps the source.
+  useEffect(() => {
+    setCurrentSrc(src);
+    setLoaded(false);
+    setBroken(false);
+  }, [src]);
+
+  const activeRemote = isRemote(currentSrc);
+
+  // Derived LQIP: explicit prop wins, otherwise a tiny remote variant.
+  const lqipSrc =
+    lqip ??
+    (activeRemote && !broken
+      ? withParams(currentSrc, { w: LQIP_WIDTH, q: LQIP_QUALITY, format: "webp" })
+      : undefined);
+
+  const resolvedSizes = sizes ?? generateImageSizes();
+  const webpSrcSet = activeRemote
+    ? buildSrcSet(currentSrc, widths, quality, "webp")
+    : undefined;
+  const fallbackSrcSet = activeRemote
+    ? buildSrcSet(currentSrc, widths, quality, "auto")
+    : undefined;
+  const fullSrc = activeRemote
+    ? withParams(currentSrc, { q: quality, format: "auto" })
+    : currentSrc;
+
+  // Lazy-load: reveal the real <img> once the wrapper nears the viewport.
+  useEffect(() => {
+    if (inView) return;
+    const node = wrapperRef.current;
+    if (!node || typeof IntersectionObserver === "undefined") {
+      setInView(true);
+      return;
+    }
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((e) => e.isIntersecting)) {
+          setInView(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin }
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [inView, rootMargin]);
+
+  const handleLoad = useCallback(() => {
+    setLoaded(true);
+    onLoad?.();
+  }, [onLoad]);
+
+  const handleError = useCallback(() => {
+    // Try the fallback once; if that also fails, show the broken state.
+    if (fallbackSrc && currentSrc !== fallbackSrc) {
+      setCurrentSrc(fallbackSrc);
+      setLoaded(false);
+    } else {
+      setBroken(true);
+    }
+  }, [fallbackSrc, currentSrc]);
+
+  const showBrokenState = broken;
+  const transitionClass = prefersReducedMotion
+    ? ""
+    : "transition-opacity duration-500 ease-out";
+
+  return (
+    <div
+      ref={wrapperRef}
+      className={cn(
+        "relative overflow-hidden bg-muted/40",
+        wrapperClassName
+      )}
+      style={{
+        aspectRatio,
+        width,
+        height,
+        ...style,
+      }}
+      aria-busy={!loaded && !showBrokenState}
+    >
+      {/* LQIP / skeleton layer */}
+      {!showBrokenState &&
+        (lqipSrc ? (
+          <img
+            src={lqipSrc}
+            alt=""
+            aria-hidden="true"
+            draggable={false}
+            className={cn(
+              "absolute inset-0 h-full w-full scale-110 blur-lg",
+              OBJECT_FIT_CLASS[objectFit],
+              transitionClass,
+              loaded ? "opacity-0" : "opacity-100"
+            )}
+          />
+        ) : (
+          <div
+            aria-hidden="true"
+            className={cn(
+              "absolute inset-0 h-full w-full",
+              !loaded && !prefersReducedMotion && "animate-pulse",
+              transitionClass,
+              loaded ? "opacity-0" : "opacity-100"
+            )}
+          />
+        ))}
+
+      {/* Full image — only mounted once in view (lazy) */}
+      {inView && !showBrokenState && (
+        <picture>
+          {webpSrcSet && (
+            <source type="image/webp" srcSet={webpSrcSet} sizes={resolvedSizes} />
+          )}
+          {fallbackSrcSet && (
+            <source srcSet={fallbackSrcSet} sizes={resolvedSizes} />
+          )}
+          <img
+            {...imgProps}
+            key={currentSrc}
+            src={fullSrc}
+            alt={alt}
+            decoding="async"
+            loading={priority ? "eager" : "lazy"}
+            onLoad={handleLoad}
+            onError={handleError}
+            className={cn(
+              "absolute inset-0 h-full w-full",
+              OBJECT_FIT_CLASS[objectFit],
+              transitionClass,
+              loaded ? "opacity-100" : "opacity-0",
+              className
+            )}
+          />
+        </picture>
+      )}
+
+      {/* Broken-image state */}
+      {showBrokenState && (
+        <div
+          role="img"
+          aria-label={alt || "Image failed to load"}
+          className="absolute inset-0 flex flex-col items-center justify-center gap-1 bg-muted text-muted-foreground"
+        >
+          <ImageOff className="h-6 w-6" aria-hidden="true" />
+          <span className="text-xs">Image unavailable</span>
+        </div>
+      )}
+
+      {/* No-JS fallback so the asset still renders without hydration. */}
+      <noscript>
+        <img
+          src={fullSrc}
+          alt={alt}
+          className={cn("absolute inset-0 h-full w-full", OBJECT_FIT_CLASS[objectFit])}
+        />
+      </noscript>
+    </div>
+  );
+}
+
+/** Alias export — some call sites prefer the shorter name. */
+export { ProgressiveImage as Image };
+
+export default ProgressiveImage;


### PR DESCRIPTION
## Summary

Adds a reusable progressive image component (`frontend/src/components/common/Image.tsx`) that renders a tiny blurred placeholder first, lazy-loads the real asset as it nears the viewport, and serves WebP with an automatic fallback — eliminating layout shift and cutting initial image payload.

## Type of change

- [x] New feature

## Related issues

Closes #927

## Changes

- New `<ProgressiveImage />` (aliased as `Image`) in `frontend/src/components/common/Image.tsx`:
  - **LQIP + blur-up**: renders a 32px / q20 placeholder (well under the 50KB budget) that blurs-up to the full image once it decodes; honors `prefers-reduced-motion`. An explicit `lqip` data URL can be supplied by the caller.
  - **Lazy loading**: defers the network request until the wrapper nears the viewport via `IntersectionObserver` (`rootMargin` configurable, default 200px); `priority` bypasses it for above-the-fold images.
  - **WebP + fallback**: hand-rolled `<picture>` with a `type="image/webp"` `<source>`, a responsive srcset (width descriptors), and an original-format fallback source.
  - **Resilience & a11y**: reserves layout space (`aspectRatio` / `width`+`height`) to prevent CLS, `aria-busy` while loading, single `fallbackSrc` retry then an accessible broken-image state, and a `<noscript>` fallback.
- Adds unit tests in `frontend/src/__tests__/progressive-image.test.tsx`.

## Testing

- [x] Unit tests pass (`npm test`) — 8/8 in `progressive-image.test.tsx` (priority vs. lazy load, WebP source + fallback, LQIP size budget, explicit LQIP override, blur-up transition, fallback→broken chain, aria-busy toggling).
- [x] Manually tested locally

## Checklist

- [x] Code follows project conventions
- [x] No secrets or PII committed
- [x] CI passes
