### PR TITLE
security: add SSL/TLS certificate pinning for API clients

### DIFF
--- a/docs/security/certificate-pinning.md
+++ b/docs/security/certificate-pinning.md
@@ -1,0 +1,126 @@
+# SSL/TLS Certificate Pinning
+
+## What this protects against
+
+Without pinning, the frontend trusts any certificate chaining to a
+CA in the platform's trust store. If that trust store is compromised
+— a rogue enterprise/government CA, a malicious root installed on a
+device, a compromised CA — an attacker can MITM API traffic even
+though the connection is "valid HTTPS". Pinning adds a second check:
+the server's key must match one we've explicitly published, not just
+chain to *any* trusted CA.
+
+## Where this lives
+
+- `frontend/src/api/certificatePinning.ts` — the pin set, the pinning
+  policy, and `pinnedFetch()`, a drop-in replacement for `fetch()`.
+- `frontend/src/lib/api.ts` and `frontend/src/data/apiClient.ts` — the
+  two API client modules; every `fetch()` call site in both now goes
+  through `pinnedFetch()`.
+- `frontend/src/api/__tests__/certificatePinning.test.ts` — pinning
+  validation tests (fallback behavior, native-verified, native-rejected,
+  unconfigured host).
+
+## Why the web app alone can't fully enforce this
+
+A browser's TLS handshake completes before any page JavaScript runs, and
+`fetch`/`XMLHttpRequest` give no API to inspect the certificate that was
+presented. So a pure web page cannot itself reject a connection based on
+the server's public key — only a native TLS stack can. This is a
+platform limitation, not a gap in this implementation.
+
+`certificatePinning.ts` is designed around that constraint:
+
+- It **enforces** pinning when a native bridge is present — i.e. from
+  inside a future mobile app shell (React Native / Capacitor) that
+  exposes `window.__ARENAX_NATIVE__.verifyCertificate(host, pins)` backed
+  by real platform TLS inspection.
+- It **falls back to system trust** when no such bridge exists — i.e.
+  running as a plain web page today. `pinnedFetch()` still makes the
+  request over HTTPS; it just can't add the extra key-pin check. Every
+  fallback path is explicit and typed (`PinningResult.reason ===
+  "no-native-bridge-fallback-to-system-trust"`), never a silent no-op.
+
+## Native (mobile) implementation
+
+When ArenaX ships a native app shell, `window.__ARENAX_NATIVE__` should be
+implemented on top of the platform's real pinning mechanism:
+
+- **iOS:** App Transport Security pinning dictionary in `Info.plist`, or a
+  `URLSessionDelegate` performing manual server-trust evaluation (e.g. via
+  TrustKit) — compare the presented certificate's SPKI SHA-256 hash
+  against the pins passed in from `certificatePinning.ts`.
+- **Android:** Network Security Config `<pin-set>` in
+  `res/xml/network_security_config.xml`, or OkHttp's `CertificatePinner`
+  configured with the same SPKI hashes.
+- **React Native / Capacitor:** a small native module bridging
+  `verifyCertificate(host, pinsSha256)` to the platform API above, then
+  registering it as `window.__ARENAX_NATIVE__` before the JS bundle loads.
+
+The web and native pin sets must stay in sync — `certificatePinning.ts` is
+the single source of truth for *which* pins are valid; only the mechanism
+that checks them differs by platform.
+
+## Certificate rotation
+
+Each host in `PIN_SETS` carries two pins:
+
+- `primary` — the key currently served in production.
+- `backup` — the key ArenaX will rotate to next, published ahead of time.
+
+Publishing the backup pin before the actual rotation means:
+
+- A client on an older build (knows only the primary pin) keeps working
+  right up until the rotation happens.
+- A client on a newer build (already knows the backup pin) keeps working
+  immediately after the rotation, with no lockout window.
+
+**Rotation runbook:**
+
+1. Generate the new certificate/key ahead of the planned rotation date.
+2. Compute its SPKI pin (see below) and add it as the new `backup` entry
+   in `PIN_SETS`, with an `expiresAt` comfortably after the planned
+   rotation date. Ship this as a normal release — it changes nothing
+   about which certificate is currently served.
+3. Wait until the new pin has propagated to effectively all active
+   clients (i.e. your app's minimum-supported-version window).
+4. Deploy the new certificate to production infrastructure.
+5. In the next release, promote the former `backup` pin to `primary` and
+   set a fresh `backup` pin for the *next* rotation.
+6. Retire old pins only after their `expiresAt` has passed and no
+   meaningful client population still needs them.
+
+## Computing a pin
+
+The pin is the base64-encoded SHA-256 hash of the certificate's
+SubjectPublicKeyInfo (the same value used for HPKP `pin-sha256`):
+
+```sh
+openssl x509 -in certificate.pem -pubkey -noout \
+  | openssl pkey -pubin -outform der \
+  | openssl dgst -sha256 -binary \
+  | openssl enc -base64
+```
+
+Or directly against a live host:
+
+```sh
+openssl s_client -connect api.arenax.gg:443 -servername api.arenax.gg </dev/null 2>/dev/null \
+  | openssl x509 -pubkey -noout \
+  | openssl pkey -pubin -outform der \
+  | openssl dgst -sha256 -binary \
+  | openssl enc -base64
+```
+
+## Validation
+
+Run the pinning unit tests:
+
+```sh
+cd frontend && npx jest src/api/__tests__/certificatePinning.test.ts
+```
+
+They cover: active-pin filtering by expiry, fallback-to-system-trust with
+no native bridge, native-verified/native-rejected outcomes, not failing
+closed for a host with no configured pins, and that `pinnedFetch` never
+calls the network when the bridge rejects a pin.

--- a/frontend/src/api/__tests__/certificatePinning.test.ts
+++ b/frontend/src/api/__tests__/certificatePinning.test.ts
@@ -1,0 +1,102 @@
+import {
+  CertificatePinningError,
+  getActivePins,
+  PIN_SETS,
+  pinnedFetch,
+  verifyPinnedConnection,
+} from "@/api/certificatePinning";
+
+describe("getActivePins", () => {
+  it("returns configured pins that haven't expired", () => {
+    const host = PIN_SETS[0].host;
+    const pins = getActivePins(host, new Date("2026-01-01T00:00:00Z"));
+    expect(pins).toHaveLength(2);
+  });
+
+  it("filters out pins past their expiresAt", () => {
+    const host = PIN_SETS[0].host;
+    const pins = getActivePins(host, new Date("2028-01-01T00:00:00Z"));
+    expect(pins).toHaveLength(0);
+  });
+
+  it("returns nothing for an unknown host", () => {
+    expect(getActivePins("unknown.example.com")).toHaveLength(0);
+  });
+});
+
+describe("verifyPinnedConnection", () => {
+  const win = window as unknown as { __ARENAX_NATIVE__?: unknown };
+
+  afterEach(() => {
+    delete win.__ARENAX_NATIVE__;
+  });
+
+  it("falls back to system trust when no native bridge is present", async () => {
+    const result = await verifyPinnedConnection(PIN_SETS[0].host);
+    expect(result).toEqual({
+      enforced: false,
+      allowed: true,
+      reason: "no-native-bridge-fallback-to-system-trust",
+    });
+  });
+
+  it("allows the connection when the native bridge verifies the pin", async () => {
+    win.__ARENAX_NATIVE__ = {
+      verifyCertificate: jest.fn().mockResolvedValue(true),
+    };
+    const result = await verifyPinnedConnection(PIN_SETS[0].host);
+    expect(result).toEqual({ enforced: true, allowed: true, reason: "native-verified" });
+  });
+
+  it("rejects the connection when the native bridge fails verification", async () => {
+    win.__ARENAX_NATIVE__ = {
+      verifyCertificate: jest.fn().mockResolvedValue(false),
+    };
+    const result = await verifyPinnedConnection(PIN_SETS[0].host);
+    expect(result).toEqual({ enforced: true, allowed: false, reason: "native-rejected" });
+  });
+
+  it("does not fail closed for a host with no configured pins, even with a bridge present", async () => {
+    win.__ARENAX_NATIVE__ = {
+      verifyCertificate: jest.fn().mockResolvedValue(false),
+    };
+    const result = await verifyPinnedConnection("unknown.example.com");
+    expect(result).toEqual({
+      enforced: false,
+      allowed: true,
+      reason: "no-pins-configured-for-host",
+    });
+  });
+});
+
+describe("pinnedFetch", () => {
+  const win = window as unknown as { __ARENAX_NATIVE__?: unknown };
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    delete win.__ARENAX_NATIVE__;
+    global.fetch = originalFetch;
+  });
+
+  it("passes the request through to fetch when allowed", async () => {
+    const mockFetch = jest.fn().mockResolvedValue({ ok: true } as Response);
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    const response = await pinnedFetch("https://unpinned.example.com/api/ping");
+    expect(mockFetch).toHaveBeenCalledWith("https://unpinned.example.com/api/ping", undefined);
+    expect(response.ok).toBe(true);
+  });
+
+  it("throws CertificatePinningError and never calls fetch when the bridge rejects the pin", async () => {
+    win.__ARENAX_NATIVE__ = {
+      verifyCertificate: jest.fn().mockResolvedValue(false),
+    };
+    const mockFetch = jest.fn();
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    await expect(pinnedFetch(`https://${PIN_SETS[0].host}/api/ping`)).rejects.toThrow(
+      CertificatePinningError,
+    );
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/api/certificatePinning.ts
+++ b/frontend/src/api/certificatePinning.ts
@@ -1,0 +1,169 @@
+/**
+ * SSL/TLS certificate pinning for the ArenaX API client.
+ *
+ * Full certificate/public-key pinning (rejecting a connection whose server
+ * certificate doesn't match a known-good key, even if it's issued by a
+ * publicly trusted CA) cannot be enforced from JavaScript in a standard web
+ * browser: the TLS handshake completes before any page JS runs, and
+ * fetch/XHR expose no hook into the certificate that was presented. Real
+ * enforcement has to happen natively:
+ *   - iOS: `NSURLSession` server-trust evaluation (App Transport Security
+ *     pinning dictionary) or TrustKit, configured via Info.plist / a
+ *     `URLSessionDelegate`.
+ *   - Android: Network Security Config `<pin-set>`
+ *     (res/xml/network_security_config.xml) or OkHttp's `CertificatePinner`.
+ *   - React Native / Capacitor wrappers around ArenaX web: a native module
+ *     bridging to the platform APIs above.
+ *
+ * This module is the pinning *policy* (the pin set, with rotation support)
+ * plus the client-side integration point. When a native pinning bridge is
+ * present — the mobile app shell — every request is checked against it
+ * before being allowed to proceed. On plain web, where no such bridge
+ * exists, it explicitly falls back to the browser's system trust store
+ * (still full HTTPS, just without the additional key pin) rather than
+ * silently no-op'ing. See `docs/security/certificate-pinning.md` for the
+ * update/rotation runbook.
+ */
+
+export interface CertificatePin {
+  /** Base64-encoded SHA-256 hash of the certificate's SubjectPublicKeyInfo (the `pin-sha256` value from HPKP-style pinning). */
+  sha256: string;
+  /** ISO-8601 timestamp after which this pin is no longer offered to the native bridge. */
+  expiresAt: string;
+}
+
+export interface HostPinSet {
+  host: string;
+  /** Pin for the certificate currently served in production. */
+  primary: CertificatePin;
+  /**
+   * Pin for the certificate/key ArenaX will rotate to next. Publishing this
+   * ahead of the actual rotation means clients on an older app build (which
+   * only knows the primary pin) keep working right up to rotation, and
+   * clients on a newer build (which already knows the backup pin) work
+   * immediately after — there is no window where a fully-updated client is
+   * locked out.
+   */
+  backup: CertificatePin;
+}
+
+/**
+ * Pin set for ArenaX's API hosts.
+ *
+ * The hashes below are placeholders and MUST be replaced with the real
+ * production SPKI pins before this is relied on for enforcement — see
+ * `docs/security/certificate-pinning.md#computing-a-pin` for how to compute
+ * them from the live certificate.
+ */
+export const PIN_SETS: HostPinSet[] = [
+  {
+    host: "api.arenax.gg",
+    primary: {
+      sha256: "REPLACE_WITH_PRODUCTION_SPKI_PIN_BASE64",
+      expiresAt: "2027-01-01T00:00:00Z",
+    },
+    backup: {
+      sha256: "REPLACE_WITH_PRODUCTION_BACKUP_SPKI_PIN_BASE64",
+      expiresAt: "2027-07-01T00:00:00Z",
+    },
+  },
+];
+
+/** Returns the pins for `host` that haven't passed their `expiresAt`. */
+export function getActivePins(host: string, now: Date = new Date()): CertificatePin[] {
+  const set = PIN_SETS.find((s) => s.host === host);
+  if (!set) return [];
+  return [set.primary, set.backup].filter((pin) => new Date(pin.expiresAt) > now);
+}
+
+/**
+ * Contract a native shell (React Native / Capacitor) implements and exposes
+ * on `window.__ARENAX_NATIVE__` to let web code ask "does this host's
+ * certificate match one of these pins?" using the platform's real TLS
+ * inspection.
+ */
+export interface NativePinningBridge {
+  verifyCertificate(host: string, pinsSha256: string[]): Promise<boolean>;
+}
+
+function getNativeBridge(): NativePinningBridge | undefined {
+  if (typeof window === "undefined") return undefined;
+  return (window as unknown as { __ARENAX_NATIVE__?: NativePinningBridge }).__ARENAX_NATIVE__;
+}
+
+export type PinningResult =
+  | { enforced: true; allowed: boolean; reason: "native-verified" | "native-rejected" }
+  | {
+      enforced: false;
+      allowed: true;
+      reason: "no-native-bridge-fallback-to-system-trust" | "no-pins-configured-for-host";
+    };
+
+/**
+ * Checks pinning status for `host` without making a request. `pinnedFetch`
+ * calls this before every request; exported separately so it can be
+ * inspected/tested directly and reused for diagnostics.
+ */
+export async function verifyPinnedConnection(host: string): Promise<PinningResult> {
+  const bridge = getNativeBridge();
+
+  if (!bridge) {
+    // Fallback to system trust: no native TLS-inspection hook exists (we're
+    // running as a plain web page), so we rely on the browser's own trust
+    // store. The connection is still HTTPS-only; it just isn't additionally
+    // key-pinned from here.
+    return { enforced: false, allowed: true, reason: "no-native-bridge-fallback-to-system-trust" };
+  }
+
+  const pins = getActivePins(host);
+  if (pins.length === 0) {
+    // Don't fail closed on a configuration gap (a host with no/expired
+    // pins), but this is worth alerting on — it means pinning silently
+    // isn't happening for this host despite a native bridge being present.
+    // eslint-disable-next-line no-console
+    console.warn(`[certificate-pinning] no active pins configured for host "${host}"`);
+    return { enforced: false, allowed: true, reason: "no-pins-configured-for-host" };
+  }
+
+  const allowed = await bridge.verifyCertificate(
+    host,
+    pins.map((pin) => pin.sha256),
+  );
+  return { enforced: true, allowed, reason: allowed ? "native-verified" : "native-rejected" };
+}
+
+export class CertificatePinningError extends Error {
+  constructor(host: string) {
+    super(`Connection to "${host}" was rejected: certificate did not match any pinned key.`);
+    this.name = "CertificatePinningError";
+  }
+}
+
+function resolveHost(input: RequestInfo | URL): string | undefined {
+  try {
+    const raw = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    const base = typeof window !== "undefined" ? window.location.origin : undefined;
+    return new URL(raw, base).host;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Drop-in replacement for the global `fetch()` that enforces certificate
+ * pinning (when a native bridge is present) before the request is made.
+ * Every API client call site should go through this instead of calling
+ * `fetch` directly.
+ */
+export async function pinnedFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+  const host = resolveHost(input);
+
+  if (host) {
+    const result = await verifyPinnedConnection(host);
+    if (!result.allowed) {
+      throw new CertificatePinningError(host);
+    }
+  }
+
+  return fetch(input, init);
+}

--- a/frontend/src/data/apiClient.ts
+++ b/frontend/src/data/apiClient.ts
@@ -27,6 +27,7 @@ import {
   type InterceptedRequest,
 } from "@/lib/responseInterceptor";
 import type { StandardResponse, PaginatedStandardResponse } from "@/types/response";
+import { pinnedFetch } from "@/api/certificatePinning";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -206,7 +207,7 @@ export class EnhancedApiClient {
       const refreshToken = getStoredRefreshToken();
       if (!refreshToken) return null;
       try {
-        const res = await fetch(`${this.baseURL}/auth/refresh`, {
+        const res = await pinnedFetch(`${this.baseURL}/auth/refresh`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ refreshToken }),
@@ -249,7 +250,7 @@ export class EnhancedApiClient {
     let success = false;
 
     try {
-      const response = await fetch(url, { ...init, signal: controller.signal });
+      const response = await pinnedFetch(url, { ...init, signal: controller.signal });
       clearTimeout(timeoutId);
       status = response.status;
 
@@ -479,7 +480,7 @@ export class EnhancedApiClient {
     if (token) headers["Authorization"] = `Bearer ${token}`;
 
     const startTime = performance.now();
-    const response = await fetch(url, {
+    const response = await pinnedFetch(url, {
       method: "GET",
       headers,
       signal: AbortSignal.timeout(this.timeoutMs),
@@ -519,7 +520,7 @@ export class EnhancedApiClient {
     if (token) headers["Authorization"] = `Bearer ${token}`;
 
     const startTime = performance.now();
-    const response = await fetch(url, {
+    const response = await pinnedFetch(url, {
       method: "GET",
       headers,
       signal: AbortSignal.timeout(this.timeoutMs),

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -49,6 +49,7 @@ import {
 } from "../types/social";
 import { AuthApiError } from "./authErrors";
 import { API_BASE } from "./constants";
+import { pinnedFetch } from "../api/certificatePinning";
 
 // ---------------------------------------------------------------------------
 // ApiClient
@@ -95,7 +96,7 @@ class ApiClient {
     this.isRefreshing = true;
     this.refreshPromise = (async () => {
       const url = `${this.baseURL}/auth/refresh`;
-      const response = await fetch(url, {
+      const response = await pinnedFetch(url, {
         method: "POST",
         credentials: "include",
         headers: { "Content-Type": "application/json" },
@@ -129,7 +130,7 @@ class ApiClient {
       ...(options.headers as Record<string, string>),
     };
 
-    const response = await fetch(url, {
+    const response = await pinnedFetch(url, {
       ...options,
       headers,
       // Always include cookies — the httpOnly auth_token cookie carries the
@@ -175,7 +176,7 @@ class ApiClient {
       "Content-Type": "application/json",
       ...(options.headers as Record<string, string>),
     };
-    const response = await fetch(url, {
+    const response = await pinnedFetch(url, {
       ...options,
       headers,
       credentials: "include",


### PR DESCRIPTION
## Summary
- `frontend/src/api/certificatePinning.ts` (new): the certificate-pinning policy and integration point.
  - `PIN_SETS` holds a `primary` + `backup` pin (SPKI SHA-256, base64) per host, each with an `expiresAt` for rotation support — see the rotation runbook in the docs below.
  - `verifyPinnedConnection(host)` checks for a native pinning bridge (`window.__ARENAX_NATIVE__.verifyCertificate`, meant to be implemented by a future React Native/Capacitor shell using real platform TLS inspection — iOS TrustKit/App Transport Security, Android Network Security Config). When no bridge exists (today: plain web), it explicitly **falls back to system trust** rather than silently no-op'ing.
  - `pinnedFetch()` is a drop-in `fetch()` replacement that runs the pin check first and throws `CertificatePinningError` if a native bridge rejects the connection.
- Migrated all 6 raw `fetch()` call sites in `frontend/src/lib/api.ts` and `frontend/src/data/apiClient.ts` to `pinnedFetch()`.
- `frontend/src/api/__tests__/certificatePinning.test.ts`: covers pin-expiry filtering, native-verified/native-rejected outcomes, the system-trust fallback with no bridge, not failing closed for an unconfigured host, and that `pinnedFetch` never touches the network when a pin check rejects.
- `docs/security/certificate-pinning.md`: explains why a plain web page can't fully enforce TLS pinning (no JS hook into the handshake) and how this implementation is structured around that — enforced via the native bridge on mobile, system-trust fallback on web — plus the native (iOS/Android) wiring needed when a mobile app ships, the rotation runbook, and how to compute a pin with `openssl`.

## Acceptance criteria
- [x] Certificate pinning in mobile apps — native-bridge contract (`__ARENAX_NATIVE__.verifyCertificate`) ready for a React Native/Capacitor shell to implement against iOS/Android platform pinning APIs (documented; this repo currently ships a Next.js web app, no native shell exists yet to wire the bridge itself into).
- [x] Fallback to system trust — explicit, typed fallback path when no native bridge is present.
- [x] Certificate rotation handling — primary + backup pin per host with `expiresAt`.
- [x] Pinning validation tested — unit tests in `certificatePinning.test.ts`.
- [x] Update mechanism documented — `docs/security/certificate-pinning.md`.

## Test plan
- Not run per task instructions (CI/tests out of scope for this change; frontend `node_modules` isn't installed in this environment). Unit tests are included for when CI runs.

Closes #977