### PR TITLE
feat(contracts): add governed upgrade manager for deployed contracts

### DIFF
--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "time-lock",
     "zk-proof",
     "airdrop",
+    "upgrade-manager",
 ]
 resolver = "2"
 

--- a/contracts/arenax-events/src/events_registry.rs
+++ b/contracts/arenax-events/src/events_registry.rs
@@ -10,7 +10,7 @@
 use crate::{
     anti_cheat, auth_gateway, ax_token, contract_registry, dispute, escrow, governance, identity,
     match_contract, match_lifecycle, player_reputation, prize_distribution, registry, reputation,
-    reputation_index, slashing, staking, time_lock, tournament, virtual_economy,
+    reputation_index, slashing, staking, time_lock, tournament, upgrade_manager, virtual_economy,
 };
 
 /// A single entry in the namespace registry.
@@ -42,6 +42,7 @@ pub const NAMESPACES: &[NamespaceEntry] = &[
     NamespaceEntry { namespace: staking::NAMESPACE, version: staking::VERSION },
     NamespaceEntry { namespace: time_lock::NAMESPACE, version: time_lock::VERSION },
     NamespaceEntry { namespace: tournament::NAMESPACE, version: tournament::VERSION },
+    NamespaceEntry { namespace: upgrade_manager::NAMESPACE, version: upgrade_manager::VERSION },
     NamespaceEntry { namespace: virtual_economy::NAMESPACE, version: virtual_economy::VERSION },
 ];
 

--- a/contracts/arenax-events/src/lib.rs
+++ b/contracts/arenax-events/src/lib.rs
@@ -42,5 +42,6 @@ pub mod slashing;
 pub mod staking;
 pub mod time_lock;
 pub mod tournament;
+pub mod upgrade_manager;
 pub mod virtual_economy;
 pub mod zk_proof;

--- a/contracts/arenax-events/src/upgrade_manager.rs
+++ b/contracts/arenax-events/src/upgrade_manager.rs
@@ -1,0 +1,144 @@
+use soroban_sdk::{contractevent, Address, BytesN, Symbol};
+
+pub const NAMESPACE: &str = "ArenaXUpgradeManager";
+pub const VERSION: &str = "v1";
+
+#[contractevent(topics = ["ArenaXUpg_v1", "INIT"])]
+pub struct Initialized {
+    pub admin: Address,
+    pub approval_threshold: u32,
+}
+
+#[contractevent(topics = ["ArenaXUpg_v1", "PROPOSED"])]
+pub struct UpgradeProposed {
+    pub proposal_id: u32,
+    pub contract_name: Symbol,
+    pub new_wasm_hash: BytesN<32>,
+    pub proposed_by: Address,
+    pub timelock_end: u64,
+}
+
+#[contractevent(topics = ["ArenaXUpg_v1", "VALIDATED"])]
+pub struct UpgradeValidated {
+    pub proposal_id: u32,
+    pub is_valid: bool,
+    pub validated_by: Address,
+}
+
+#[contractevent(topics = ["ArenaXUpg_v1", "VOTED"])]
+pub struct UpgradeVoted {
+    pub proposal_id: u32,
+    pub voter: Address,
+    pub approve: bool,
+    pub votes_for: u32,
+}
+
+#[contractevent(topics = ["ArenaXUpg_v1", "EXECUTED"])]
+pub struct UpgradeExecuted {
+    pub proposal_id: u32,
+    pub contract_name: Symbol,
+    pub previous_wasm_hash: BytesN<32>,
+    pub new_wasm_hash: BytesN<32>,
+    pub executed_by: Address,
+}
+
+#[contractevent(topics = ["ArenaXUpg_v1", "ROLLED_BACK"])]
+pub struct UpgradeRolledBack {
+    pub proposal_id: u32,
+    pub contract_name: Symbol,
+    pub restored_wasm_hash: BytesN<32>,
+    pub rolled_back_by: Address,
+    pub reason: Symbol,
+}
+
+pub fn emit_initialized(env: &soroban_sdk::Env, admin: &Address, approval_threshold: u32) {
+    Initialized {
+        admin: admin.clone(),
+        approval_threshold,
+    }
+    .publish(env);
+}
+
+pub fn emit_upgrade_proposed(
+    env: &soroban_sdk::Env,
+    proposal_id: u32,
+    contract_name: &Symbol,
+    new_wasm_hash: &BytesN<32>,
+    proposed_by: &Address,
+    timelock_end: u64,
+) {
+    UpgradeProposed {
+        proposal_id,
+        contract_name: contract_name.clone(),
+        new_wasm_hash: new_wasm_hash.clone(),
+        proposed_by: proposed_by.clone(),
+        timelock_end,
+    }
+    .publish(env);
+}
+
+pub fn emit_upgrade_validated(
+    env: &soroban_sdk::Env,
+    proposal_id: u32,
+    is_valid: bool,
+    validated_by: &Address,
+) {
+    UpgradeValidated {
+        proposal_id,
+        is_valid,
+        validated_by: validated_by.clone(),
+    }
+    .publish(env);
+}
+
+pub fn emit_upgrade_voted(
+    env: &soroban_sdk::Env,
+    proposal_id: u32,
+    voter: &Address,
+    approve: bool,
+    votes_for: u32,
+) {
+    UpgradeVoted {
+        proposal_id,
+        voter: voter.clone(),
+        approve,
+        votes_for,
+    }
+    .publish(env);
+}
+
+pub fn emit_upgrade_executed(
+    env: &soroban_sdk::Env,
+    proposal_id: u32,
+    contract_name: &Symbol,
+    previous_wasm_hash: &BytesN<32>,
+    new_wasm_hash: &BytesN<32>,
+    executed_by: &Address,
+) {
+    UpgradeExecuted {
+        proposal_id,
+        contract_name: contract_name.clone(),
+        previous_wasm_hash: previous_wasm_hash.clone(),
+        new_wasm_hash: new_wasm_hash.clone(),
+        executed_by: executed_by.clone(),
+    }
+    .publish(env);
+}
+
+pub fn emit_upgrade_rolled_back(
+    env: &soroban_sdk::Env,
+    proposal_id: u32,
+    contract_name: &Symbol,
+    restored_wasm_hash: &BytesN<32>,
+    rolled_back_by: &Address,
+    reason: &Symbol,
+) {
+    UpgradeRolledBack {
+        proposal_id,
+        contract_name: contract_name.clone(),
+        restored_wasm_hash: restored_wasm_hash.clone(),
+        rolled_back_by: rolled_back_by.clone(),
+        reason: reason.clone(),
+    }
+    .publish(env);
+}

--- a/contracts/upgrade-manager/Cargo.toml
+++ b/contracts/upgrade-manager/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "upgrade-manager"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "ArenaX Upgrade Manager - Governed proxy-upgrade lifecycle for deployed contracts"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk.workspace = true
+arenax-events = { path = "../arenax-events" }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[features]
+testutils = ["soroban-sdk/testutils"]

--- a/contracts/upgrade-manager/README.md
+++ b/contracts/upgrade-manager/README.md
@@ -1,0 +1,58 @@
+# Upgrade Manager
+
+Governed contract-upgrade lifecycle for ArenaX Soroban contracts, closing
+[#969](https://github.com/Arenax-gaming/ArenaX/issues/969).
+
+## Why this shape
+
+Soroban has no EVM-style `delegatecall` proxy. Instead a contract's
+*address* is permanent while its wasm implementation can be swapped in
+place via `Env::deployer().update_current_contract_wasm(hash)` — callers,
+other contracts, and off-chain indexers never need to learn a new address.
+That address stability is the proxy-equivalent guarantee this contract is
+built around.
+
+`UpgradeManager` is the governance layer in front of that primitive:
+
+1. **Propose** — anyone can call `propose_upgrade(contract_name, new_wasm_hash, description, timelock_seconds)`.
+2. **Validate** — a governor records an implementation-validation verdict
+   (`validate_upgrade`) before a vote can pass execution.
+3. **Vote** — governors cast one yes/no vote each (`vote_upgrade`); a
+   proposal needs `approval_threshold` yes-votes to be executable.
+4. **Execute** — once validated, past threshold, and past the timelock,
+   `execute_upgrade` runs. For the manager's own implementation
+   (`SELF_CONTRACT`) it calls `update_current_contract_wasm` directly.
+   For any other tracked contract it records the governance-approved
+   wasm hash; that contract's own admin-gated `upgrade()` entrypoint
+   reads it via `get_approved_wasm_hash` and applies it to itself — one
+   contract cannot rewrite another's wasm directly on Soroban, so this
+   indirection is what makes third-party contracts governable from a
+   single place.
+5. **Rollback** — `rollback_upgrade` restores the previously-approved
+   wasm hash for a contract (or immediately re-applies it for `SELF`),
+   with a reason recorded.
+6. **History** — every execution and rollback appends an `UpgradeRecord`
+   to `get_upgrade_history(contract_name)`, and every step also emits a
+   versioned event (`arenax-events::upgrade_manager`) for off-chain
+   indexers.
+
+## Integrating a target contract
+
+```rust
+pub fn upgrade(env: Env, caller: Address) {
+    caller.require_auth();
+    let manager: Address = /* stored upgrade-manager contract id */;
+    let hash = UpgradeManagerClient::new(&env, &manager)
+        .get_approved_wasm_hash(&symbol_short!("MyContract"))
+        .expect("no approved upgrade");
+    env.deployer().update_current_contract_wasm(hash);
+}
+```
+
+## Acceptance criteria mapping
+
+- Proxy pattern implementation → stable contract address + wasm swap via `update_current_contract_wasm`.
+- Upgrade governance vote → `vote_upgrade` + `approval_threshold`.
+- Implementation validation → `validate_upgrade`, required before execution.
+- Rollback capability → `rollback_upgrade`.
+- Upgrade history logged → `get_upgrade_history` + `arenax-events::upgrade_manager` events.

--- a/contracts/upgrade-manager/src/lib.rs
+++ b/contracts/upgrade-manager/src/lib.rs
@@ -1,0 +1,504 @@
+#![no_std]
+
+//! Governed upgrade lifecycle for ArenaX Soroban contracts.
+//!
+//! Soroban has no EVM-style `delegatecall` proxy — instead a contract's
+//! *address* stays constant across releases while its wasm implementation
+//! is swapped via `Env::deployer().update_current_contract_wasm(hash)`.
+//! That address stability is what makes the pattern proxy-equivalent:
+//! callers, other contracts, and off-chain indexers keep using the same
+//! contract id forever.
+//!
+//! This contract is the governance layer sitting in front of that
+//! primitive:
+//!   - Proposals name a target contract and a candidate wasm hash.
+//!   - A validator sets a validation verdict before a vote can pass.
+//!   - Governors vote; once `approval_threshold` yes-votes are reached
+//!     and the timelock has elapsed, the upgrade can be executed.
+//!   - Executing an upgrade of *this* contract itself calls
+//!     `update_current_contract_wasm` directly. Executing an upgrade of
+//!     another tracked contract records the governance-approved hash,
+//!     which that contract's own admin-gated `upgrade()` entrypoint
+//!     reads via [`UpgradeManagerClient::get_approved_wasm_hash`] and
+//!     applies to itself — the indirection Soroban requires since one
+//!     contract cannot rewrite another contract's wasm directly.
+//!   - Every execution and rollback is appended to a per-contract
+//!     history log.
+
+use arenax_events::upgrade_manager as events;
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, symbol_short, Address, BytesN, Env,
+    String, Symbol, Vec,
+};
+
+/// Pseudo contract-name used when a proposal targets this governance
+/// contract's own implementation.
+pub const SELF_CONTRACT: Symbol = symbol_short!("SELF");
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DataKey {
+    Admin,
+    ApprovalThreshold,
+    Governors,
+    NextProposalId,
+    Proposal(u32),
+    Validation(u32),
+    Votes(u32),
+    Executed(u32),
+    ApprovedWasmHash(Symbol),
+    PreviousWasmHash(Symbol),
+    History(Symbol),
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct UpgradeProposal {
+    pub proposal_id: u32,
+    pub contract_name: Symbol,
+    pub new_wasm_hash: BytesN<32>,
+    pub proposed_by: Address,
+    pub proposed_at: u64,
+    pub timelock_end: u64,
+    pub description: String,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ValidationResult {
+    pub proposal_id: u32,
+    pub is_valid: bool,
+    pub validated_by: Address,
+    pub validated_at: u64,
+    pub notes: String,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct UpgradeRecord {
+    pub proposal_id: u32,
+    pub contract_name: Symbol,
+    pub previous_wasm_hash: BytesN<32>,
+    pub new_wasm_hash: BytesN<32>,
+    pub timestamp: u64,
+    pub actor: Address,
+    pub action: Symbol,
+}
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum UpgradeError {
+    AlreadyInitialized = 1,
+    NotInitialized = 2,
+    NotAdmin = 3,
+    NotGovernor = 4,
+    ProposalNotFound = 5,
+    AlreadyValidated = 6,
+    NotValidated = 7,
+    ValidationFailed = 8,
+    AlreadyVoted = 9,
+    ThresholdNotMet = 10,
+    TimelockNotElapsed = 11,
+    AlreadyExecuted = 12,
+    NoPriorVersion = 13,
+    InvalidThreshold = 14,
+}
+
+#[contract]
+pub struct UpgradeManager;
+
+#[contractimpl]
+impl UpgradeManager {
+    /// Initialize the upgrade manager with an admin, an initial governor
+    /// set, and the number of yes-votes required to approve a proposal.
+    pub fn initialize(
+        env: Env,
+        admin: Address,
+        governors: Vec<Address>,
+        approval_threshold: u32,
+    ) -> Result<(), UpgradeError> {
+        if env.storage().instance().has(&DataKey::Admin) {
+            return Err(UpgradeError::AlreadyInitialized);
+        }
+        if approval_threshold == 0 || approval_threshold > governors.len() {
+            return Err(UpgradeError::InvalidThreshold);
+        }
+
+        admin.require_auth();
+
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage()
+            .instance()
+            .set(&DataKey::ApprovalThreshold, &approval_threshold);
+        env.storage()
+            .instance()
+            .set(&DataKey::Governors, &governors);
+        env.storage().instance().set(&DataKey::NextProposalId, &1u32);
+
+        events::emit_initialized(&env, &admin, approval_threshold);
+        Ok(())
+    }
+
+    /// Propose an upgrade for `contract_name` (use [`SELF_CONTRACT`] to
+    /// target this governance contract) to `new_wasm_hash`. Any address
+    /// may propose; only governors can approve it via vote.
+    pub fn propose_upgrade(
+        env: Env,
+        proposer: Address,
+        contract_name: Symbol,
+        new_wasm_hash: BytesN<32>,
+        description: String,
+        timelock_seconds: u64,
+    ) -> Result<u32, UpgradeError> {
+        proposer.require_auth();
+        Self::require_initialized(&env)?;
+
+        let proposal_id: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::NextProposalId)
+            .unwrap_or(1u32);
+        let now = env.ledger().timestamp();
+        let timelock_end = now + timelock_seconds;
+
+        let proposal = UpgradeProposal {
+            proposal_id,
+            contract_name: contract_name.clone(),
+            new_wasm_hash: new_wasm_hash.clone(),
+            proposed_by: proposer.clone(),
+            proposed_at: now,
+            timelock_end,
+            description,
+        };
+        env.storage()
+            .persistent()
+            .set(&DataKey::Proposal(proposal_id), &proposal);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Votes(proposal_id), &Vec::<Address>::new(&env));
+        env.storage()
+            .instance()
+            .set(&DataKey::NextProposalId, &(proposal_id + 1));
+
+        events::emit_upgrade_proposed(
+            &env,
+            proposal_id,
+            &contract_name,
+            &new_wasm_hash,
+            &proposer,
+            timelock_end,
+        );
+        Ok(proposal_id)
+    }
+
+    /// Record an implementation-validation verdict (compatibility check,
+    /// audit sign-off, etc.) for a proposal. Must be done by a governor
+    /// before the proposal can be executed.
+    pub fn validate_upgrade(
+        env: Env,
+        validator: Address,
+        proposal_id: u32,
+        is_valid: bool,
+        notes: String,
+    ) -> Result<(), UpgradeError> {
+        validator.require_auth();
+        Self::require_governor(&env, &validator)?;
+        Self::get_proposal(&env, proposal_id)?;
+
+        if env
+            .storage()
+            .persistent()
+            .has(&DataKey::Validation(proposal_id))
+        {
+            return Err(UpgradeError::AlreadyValidated);
+        }
+
+        let result = ValidationResult {
+            proposal_id,
+            is_valid,
+            validated_by: validator.clone(),
+            validated_at: env.ledger().timestamp(),
+            notes,
+        };
+        env.storage()
+            .persistent()
+            .set(&DataKey::Validation(proposal_id), &result);
+
+        events::emit_upgrade_validated(&env, proposal_id, is_valid, &validator);
+        Ok(())
+    }
+
+    /// Cast a governor's yes/no vote on a proposal. One vote per governor.
+    pub fn vote_upgrade(
+        env: Env,
+        voter: Address,
+        proposal_id: u32,
+        approve: bool,
+    ) -> Result<u32, UpgradeError> {
+        voter.require_auth();
+        Self::require_governor(&env, &voter)?;
+        Self::get_proposal(&env, proposal_id)?;
+
+        let mut votes: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Votes(proposal_id))
+            .unwrap_or_else(|| Vec::new(&env));
+
+        if votes.contains(&voter) {
+            return Err(UpgradeError::AlreadyVoted);
+        }
+
+        if approve {
+            votes.push_back(voter.clone());
+            env.storage()
+                .persistent()
+                .set(&DataKey::Votes(proposal_id), &votes);
+        }
+
+        events::emit_upgrade_voted(&env, proposal_id, &voter, approve, votes.len());
+        Ok(votes.len())
+    }
+
+    /// Execute an approved proposal. Requires: a positive validation
+    /// verdict, at least `approval_threshold` yes-votes, the timelock
+    /// elapsed, and no prior execution of this proposal.
+    ///
+    /// For [`SELF_CONTRACT`] this calls `update_current_contract_wasm`
+    /// directly. For any other tracked contract it records the approved
+    /// hash so that contract's own upgrade entrypoint can apply it.
+    pub fn execute_upgrade(env: Env, caller: Address, proposal_id: u32) -> Result<(), UpgradeError> {
+        caller.require_auth();
+        Self::require_governor(&env, &caller)?;
+
+        let proposal = Self::get_proposal(&env, proposal_id)?;
+
+        if env
+            .storage()
+            .persistent()
+            .get(&DataKey::Executed(proposal_id))
+            .unwrap_or(false)
+        {
+            return Err(UpgradeError::AlreadyExecuted);
+        }
+
+        let validation: ValidationResult = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Validation(proposal_id))
+            .ok_or(UpgradeError::NotValidated)?;
+        if !validation.is_valid {
+            return Err(UpgradeError::ValidationFailed);
+        }
+
+        let votes: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Votes(proposal_id))
+            .unwrap_or_else(|| Vec::new(&env));
+        let threshold: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::ApprovalThreshold)
+            .unwrap_or(u32::MAX);
+        if votes.len() < threshold {
+            return Err(UpgradeError::ThresholdNotMet);
+        }
+
+        if env.ledger().timestamp() < proposal.timelock_end {
+            return Err(UpgradeError::TimelockNotElapsed);
+        }
+
+        let previous_hash = env
+            .storage()
+            .persistent()
+            .get(&DataKey::ApprovedWasmHash(proposal.contract_name.clone()))
+            .unwrap_or_else(|| Self::unknown_hash(&env));
+
+        env.storage().persistent().set(
+            &DataKey::PreviousWasmHash(proposal.contract_name.clone()),
+            &previous_hash,
+        );
+        env.storage().persistent().set(
+            &DataKey::ApprovedWasmHash(proposal.contract_name.clone()),
+            &proposal.new_wasm_hash,
+        );
+        env.storage()
+            .persistent()
+            .set(&DataKey::Executed(proposal_id), &true);
+
+        if proposal.contract_name == SELF_CONTRACT {
+            env.deployer()
+                .update_current_contract_wasm(proposal.new_wasm_hash.clone());
+        }
+
+        Self::append_history(
+            &env,
+            &proposal.contract_name,
+            UpgradeRecord {
+                proposal_id,
+                contract_name: proposal.contract_name.clone(),
+                previous_wasm_hash: previous_hash.clone(),
+                new_wasm_hash: proposal.new_wasm_hash.clone(),
+                timestamp: env.ledger().timestamp(),
+                actor: caller.clone(),
+                action: symbol_short!("EXECUTE"),
+            },
+        );
+
+        events::emit_upgrade_executed(
+            &env,
+            proposal_id,
+            &proposal.contract_name,
+            &previous_hash,
+            &proposal.new_wasm_hash,
+            &caller,
+        );
+        Ok(())
+    }
+
+    /// Roll a contract back to its previously-approved wasm hash. Only
+    /// the admin or a governor may trigger a rollback. For
+    /// [`SELF_CONTRACT`] this immediately re-applies the prior wasm via
+    /// `update_current_contract_wasm`; for other contracts it resets the
+    /// approved hash so their upgrade entrypoint re-applies the old
+    /// implementation.
+    pub fn rollback_upgrade(
+        env: Env,
+        caller: Address,
+        contract_name: Symbol,
+        reason: Symbol,
+    ) -> Result<(), UpgradeError> {
+        caller.require_auth();
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(UpgradeError::NotInitialized)?;
+        if caller != admin {
+            Self::require_governor(&env, &caller)?;
+        }
+
+        let previous_hash: BytesN<32> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::PreviousWasmHash(contract_name.clone()))
+            .ok_or(UpgradeError::NoPriorVersion)?;
+        let current_hash: BytesN<32> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::ApprovedWasmHash(contract_name.clone()))
+            .unwrap_or_else(|| Self::unknown_hash(&env));
+
+        env.storage().persistent().set(
+            &DataKey::ApprovedWasmHash(contract_name.clone()),
+            &previous_hash,
+        );
+        env.storage().persistent().set(
+            &DataKey::PreviousWasmHash(contract_name.clone()),
+            &current_hash,
+        );
+
+        if contract_name == SELF_CONTRACT {
+            env.deployer()
+                .update_current_contract_wasm(previous_hash.clone());
+        }
+
+        Self::append_history(
+            &env,
+            &contract_name,
+            UpgradeRecord {
+                proposal_id: 0,
+                contract_name: contract_name.clone(),
+                previous_wasm_hash: current_hash,
+                new_wasm_hash: previous_hash.clone(),
+                timestamp: env.ledger().timestamp(),
+                actor: caller.clone(),
+                action: symbol_short!("ROLLBACK"),
+            },
+        );
+
+        events::emit_upgrade_rolled_back(&env, 0, &contract_name, &previous_hash, &caller, &reason);
+        Ok(())
+    }
+
+    /// The wasm hash a tracked contract's own upgrade entrypoint should
+    /// apply to itself after governance approval.
+    pub fn get_approved_wasm_hash(env: Env, contract_name: Symbol) -> Option<BytesN<32>> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ApprovedWasmHash(contract_name))
+    }
+
+    pub fn get_proposal_query(env: Env, proposal_id: u32) -> Option<UpgradeProposal> {
+        env.storage().persistent().get(&DataKey::Proposal(proposal_id))
+    }
+
+    pub fn get_validation_query(env: Env, proposal_id: u32) -> Option<ValidationResult> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Validation(proposal_id))
+    }
+
+    pub fn get_votes_query(env: Env, proposal_id: u32) -> Vec<Address> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Votes(proposal_id))
+            .unwrap_or_else(|| Vec::new(&env))
+    }
+
+    /// Full, append-only upgrade + rollback history for a contract.
+    pub fn get_upgrade_history(env: Env, contract_name: Symbol) -> Vec<UpgradeRecord> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::History(contract_name))
+            .unwrap_or_else(|| Vec::new(&env))
+    }
+
+    fn require_initialized(env: &Env) -> Result<(), UpgradeError> {
+        if !env.storage().instance().has(&DataKey::Admin) {
+            return Err(UpgradeError::NotInitialized);
+        }
+        Ok(())
+    }
+
+    fn require_governor(env: &Env, address: &Address) -> Result<(), UpgradeError> {
+        let governors: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Governors)
+            .ok_or(UpgradeError::NotInitialized)?;
+        if !governors.contains(address) {
+            return Err(UpgradeError::NotGovernor);
+        }
+        Ok(())
+    }
+
+    fn get_proposal(env: &Env, proposal_id: u32) -> Result<UpgradeProposal, UpgradeError> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Proposal(proposal_id))
+            .ok_or(UpgradeError::ProposalNotFound)
+    }
+
+    /// Sentinel used when no prior wasm hash has been recorded for a
+    /// contract yet (its first tracked upgrade) — genuinely unknown
+    /// rather than assumed, since Soroban has no host function to read
+    /// back another contract's currently-installed wasm hash on demand.
+    fn unknown_hash(env: &Env) -> BytesN<32> {
+        BytesN::from_array(env, &[0u8; 32])
+    }
+
+    fn append_history(env: &Env, contract_name: &Symbol, record: UpgradeRecord) {
+        let mut history: Vec<UpgradeRecord> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::History(contract_name.clone()))
+            .unwrap_or_else(|| Vec::new(env));
+        history.push_back(record);
+        env.storage()
+            .persistent()
+            .set(&DataKey::History(contract_name.clone()), &history);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new `upgrade-manager` Soroban contract that implements a governed, proxy-equivalent upgrade lifecycle for deployed ArenaX contracts. Soroban has no `delegatecall`-style proxy — a contract's address stays constant while its wasm implementation can be swapped via `Env::deployer().update_current_contract_wasm(hash)`. This contract is the governance layer in front of that primitive.

- **Proxy pattern implementation** — stable contract address across wasm swaps via `update_current_contract_wasm`; other contracts integrate by reading `get_approved_wasm_hash` and applying it to themselves in their own admin-gated `upgrade()` entrypoint.
- **Upgrade governance vote** — `propose_upgrade` → `vote_upgrade` (one vote per governor) → execution requires `approval_threshold` yes-votes.
- **Implementation validation** — `validate_upgrade` records a validation verdict; execution is blocked until a positive verdict is recorded.
- **Rollback capability** — `rollback_upgrade` restores the previously-approved wasm hash for a contract (or re-applies it immediately for the manager's own implementation), with a recorded reason.
- **Upgrade history logged** — every execution/rollback appends to a per-contract `get_upgrade_history` log, and each lifecycle step emits a versioned event via a new `arenax-events::upgrade_manager` module.

Also registers the new event namespace in `arenax-events`' `events_registry` list (`lib.rs`, `events_registry.rs`) alongside the existing domains, and adds `upgrade-manager` to the `contracts` workspace members.

See `contracts/upgrade-manager/README.md` for the full design rationale and an integration example for a target contract's own `upgrade()` entrypoint.

## Test plan

- [ ] `cargo build` / `cargo test` across the `contracts` workspace (not run in this environment — no Rust toolchain available here)
- [ ] Exercise the propose → validate → vote → execute flow against testnet
- [ ] Exercise rollback after a bad upgrade

Closes #969