### PR TITLE
feat(observability): unified monitoring and alerting across backend + server

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -38,6 +38,8 @@ rand = "0.8"
 futures = "0.3"
 futures-util = "0.3"
 hex = "0.4"
+prometheus = { version = "0.13", features = ["process"] }
+once_cell = "1.19"
 
 # Security: pin patched versions of transitive deps
 quinn-proto = "0.11.14"

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -3,6 +3,7 @@ pub mod auth;
 pub mod config;
 pub mod db;
 pub mod http;
+pub mod metrics;
 pub mod middleware;
 pub mod models;
 pub mod realtime;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -8,6 +8,7 @@ mod auth;
 mod config;
 mod db;
 mod http;
+mod metrics;
 mod middleware;
 mod models;
 mod realtime;
@@ -19,6 +20,7 @@ use crate::config::Config;
 use crate::db::{create_pool, run_startup_migrations};
 use crate::middleware::cors_middleware;
 use crate::middleware::idempotency_middleware::IdempotencyMiddleware;
+use crate::middleware::metrics_middleware::RequestMetrics;
 use crate::middleware::rate_limit::RateLimitMiddleware;
 use crate::middleware::security::{SecurityConfig, SecurityMiddleware};
 use crate::middleware::tracing_middleware::RequestTracing;
@@ -41,6 +43,10 @@ async fn main() -> io::Result<()> {
     // are flushed to the OTLP exporter (Jaeger/Datadog) on shutdown.
     let _telemetry_guard = init_telemetry();
 
+    // Register Prometheus collectors so they show up in /metrics even
+    // before their first observation.
+    crate::metrics::init_metrics();
+
     // Create database pool
     let db_pool = create_pool(&config)
         .await
@@ -49,6 +55,20 @@ async fn main() -> io::Result<()> {
     run_startup_migrations(&config, &db_pool)
         .await
         .expect("Failed to run database migrations");
+
+    // Periodically snapshot DB pool utilization into the
+    // db_pool_connections_active / db_pool_connections_idle gauges.
+    let pool_metrics_handle = db_pool.clone();
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(15));
+        loop {
+            interval.tick().await;
+            crate::metrics::record_pool_stats(
+                pool_metrics_handle.size(),
+                pool_metrics_handle.num_idle(),
+            );
+        }
+    });
 
     // Spawn the Reaper — forfeits players who miss the reporting deadline
     let reaper = Arc::new(ReaperService::new(db_pool.clone()));
@@ -187,10 +207,15 @@ async fn main() -> io::Result<()> {
             .wrap(AntiBotMiddleware::new(redis_conn.clone(), AntiBotConfig::default()))
             .wrap(cors_middleware())
             .wrap(actix_web::middleware::Logger::default())
+            .wrap(RequestMetrics::new())
             // Outermost: sees the request first (extracts trace context /
             // correlation id) and the response last (records latency,
             // stamps correlation headers).
             .wrap(RequestTracing::new())
+            // Unauthenticated Prometheus scrape target — kept outside the
+            // `/api` scope (and its rate-limit/idempotency/security
+            // middleware) so scraping never competes with real traffic.
+            .route("/metrics", web::get().to(crate::metrics::metrics_handler))
             .service(
                 web::scope("/api")
                     .route("/health", web::get().to(crate::http::health::health_check))

--- a/backend/src/metrics.rs
+++ b/backend/src/metrics.rs
@@ -1,0 +1,110 @@
+//! Prometheus metrics export.
+//!
+//! Exposes a `/metrics` endpoint (Prometheus text exposition format) so a
+//! Prometheus server can scrape this service the same way it already
+//! scrapes `arenax-server` (see `server/infra/monitoring/prometheus.yml`),
+//! giving both services a single, unified monitoring stack instead of one
+//! per service.
+use actix_web::{HttpResponse, Result};
+use once_cell::sync::Lazy;
+use prometheus::{
+    Encoder, HistogramVec, IntCounterVec, IntGauge, Opts, Registry, TextEncoder,
+};
+
+pub static REGISTRY: Lazy<Registry> = Lazy::new(Registry::new);
+
+pub static HTTP_REQUESTS_TOTAL: Lazy<IntCounterVec> = Lazy::new(|| {
+    let counter = IntCounterVec::new(
+        Opts::new("http_requests_total", "Total HTTP requests processed"),
+        &["method", "route", "status_code"],
+    )
+    .expect("metric can be created");
+    REGISTRY
+        .register(Box::new(counter.clone()))
+        .expect("metric can be registered");
+    counter
+});
+
+pub static HTTP_REQUEST_DURATION_SECONDS: Lazy<HistogramVec> = Lazy::new(|| {
+    let histogram = HistogramVec::new(
+        prometheus::HistogramOpts::new(
+            "http_request_duration_seconds",
+            "HTTP request latency in seconds",
+        )
+        .buckets(vec![
+            0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
+        ]),
+        &["method", "route"],
+    )
+    .expect("metric can be created");
+    REGISTRY
+        .register(Box::new(histogram.clone()))
+        .expect("metric can be registered");
+    histogram
+});
+
+pub static DB_POOL_CONNECTIONS_ACTIVE: Lazy<IntGauge> = Lazy::new(|| {
+    let gauge = IntGauge::new(
+        "db_pool_connections_active",
+        "Active PostgreSQL connections held by the pool",
+    )
+    .expect("metric can be created");
+    REGISTRY
+        .register(Box::new(gauge.clone()))
+        .expect("metric can be registered");
+    gauge
+});
+
+pub static DB_POOL_CONNECTIONS_IDLE: Lazy<IntGauge> = Lazy::new(|| {
+    let gauge = IntGauge::new(
+        "db_pool_connections_idle",
+        "Idle PostgreSQL connections held by the pool",
+    )
+    .expect("metric can be created");
+    REGISTRY
+        .register(Box::new(gauge.clone()))
+        .expect("metric can be registered");
+    gauge
+});
+
+/// Force all lazily-registered metrics to initialize (and therefore
+/// register with the collector registry) at startup, before the first
+/// scrape — otherwise a metric with no observations yet simply wouldn't
+/// appear in `/metrics` output.
+pub fn init_metrics() {
+    Lazy::force(&HTTP_REQUESTS_TOTAL);
+    Lazy::force(&HTTP_REQUEST_DURATION_SECONDS);
+    Lazy::force(&DB_POOL_CONNECTIONS_ACTIVE);
+    Lazy::force(&DB_POOL_CONNECTIONS_IDLE);
+
+    // Process-level metrics (process_resident_memory_bytes, process_cpu_seconds_total,
+    // open fds, ...) — same names Node's prom-client exports by default, so the
+    // existing `HighProcessMemory`-style alert expressions work unchanged for
+    // this service too.
+    if let Err(e) = REGISTRY.register(Box::new(
+        prometheus::process_collector::ProcessCollector::for_self(),
+    )) {
+        tracing::warn!(error = %e, "failed to register process metrics collector");
+    }
+}
+
+/// Snapshot the DB pool's active/idle connection counts into the gauges
+/// above. Called periodically by a background task in `main.rs`.
+pub fn record_pool_stats(size: u32, idle: usize) {
+    DB_POOL_CONNECTIONS_ACTIVE.set(size as i64 - idle as i64);
+    DB_POOL_CONNECTIONS_IDLE.set(idle as i64);
+}
+
+pub async fn metrics_handler() -> Result<HttpResponse> {
+    let encoder = TextEncoder::new();
+    let metric_families = REGISTRY.gather();
+    let mut buffer = Vec::new();
+    if let Err(e) = encoder.encode(&metric_families, &mut buffer) {
+        tracing::error!(error = %e, "failed to encode prometheus metrics");
+        return Ok(HttpResponse::InternalServerError().finish());
+    }
+
+    Ok(HttpResponse::Ok()
+        .content_type(encoder.format_type())
+        .body(buffer))
+}

--- a/backend/src/middleware/metrics_middleware.rs
+++ b/backend/src/middleware/metrics_middleware.rs
@@ -1,0 +1,89 @@
+//! Records per-request Prometheus metrics (`http_requests_total`,
+//! `http_request_duration_seconds`) so request rate, error rate, and
+//! latency are all queryable the same way for this service as for
+//! `arenax-server`.
+use std::{
+    future::{ready, Future, Ready},
+    pin::Pin,
+    time::Instant,
+};
+
+use actix_web::{
+    dev::{forward_ready, Service, ServiceRequest, ServiceResponse, Transform},
+    Error,
+};
+
+use crate::metrics::{HTTP_REQUESTS_TOTAL, HTTP_REQUEST_DURATION_SECONDS};
+
+pub struct RequestMetrics;
+
+impl RequestMetrics {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for RequestMetrics {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<S, B> Transform<S, ServiceRequest> for RequestMetrics
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
+    B: 'static,
+{
+    type Response = ServiceResponse<B>;
+    type Error = Error;
+    type InitError = ();
+    type Transform = RequestMetricsMiddleware<S>;
+    type Future = Ready<Result<Self::Transform, Self::InitError>>;
+
+    fn new_transform(&self, service: S) -> Self::Future {
+        ready(Ok(RequestMetricsMiddleware { service }))
+    }
+}
+
+pub struct RequestMetricsMiddleware<S> {
+    service: S,
+}
+
+impl<S, B> Service<ServiceRequest> for RequestMetricsMiddleware<S>
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
+    B: 'static,
+{
+    type Response = ServiceResponse<B>;
+    type Error = Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>>>>;
+
+    forward_ready!(service);
+
+    fn call(&self, req: ServiceRequest) -> Self::Future {
+        let start = Instant::now();
+        let method = req.method().to_string();
+        let route = req
+            .match_pattern()
+            .unwrap_or_else(|| req.path().to_string());
+
+        let fut = self.service.call(req);
+
+        Box::pin(async move {
+            let outcome = fut.await;
+            let elapsed = start.elapsed().as_secs_f64();
+            HTTP_REQUEST_DURATION_SECONDS
+                .with_label_values(&[&method, &route])
+                .observe(elapsed);
+
+            if let Ok(res) = &outcome {
+                let status = res.status().as_u16().to_string();
+                HTTP_REQUESTS_TOTAL
+                    .with_label_values(&[&method, &route, &status])
+                    .inc();
+            }
+
+            outcome
+        })
+    }
+}

--- a/backend/src/middleware/mod.rs
+++ b/backend/src/middleware/mod.rs
@@ -1,11 +1,13 @@
 // Middleware module for ArenaX
 pub mod idempotency_middleware;
+pub mod metrics_middleware;
 pub mod rate_limit;
 pub mod security;
 pub mod tracing_middleware;
 
 pub use anti_bot::AntiBotMiddleware;
 pub use idempotency_middleware::IdempotencyMiddleware;
+pub use metrics_middleware::RequestMetrics;
 pub use rate_limit::RateLimitMiddleware;
 pub use security::SecurityMiddleware;
 pub use tracing_middleware::{correlation_id, CorrelationId, RequestTracing};

--- a/server/infra/monitoring/ONCALL.md
+++ b/server/infra/monitoring/ONCALL.md
@@ -1,0 +1,80 @@
+# On-Call & Alerting
+
+Closes [#970](https://github.com/Arenax-gaming/ArenaX/issues/970) — unified
+monitoring and alerting across `arenax-server` and `arenax-backend`.
+
+## Stack
+
+```
+Prometheus  --scrapes-->  arenax-server (/api/metrics), arenax-backend (/metrics)
+Prometheus  --evaluates-> alert.rules.yml, backend-alert.rules.yml
+Prometheus  --fires-->    Alertmanager
+Alertmanager --routes-->  PagerDuty (Events API v2)
+Grafana     --queries-->  Prometheus, renders arenax-server-overview / arenax-backend-overview
+```
+
+Bring it up:
+
+```bash
+mkdir -p server/infra/monitoring/secrets
+echo -n '<pagerduty critical service integration key>' > server/infra/monitoring/secrets/pagerduty_critical_routing_key
+echo -n '<pagerduty warning service integration key>'  > server/infra/monitoring/secrets/pagerduty_warning_routing_key
+docker compose -f server/infra/monitoring/docker-compose.yml up -d
+```
+
+- Prometheus: http://localhost:9090
+- Alertmanager: http://localhost:9093
+- Grafana: http://localhost:3002 (`admin` / `admin`, change on first login)
+
+## Alert thresholds
+
+| Alert | Service | Threshold | Severity | For |
+|---|---|---|---|---|
+| `ArenaXServerDown` / `ArenaXBackendDown` | both | scrape target down (`up == 0`) | critical | 1m |
+| `HighHttpErrorRate` / `BackendHighHttpErrorRate` | both | 5xx ratio > 5% | critical | 5m |
+| `HighHttpLatencyP95` / `BackendHighHttpLatencyP95` | both | p95 latency > 1s | warning | 5m |
+| `HighProcessMemory` / `BackendHighProcessMemory` | both | RSS > 1.5GB | warning | 10m |
+| `ElevatedApplicationErrors` | arenax-server | high/critical app errors > 1/s | warning | 5m |
+| `BackendDbPoolNearExhaustion` | arenax-backend | pool >90% active connections | warning | 5m |
+
+Definitions live in `alert.rules.yml` (arenax-server) and
+`backend-alert.rules.yml` (arenax-backend). Adjust thresholds there as
+real-world baselines are established — treat the numbers above as
+starting points, not permanent SLOs.
+
+## Escalation policy
+
+1. **Critical alert fires** → Alertmanager pages the on-call engineer via
+   PagerDuty immediately (`group_wait: 10s`, re-notifies every 1h while
+   still firing).
+2. **No acknowledgement within 15 minutes** → PagerDuty's escalation
+   policy (configured in the PagerDuty service, not in this repo) escalates
+   to the secondary on-call.
+3. **No acknowledgement within 30 minutes** → escalates to the engineering
+   lead / team channel.
+4. **Warning alert fires** → pages on-call once (`group_wait: 30s`,
+   re-notifies every 6h while still firing); no auto-escalation past
+   primary on-call. Warnings for a service that's already fully down
+   (`*Down` alert active) are suppressed by `inhibit_rules` in
+   `alertmanager.yml` so a full outage doesn't also spam latency/memory
+   pages for the same root cause.
+5. **Acknowledge in PagerDuty** as soon as you start investigating, so the
+   escalation timers above reset and the rest of the rotation isn't paged
+   for the same incident.
+
+Rotation membership, secondary/lead assignment, and notification channels
+(phone/SMS/push) are configured in the PagerDuty service itself, not in
+this repo — this file documents the policy Alertmanager's routing enforces
+and the thresholds behind it, so anyone touching `alert.rules.yml` /
+`backend-alert.rules.yml` / `alertmanager.yml` knows what behavior they're
+changing.
+
+## Adding a new alert
+
+1. Add the Prometheus rule to `alert.rules.yml` or `backend-alert.rules.yml`
+   with a `severity` label of `critical` or `warning` (Alertmanager's
+   routing in `alertmanager.yml` matches on that label — anything else
+   falls through to the default `pagerduty-warning` receiver).
+2. Add a row to the threshold table above.
+3. If it should show up on a dashboard, add a panel to the relevant
+   `grafana/dashboards/*.json` file.

--- a/server/infra/monitoring/alertmanager.yml
+++ b/server/infra/monitoring/alertmanager.yml
@@ -1,0 +1,63 @@
+# Alertmanager routing/escalation policy for #970.
+#
+# Routes every alert coming from Prometheus (arenax-server + arenax-backend
+# rule groups in alert.rules.yml / backend-alert.rules.yml) to PagerDuty,
+# split by severity:
+#   - severity: critical -> pages on-call immediately (primary escalation)
+#   - severity: warning  -> pages on-call but auto-resolves quietly, no
+#                            repeat page storm
+#
+# See ONCALL.md in this directory for the full on-call escalation policy
+# (who gets paged, how escalation steps up if unacknowledged, etc).
+
+global:
+  resolve_timeout: 5m
+
+route:
+  group_by: ['alertname', 'service']
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 4h
+  receiver: pagerduty-warning
+  routes:
+    - matchers:
+        - severity = critical
+      receiver: pagerduty-critical
+      group_wait: 10s
+      repeat_interval: 1h
+      continue: false
+    - matchers:
+        - severity = warning
+      receiver: pagerduty-warning
+      repeat_interval: 6h
+      continue: false
+
+receivers:
+  - name: pagerduty-critical
+    pagerduty_configs:
+      - routing_key_file: /etc/alertmanager/secrets/pagerduty_critical_routing_key
+        severity: critical
+        description: '{{ .CommonAnnotations.summary }}'
+        details:
+          firing_alerts: '{{ .Alerts.Firing | len }}'
+          service: '{{ .CommonLabels.service }}'
+          runbook: 'server/infra/monitoring/ONCALL.md'
+
+  - name: pagerduty-warning
+    pagerduty_configs:
+      - routing_key_file: /etc/alertmanager/secrets/pagerduty_warning_routing_key
+        severity: warning
+        description: '{{ .CommonAnnotations.summary }}'
+        details:
+          firing_alerts: '{{ .Alerts.Firing | len }}'
+          service: '{{ .CommonLabels.service }}'
+          runbook: 'server/infra/monitoring/ONCALL.md'
+
+inhibit_rules:
+  # Don't page separately for latency/memory/pool warnings on a service
+  # that's already known to be fully down.
+  - source_matchers:
+      - alertname =~ "ArenaXServerDown|ArenaXBackendDown"
+    target_matchers:
+      - severity = warning
+    equal: ['service']

--- a/server/infra/monitoring/backend-alert.rules.yml
+++ b/server/infra/monitoring/backend-alert.rules.yml
@@ -1,0 +1,64 @@
+groups:
+  - name: arenax-backend
+    rules:
+      - alert: ArenaXBackendDown
+        expr: up{job="arenax-backend"} == 0
+        for: 1m
+        labels:
+          severity: critical
+          service: arenax-backend
+        annotations:
+          summary: "arenax-backend is not being scraped"
+          description: "Prometheus has not been able to scrape /metrics on arenax-backend for 1 minute."
+
+      - alert: BackendHighHttpErrorRate
+        expr: |
+          sum(rate(http_requests_total{job="arenax-backend", status_code=~"5.."}[5m]))
+          /
+          sum(rate(http_requests_total{job="arenax-backend"}[5m]))
+          > 0.05
+        for: 5m
+        labels:
+          severity: critical
+          service: arenax-backend
+        annotations:
+          summary: "arenax-backend 5xx error rate above 5%"
+          description: "More than 5% of HTTP responses from arenax-backend have been 5xx over the last 5 minutes."
+
+      - alert: BackendHighHttpLatencyP95
+        expr: |
+          histogram_quantile(
+            0.95,
+            sum(rate(http_request_duration_seconds_bucket{job="arenax-backend"}[5m])) by (le)
+          ) > 1
+        for: 5m
+        labels:
+          severity: warning
+          service: arenax-backend
+        annotations:
+          summary: "arenax-backend p95 HTTP latency above 1s"
+          description: "95th percentile request duration on arenax-backend has been above 1 second for 5 minutes."
+
+      - alert: BackendDbPoolNearExhaustion
+        expr: |
+          db_pool_connections_active{job="arenax-backend"}
+          /
+          (db_pool_connections_active{job="arenax-backend"} + db_pool_connections_idle{job="arenax-backend"})
+          > 0.9
+        for: 5m
+        labels:
+          severity: warning
+          service: arenax-backend
+        annotations:
+          summary: "arenax-backend DB connection pool over 90% utilized"
+          description: "The Postgres connection pool has been over 90% active for 5 minutes — requests may start queuing on pool checkout."
+
+      - alert: BackendHighProcessMemory
+        expr: process_resident_memory_bytes{job="arenax-backend"} > 1.5e9
+        for: 10m
+        labels:
+          severity: warning
+          service: arenax-backend
+        annotations:
+          summary: "arenax-backend resident memory above 1.5GB"
+          description: "Process RSS has been above 1.5GB for 10 minutes — check for leaks or scale up."

--- a/server/infra/monitoring/docker-compose.yml
+++ b/server/infra/monitoring/docker-compose.yml
@@ -1,16 +1,22 @@
 version: '3.8'
 
-# Prometheus + Grafana monitoring stack for #661.
+# Prometheus + Alertmanager + Grafana monitoring stack for #661 / #970.
 #
 # arenax-server already exposes Prometheus-format metrics at
 # `/api/metrics` via prom-client (src/services/metrics.service.ts,
-# src/routes/metrics.routes.ts) — this adds the scraping/storage/
-# visualization/alerting side around that existing instrumentation,
-# without changing how the app itself records metrics.
+# src/routes/metrics.routes.ts), and arenax-backend (the Rust service)
+# now exposes them at `/metrics` (backend/src/metrics.rs) — this stack
+# scrapes both, so the two services are covered by one unified monitoring
+# setup instead of each needing its own. Alertmanager fans firing alerts
+# out to PagerDuty per the routing/severity policy in alertmanager.yml.
 #
 # Usage:
+#   mkdir -p server/infra/monitoring/secrets
+#   echo -n '<pagerduty critical service integration key>' > server/infra/monitoring/secrets/pagerduty_critical_routing_key
+#   echo -n '<pagerduty warning service integration key>'  > server/infra/monitoring/secrets/pagerduty_warning_routing_key
 #   docker compose -f server/infra/monitoring/docker-compose.yml up -d
 #   open http://localhost:9090   # Prometheus
+#   open http://localhost:9093   # Alertmanager
 #   open http://localhost:3002   # Grafana (admin / admin, change on first login)
 services:
   prometheus:
@@ -18,6 +24,7 @@ services:
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - ./alert.rules.yml:/etc/prometheus/alert.rules.yml:ro
+      - ./backend-alert.rules.yml:/etc/prometheus/backend-alert.rules.yml:ro
       - prometheus_data:/prometheus
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
@@ -27,6 +34,31 @@ services:
       - "9090:9090"
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://localhost:9090/-/healthy || exit 1"]
+      interval: 15s
+      timeout: 10s
+      retries: 10
+    depends_on:
+      alertmanager:
+        condition: service_healthy
+    networks:
+      - monitoring-network
+
+  alertmanager:
+    image: prom/alertmanager:v0.27.0
+    volumes:
+      - ./alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+      # PagerDuty Events API v2 integration keys, one secret per file —
+      # see the Usage block above. Never commit real keys; this directory
+      # is gitignored.
+      - ./secrets:/etc/alertmanager/secrets:ro
+      - alertmanager_data:/alertmanager
+    command:
+      - '--config.file=/etc/alertmanager/alertmanager.yml'
+      - '--storage.path=/alertmanager'
+    ports:
+      - "9093:9093"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:9093/-/healthy || exit 1"]
       interval: 15s
       timeout: 10s
       retries: 10
@@ -57,4 +89,5 @@ networks:
 
 volumes:
   prometheus_data:
+  alertmanager_data:
   grafana_data:

--- a/server/infra/monitoring/grafana/dashboards/arenax-backend-overview.json
+++ b/server/infra/monitoring/grafana/dashboards/arenax-backend-overview.json
@@ -1,0 +1,114 @@
+{
+  "title": "ArenaX Backend Overview",
+  "uid": "arenax-backend-overview",
+  "tags": ["arenax", "backend"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-6h", "to": "now" },
+  "panels": [
+    {
+      "id": 1,
+      "title": "HTTP Request Rate (by status class)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "arenax-prometheus" },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{job=\"arenax-backend\"}[5m])) by (status_code)",
+          "legendFormat": "{{status_code}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "5xx Error Rate",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "arenax-prometheus" },
+      "fieldConfig": { "defaults": { "unit": "percentunit" }, "overrides": [] },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{job=\"arenax-backend\", status_code=~\"5..\"}[5m])) / sum(rate(http_requests_total{job=\"arenax-backend\"}[5m]))",
+          "legendFormat": "5xx ratio",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "HTTP Latency (p50 / p95 / p99)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "arenax-prometheus" },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket{job=\"arenax-backend\"}[5m])) by (le))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{job=\"arenax-backend\"}[5m])) by (le))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket{job=\"arenax-backend\"}[5m])) by (le))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "DB Connection Pool",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "arenax-prometheus" },
+      "targets": [
+        {
+          "expr": "db_pool_connections_active{job=\"arenax-backend\"}",
+          "legendFormat": "active",
+          "refId": "A"
+        },
+        {
+          "expr": "db_pool_connections_idle{job=\"arenax-backend\"}",
+          "legendFormat": "idle",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Process Resident Memory",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "datasource": { "type": "prometheus", "uid": "arenax-prometheus" },
+      "fieldConfig": { "defaults": { "unit": "bytes" }, "overrides": [] },
+      "targets": [
+        {
+          "expr": "process_resident_memory_bytes{job=\"arenax-backend\"}",
+          "legendFormat": "RSS",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "title": "Service Up",
+      "type": "stat",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "datasource": { "type": "prometheus", "uid": "arenax-prometheus" },
+      "targets": [
+        {
+          "expr": "up{job=\"arenax-backend\"}",
+          "legendFormat": "up",
+          "refId": "A"
+        }
+      ]
+    }
+  ]
+}

--- a/server/infra/monitoring/prometheus.yml
+++ b/server/infra/monitoring/prometheus.yml
@@ -2,23 +2,40 @@ global:
   scrape_interval: 15s
   evaluation_interval: 15s
 
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: ['alertmanager:9093']
+
 rule_files:
   - /etc/prometheus/alert.rules.yml
+  - /etc/prometheus/backend-alert.rules.yml
 
 scrape_configs:
   - job_name: prometheus
     static_configs:
       - targets: ['localhost:9090']
 
-  # arenax-server runs on the host (npm run dev / npm start), not inside
-  # this compose network — same pattern as infra/elk's bind-mounted log
-  # tailing. `host.docker.internal` reaches the host from a container on
-  # Docker Desktop (Mac/Windows). On Linux, either run Docker with
-  # `--add-host=host.docker.internal:host-gateway` (Docker Engine 20.10+)
-  # or replace the target below with the host's actual IP/hostname.
+  # arenax-server and arenax-backend both run on the host (npm run dev /
+  # npm start, cargo run), not inside this compose network — same pattern
+  # as infra/elk's bind-mounted log tailing. `host.docker.internal` reaches
+  # the host from a container on Docker Desktop (Mac/Windows). On Linux,
+  # either run Docker with `--add-host=host.docker.internal:host-gateway`
+  # (Docker Engine 20.10+) or replace the targets below with the host's
+  # actual IP/hostname.
   - job_name: arenax-server
     metrics_path: /api/metrics
     static_configs:
       - targets: ['host.docker.internal:3001']
         labels:
           service: arenax-server
+
+  # Rust backend (backend/) — Prometheus metrics added for #970 so both
+  # services are visible in one unified stack instead of arenax-server
+  # being the only instrumented one.
+  - job_name: arenax-backend
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['host.docker.internal:8080']
+        labels:
+          service: arenax-backend

--- a/server/infra/monitoring/secrets/.gitignore
+++ b/server/infra/monitoring/secrets/.gitignore
@@ -1,0 +1,3 @@
+# PagerDuty routing keys are secrets — never commit real values here.
+*
+!.gitignore


### PR DESCRIPTION
## Summary

Extends the existing Prometheus/Grafana stack (previously arenax-server only, #661) into unified monitoring across both services, and wires up PagerDuty alerting end to end.

- **Prometheus metrics export** — the Rust `backend/` service now exposes `/metrics` (new `backend/src/metrics.rs` + `RequestMetrics` middleware): HTTP request counts/status codes, request latency histogram, DB connection pool active/idle gauges, and standard process metrics (RSS, CPU, fds) via `prometheus::process_collector`.
- **Grafana dashboards** — new `server/infra/monitoring/grafana/dashboards/arenax-backend-overview.json` alongside the existing `arenax-server-overview.json`.
- **PagerDuty alerts** — new `alertmanager` service in `server/infra/monitoring/docker-compose.yml`, configured via `alertmanager.yml` with separate critical/warning PagerDuty receivers (PagerDuty Events API v2, routing keys read from files under a gitignored `secrets/` directory, never inline).
- **Alert thresholds defined** — new `backend-alert.rules.yml` (service down, 5xx rate > 5%, p95 latency > 1s, DB pool > 90% utilized, RSS > 1.5GB), scraped by Prometheus alongside the existing `alert.rules.yml` for arenax-server.
- **On-call escalation** — documented in new `server/infra/monitoring/ONCALL.md`: escalation timers, alert-threshold reference table, and inhibition rules so a full-service outage doesn't also spam latency/memory warnings for the same root cause.

## Test plan

- [ ] `cargo build` for `backend/` (not run in this environment — no Rust toolchain available here)
- [ ] `docker compose -f server/infra/monitoring/docker-compose.yml up -d` and confirm Prometheus scrapes both `arenax-server` and `arenax-backend` targets as up
- [ ] Confirm Alertmanager receives a test alert and routes it to the correct PagerDuty receiver by severity
- [ ] Load the new Grafana dashboard and confirm panels populate

Closes #970