### PR TITLE
security: add CORS whitelist, CSRF protection, and security headers

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -18,9 +18,11 @@ mod telemetry;
 use crate::config::Config;
 use crate::db::{create_pool, run_startup_migrations};
 use crate::middleware::cors_middleware;
+use crate::middleware::csrf::{csrf_protection, csrf_token_handler};
 use crate::middleware::idempotency_middleware::IdempotencyMiddleware;
 use crate::middleware::rate_limit::RateLimitMiddleware;
 use crate::middleware::security::{SecurityConfig, SecurityMiddleware};
+use crate::middleware::security_headers::security_headers;
 use crate::middleware::tracing_middleware::RequestTracing;
 use crate::service::match_authority_service::MatchAuthorityService;
 use crate::service::ReaperService;
@@ -185,15 +187,21 @@ async fn main() -> io::Result<()> {
             .wrap(RateLimitMiddleware::new(redis_conn.clone(), rate_limit_config.clone()))
             .wrap(SecurityMiddleware::new(redis_conn.clone(), SecurityConfig::default()))
             .wrap(AntiBotMiddleware::new(redis_conn.clone(), AntiBotConfig::default()))
+            .wrap(actix_web::middleware::from_fn(csrf_protection))
             .wrap(cors_middleware())
             .wrap(actix_web::middleware::Logger::default())
-            // Outermost: sees the request first (extracts trace context /
+            // RequestTracing sees the request first (extracts trace context /
             // correlation id) and the response last (records latency,
-            // stamps correlation headers).
+            // stamps correlation headers) among the "inner" layers below.
             .wrap(RequestTracing::new())
+            // Outermost: guarantees security headers land on every response,
+            // including ones short-circuited by an inner layer (CORS
+            // preflight, CSRF rejection, rate limiting, etc).
+            .wrap(actix_web::middleware::from_fn(security_headers))
             .service(
                 web::scope("/api")
                     .route("/health", web::get().to(crate::http::health::health_check))
+                    .route("/csrf-token", web::get().to(csrf_token_handler))
                     // OpenAPI 3.0 docs — Issue #901
                     .configure(crate::http::docs_handler::configure_routes)
                     // Anti-bot detection endpoints — Issue #903

--- a/backend/src/middleware/csrf.rs
+++ b/backend/src/middleware/csrf.rs
@@ -1,0 +1,111 @@
+/// CSRF protection via the double-submit-cookie pattern.
+///
+/// On any response where the caller doesn't yet hold a CSRF cookie, we mint
+/// one (`csrf_token`). It is intentionally *not* `HttpOnly` so client-side
+/// JS can read it and echo it back on the `X-CSRF-Token` header. On
+/// state-changing requests (POST/PUT/PATCH/DELETE) we require that header to
+/// match the cookie. A cross-site page can trigger a request carrying the
+/// cookie (browsers attach cookies automatically), but it cannot read the
+/// cookie's value to set the matching header (same-origin policy), which is
+/// what defeats CSRF here.
+///
+/// `SameSite=Strict` on both this cookie and the auth cookies
+/// (`backend/src/http/auth_handler.rs`) is defense in depth: modern
+/// browsers already stop the cookie being sent cross-site, and this check
+/// stops the remaining cross-site-navigation edge cases.
+use actix_web::{
+    body::{BoxBody, MessageBody},
+    cookie::{Cookie, SameSite},
+    dev::{ServiceRequest, ServiceResponse},
+    http::Method,
+    middleware::Next,
+    Error, HttpMessage, HttpResponse,
+};
+use rand::RngCore;
+
+pub const CSRF_COOKIE: &str = "csrf_token";
+pub const CSRF_HEADER: &str = "X-CSRF-Token";
+
+/// `GET /api/csrf-token` — lets clients that don't yet hold a `csrf_token`
+/// cookie fetch one before making their first mutating request. The cookie
+/// itself is minted by [`csrf_protection`], not this handler.
+pub async fn csrf_token_handler() -> HttpResponse {
+    HttpResponse::Ok().json(serde_json::json!({ "status": "ok" }))
+}
+
+/// Paths exempt from the header/cookie match check.
+///
+/// Safe methods (GET/HEAD/OPTIONS/TRACE) are always exempt since they must
+/// not mutate state. These additional exemptions cover endpoints reached
+/// before a session (and therefore a CSRF cookie) can exist.
+fn is_exempt(path: &str) -> bool {
+    path.starts_with("/api/auth/login")
+        || path.starts_with("/api/auth/register")
+        || path.starts_with("/api/auth/refresh")
+        || path.starts_with("/api/health")
+        || path.starts_with("/api/csrf-token")
+}
+
+fn generate_token() -> String {
+    let mut bytes = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    hex::encode(bytes)
+}
+
+fn is_state_changing(method: &Method) -> bool {
+    matches!(
+        *method,
+        Method::POST | Method::PUT | Method::PATCH | Method::DELETE
+    )
+}
+
+/// `actix_web::middleware::from_fn` handler — validates CSRF tokens on
+/// mutating requests and mints a fresh CSRF cookie for sessions that don't
+/// have one yet.
+pub async fn csrf_protection(
+    req: ServiceRequest,
+    next: Next<impl MessageBody + 'static>,
+) -> Result<ServiceResponse<BoxBody>, Error> {
+    let method = req.method().clone();
+    let path = req.path().to_string();
+
+    if is_state_changing(&method) && !is_exempt(&path) {
+        let cookie_token = req.cookie(CSRF_COOKIE).map(|c| c.value().to_string());
+        let header_token = req
+            .headers()
+            .get(CSRF_HEADER)
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string());
+
+        let valid = matches!(
+            (&cookie_token, &header_token),
+            (Some(c), Some(h)) if !c.is_empty() && c == h
+        );
+
+        if !valid {
+            let response = HttpResponse::Forbidden().json(serde_json::json!({
+                "error": "csrf_validation_failed",
+                "message": "Missing or invalid CSRF token. Fetch one from GET /api/csrf-token \
+                             and send it back on the X-CSRF-Token header for this request."
+            }));
+            return Ok(req.into_response(response).map_into_boxed_body());
+        }
+    }
+
+    let needs_new_cookie = req.cookie(CSRF_COOKIE).is_none();
+    let res = next.call(req).await?;
+    let mut res = res.map_into_boxed_body();
+
+    if needs_new_cookie {
+        let token = generate_token();
+        let cookie = Cookie::build(CSRF_COOKIE, token)
+            .path("/")
+            .http_only(false)
+            .secure(true)
+            .same_site(SameSite::Strict)
+            .finish();
+        let _ = res.response_mut().add_cookie(&cookie);
+    }
+
+    Ok(res)
+}

--- a/backend/src/middleware/mod.rs
+++ b/backend/src/middleware/mod.rs
@@ -1,34 +1,67 @@
 // Middleware module for ArenaX
+pub mod csrf;
 pub mod idempotency_middleware;
 pub mod rate_limit;
 pub mod security;
+pub mod security_headers;
 pub mod tracing_middleware;
 
 pub use anti_bot::AntiBotMiddleware;
+pub use csrf::{csrf_protection, csrf_token_handler, CSRF_COOKIE, CSRF_HEADER};
 pub use idempotency_middleware::IdempotencyMiddleware;
 pub use rate_limit::RateLimitMiddleware;
 pub use security::SecurityMiddleware;
+pub use security_headers::security_headers;
 pub use tracing_middleware::{correlation_id, CorrelationId, RequestTracing};
 
 use actix_cors::Cors;
+use actix_web::http::{header, Method};
 use std::env;
+use tracing::warn;
 
+/// Builds the CORS layer from an explicit origin whitelist.
+///
+/// Origins are read from the `ALLOWED_ORIGINS` env var (comma-separated).
+/// Unlike a permissive `Cors::permissive()` setup, this only allows the
+/// specific methods/headers the API actually uses, so a misconfigured or
+/// missing env var fails closed (localhost dev origins only) rather than
+/// open (reflecting any origin).
 pub fn cors_middleware() -> Cors {
-    // Get allowed origins from environment variable
-    let allowed_origins = env::var("ALLOWED_ORIGINS")
-        .unwrap_or_else(|_| "http://localhost:3000,http://localhost:5173".to_string());
-    
-    let origins: Vec<&str> = allowed_origins.split(',').map(|s| s.trim()).collect();
-    
+    let allowed_origins = env::var("ALLOWED_ORIGINS").unwrap_or_else(|_| {
+        warn!(
+            "ALLOWED_ORIGINS is not set; falling back to localhost-only CORS origins. \
+             Set ALLOWED_ORIGINS explicitly in production."
+        );
+        "http://localhost:3000,http://localhost:5173".to_string()
+    });
+
+    let origins: Vec<String> = allowed_origins
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect();
+
     let mut cors = Cors::default();
-    
-    // Add each allowed origin
     for origin in origins {
-        cors = cors.allowed_origin(origin);
+        cors = cors.allowed_origin(&origin);
     }
-    
-    cors.allow_any_method()
-        .allow_any_header()
-        .supports_credentials()
-        .max_age(3600)
+
+    cors.allowed_methods(vec![
+        Method::GET,
+        Method::POST,
+        Method::PUT,
+        Method::PATCH,
+        Method::DELETE,
+        Method::OPTIONS,
+    ])
+    .allowed_headers(vec![
+        header::AUTHORIZATION,
+        header::ACCEPT,
+        header::CONTENT_TYPE,
+        header::HeaderName::from_static("x-csrf-token"),
+        header::HeaderName::from_static("x-correlation-id"),
+        header::HeaderName::from_static("idempotency-key"),
+    ])
+    .supports_credentials()
+    .max_age(3600)
 }

--- a/backend/src/middleware/security_headers.rs
+++ b/backend/src/middleware/security_headers.rs
@@ -1,0 +1,62 @@
+/// Adds standard defensive security headers to every response.
+///
+/// Header names are constructed via `HeaderName::from_static` rather than
+/// relying on constants from the `http` crate's curated header list, since
+/// several of these (CSP, X-Frame-Options, Permissions-Policy) aren't in
+/// that curated set across all versions.
+use actix_web::{
+    body::MessageBody,
+    dev::{ServiceRequest, ServiceResponse},
+    http::header::{HeaderName, HeaderValue},
+    middleware::Next,
+    Error,
+};
+
+pub async fn security_headers(
+    req: ServiceRequest,
+    next: Next<impl MessageBody + 'static>,
+) -> Result<ServiceResponse<impl MessageBody>, Error> {
+    let mut res = next.call(req).await?;
+    let headers = res.headers_mut();
+
+    // Force HTTPS for a year, including subdomains, and allow browser
+    // preload lists to enforce it before the first request.
+    headers.insert(
+        HeaderName::from_static("strict-transport-security"),
+        HeaderValue::from_static("max-age=31536000; includeSubDomains; preload"),
+    );
+
+    // Restrictive default-src CSP; APIs don't serve HTML/JS so this mainly
+    // guards error pages and any accidental HTML responses.
+    headers.insert(
+        HeaderName::from_static("content-security-policy"),
+        HeaderValue::from_static(
+            "default-src 'none'; frame-ancestors 'none'; base-uri 'none'",
+        ),
+    );
+
+    headers.insert(
+        HeaderName::from_static("x-content-type-options"),
+        HeaderValue::from_static("nosniff"),
+    );
+    headers.insert(
+        HeaderName::from_static("x-frame-options"),
+        HeaderValue::from_static("DENY"),
+    );
+    headers.insert(
+        HeaderName::from_static("referrer-policy"),
+        HeaderValue::from_static("strict-origin-when-cross-origin"),
+    );
+    headers.insert(
+        HeaderName::from_static("permissions-policy"),
+        HeaderValue::from_static(
+            "geolocation=(), microphone=(), camera=(), payment=(), usb=()",
+        ),
+    );
+    headers.insert(
+        HeaderName::from_static("x-permitted-cross-domain-policies"),
+        HeaderValue::from_static("none"),
+    );
+
+    Ok(res)
+}


### PR DESCRIPTION
## Summary
- `backend/src/middleware/mod.rs`: `cors_middleware()` now allows only the specific methods (`GET/POST/PUT/PATCH/DELETE/OPTIONS`) and headers (`Authorization`, `Accept`, `Content-Type`, `X-CSRF-Token`, `X-Correlation-Id`, `Idempotency-Key`) the API actually uses, instead of `allow_any_method()` / `allow_any_header()`. Origins remain driven by the `ALLOWED_ORIGINS` env var (already documented in `backend/env.example`), with a logged, localhost-only fallback if unset.
- `backend/src/middleware/csrf.rs` (new): CSRF protection via the double-submit-cookie pattern. Mints a `csrf_token` cookie and requires state-changing requests (`POST/PUT/PATCH/DELETE`) to echo it on the `X-CSRF-Token` header, except for pre-session endpoints (`/api/auth/login`, `/api/auth/register`, `/api/auth/refresh`, `/api/health`, `/api/csrf-token`). Adds `GET /api/csrf-token` so clients can fetch an initial token.
- `backend/src/middleware/security_headers.rs` (new): adds `Strict-Transport-Security`, `Content-Security-Policy`, `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, `Permissions-Policy`, and `X-Permitted-Cross-Domain-Policies` to every response.
- `backend/src/main.rs`: wires both new middlewares in via `actix_web::middleware::from_fn`, with security headers as the outermost layer so they land on every response, including ones short-circuited by CORS/CSRF/rate limiting.
- Existing auth cookies (`backend/src/http/auth_handler.rs`) already used `HttpOnly; Secure; SameSite=Strict`; the new CSRF cookie follows the same `SameSite=Strict` pattern (intentionally not `HttpOnly`, so client JS can read it and echo it into the header — that's what makes the double-submit check work).

## Acceptance criteria
- [x] CORS origin whitelist
- [x] CSRF tokens for state changes
- [x] SameSite cookie attribute
- [x] Preflight request handling (via `actix-cors`, methods/headers now explicit)
- [x] Security headers (HSTS, CSP, plus X-Content-Type-Options/X-Frame-Options/Referrer-Policy/Permissions-Policy)

## Test plan
- Not run per task instructions (CI/tests out of scope for this change).

Closes #976