### PR TITLE
feat(backend): automated database backup, verification, and recovery

### DIFF
--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -1,0 +1,47 @@
+name: Database Backup
+
+on:
+  schedule:
+    # 03:00 UTC daily
+    - cron: '0 3 * * *'
+  workflow_dispatch: {}
+
+jobs:
+  backup:
+    name: Backup and verify
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./backend
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install PostgreSQL client
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Run backup
+        env:
+          DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}
+          S3_BACKUP_BUCKET: ${{ secrets.DB_BACKUP_S3_BUCKET }}
+        run: ./scripts/backup-database.sh
+
+      - name: Verify backup restores cleanly
+        env:
+          DATABASE_URL: ${{ secrets.DB_BACKUP_VERIFY_DATABASE_URL }}
+          S3_BACKUP_BUCKET: ${{ secrets.DB_BACKUP_S3_BUCKET }}
+        run: ./scripts/verify-backup.sh --latest
+
+      - name: Notify on failure
+        if: failure()
+        run: |
+          echo "::error::Daily database backup or verification failed — see BACKUP_RECOVERY.md for the manual recovery procedure and escalate per server/infra/monitoring/ONCALL.md."

--- a/backend/scripts/BACKUP_RECOVERY.md
+++ b/backend/scripts/BACKUP_RECOVERY.md
@@ -1,0 +1,83 @@
+# Database Backup & Recovery
+
+Closes [#971](https://github.com/Arenax-gaming/ArenaX/issues/971) —
+automated backups and a documented recovery path for the backend's
+PostgreSQL database.
+
+## Components
+
+| Script | Purpose |
+|---|---|
+| `backup-database.sh` | `pg_dump` a full logical backup, checksum it, upload to S3, prune local copies past retention |
+| `restore-database.sh` | Restore a local or `--latest` S3 backup into `DATABASE_URL` |
+| `verify-backup.sh` | Restore a backup into a disposable scratch database and sanity-check it — this is the "does the backup actually work" test |
+| `wal-archive-push.sh` | Postgres `archive_command` — continuously ships WAL segments to S3 |
+| `wal-archive-restore.sh` | Postgres `restore_command` — replays archived WAL for point-in-time recovery |
+
+`.github/workflows/db-backup.yml` runs `backup-database.sh` then
+`verify-backup.sh` daily on a schedule, so every backup is proven
+restorable before it's trusted.
+
+## RTO / RPO targets
+
+| Scenario | RPO (data loss) | RTO (time to recover) |
+|---|---|---|
+| Full daily backup restore | ≤ 24h (time since last daily backup) | ≤ 1h |
+| Point-in-time recovery (WAL archiving enabled) | ≤ 5 min (WAL archive/shipping lag) | ≤ 2h |
+
+These are targets to design and alert against, not guarantees — track
+actual restore duration each time `verify-backup.sh` runs in CI and
+revisit the targets if reality drifts from them.
+
+## Recovery procedures
+
+### 1. Restore the latest daily backup (most common case)
+
+```bash
+export DATABASE_URL=postgres://arenax:***@<recovery-host>:5432/arenax
+export S3_BACKUP_BUCKET=s3://arenax-db-backups/backend
+./scripts/restore-database.sh --latest
+```
+
+This gets you back to the state as of the last daily backup (RPO ≤ 24h).
+
+### 2. Point-in-time recovery (minimize data loss past the last backup)
+
+Requires WAL archiving to have been running (`archive_command` wired to
+`wal-archive-push.sh`, see that script's header for the `postgresql.conf`
+snippet):
+
+1. Provision a fresh Postgres instance from the most recent base backup
+   (`pg_basebackup`, or restore the latest `backup-database.sh` dump into
+   a fresh cluster).
+2. Set `restore_command` to `wal-archive-restore.sh` and
+   `recovery_target_time` to the desired point in time in
+   `postgresql.conf` (or the `recovery.signal` mechanism for the running
+   Postgres major version).
+3. Start Postgres; it replays archived WAL up to the target time and
+   then stops recovery.
+4. Verify with `verify-backup.sh` semantics manually (row counts, key
+   tables) before cutting traffic over.
+5. Repoint `DATABASE_URL` (app config / secrets) at the recovered
+   instance.
+
+### 3. Verify a backup is actually restorable (routine, and after any
+   backup pipeline change)
+
+```bash
+export DATABASE_URL=postgres://arenax:***@<any-postgres-with-create-db-rights>:5432/arenax
+export S3_BACKUP_BUCKET=s3://arenax-db-backups/backend
+./scripts/verify-backup.sh --latest
+```
+
+Creates and drops a scratch database — never touches the database named
+in `DATABASE_URL` itself.
+
+## Backup schedule
+
+`.github/workflows/db-backup.yml` runs `backup-database.sh` daily at
+03:00 UTC against the production database (via repo secrets
+`PROD_DATABASE_URL`, `AWS_*`, `S3_BACKUP_BUCKET`), then immediately runs
+`verify-backup.sh` against the backup it just produced so a broken backup
+is caught the same day it's taken, not discovered during an actual
+incident.

--- a/backend/scripts/backup-database.sh
+++ b/backend/scripts/backup-database.sh
@@ -1,4 +1,15 @@
 #!/usr/bin/env bash
+# Creates a full logical backup of the database at $DATABASE_URL and,
+# when S3_BACKUP_BUCKET is set, uploads it (plus a sha256 checksum) to S3.
+#
+# Env:
+#   DATABASE_URL       (required) target Postgres connection string
+#   BACKUP_DIR          (default ./backups) local staging directory
+#   S3_BACKUP_BUCKET     (optional) e.g. s3://arenax-db-backups/backend
+#   BACKUP_RETENTION_DAYS (default 30) prune local dumps older than this
+#
+# See backend/scripts/BACKUP_RECOVERY.md for RTO/RPO targets and the full
+# recovery procedure (restore-database.sh, verify-backup.sh).
 set -euo pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
@@ -9,11 +20,34 @@ if [ -z "${DATABASE_URL:-}" ]; then
 fi
 
 backup_dir="${BACKUP_DIR:-./backups}"
+retention_days="${BACKUP_RETENTION_DAYS:-30}"
 mkdir -p "$backup_dir"
 
 timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
 output="$backup_dir/arenax-$timestamp.dump"
+checksum_file="$output.sha256"
 
+echo "Creating backup: $output"
 pg_dump "$DATABASE_URL" --format=custom --no-owner --no-acl --file="$output"
+
+sha256sum "$output" > "$checksum_file"
+echo "Checksum written to $checksum_file"
+
+if [ -n "${S3_BACKUP_BUCKET:-}" ]; then
+  echo "Uploading backup to $S3_BACKUP_BUCKET"
+  aws s3 cp "$output" "$S3_BACKUP_BUCKET/$(basename "$output")"
+  aws s3 cp "$checksum_file" "$S3_BACKUP_BUCKET/$(basename "$checksum_file")"
+
+  # "latest" pointer so restore-database.sh --latest doesn't need to list
+  # the bucket to find the newest backup.
+  latest_pointer="$backup_dir/latest.txt"
+  echo "$(basename "$output")" > "$latest_pointer"
+  aws s3 cp "$latest_pointer" "$S3_BACKUP_BUCKET/latest.txt"
+fi
+
+# Prune local dumps older than the retention window. Remote (S3) retention
+# is managed by a bucket lifecycle rule instead, since that's the durable
+# copy — see BACKUP_RECOVERY.md.
+find "$backup_dir" -maxdepth 1 -name 'arenax-*.dump*' -mtime "+$retention_days" -print -delete
 
 echo "Database backup written to $output"

--- a/backend/scripts/restore-database.sh
+++ b/backend/scripts/restore-database.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Restores a backup produced by backup-database.sh into $DATABASE_URL.
+#
+# Usage:
+#   ./scripts/restore-database.sh <path-to-dump>          # restore a local dump
+#   ./scripts/restore-database.sh --latest                # fetch+restore the newest S3 backup
+#   ./scripts/restore-database.sh --latest --dry-run       # download + verify checksum only
+#
+# Env:
+#   DATABASE_URL       (required) target Postgres connection string to restore INTO
+#   BACKUP_DIR          (default ./backups) local staging directory
+#   S3_BACKUP_BUCKET     (required for --latest)
+#
+# This performs point-in-time-adjacent recovery to "as of the chosen
+# backup". For true point-in-time recovery to an arbitrary timestamp
+# between backups, replay archived WAL after this restore — see
+# BACKUP_RECOVERY.md and wal-archive-restore-command.sh.
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+if [ -z "${DATABASE_URL:-}" ]; then
+  echo "DATABASE_URL must be set before restoring a backup." >&2
+  exit 1
+fi
+
+backup_dir="${BACKUP_DIR:-./backups}"
+mkdir -p "$backup_dir"
+
+dry_run=false
+target=""
+for arg in "$@"; do
+  case "$arg" in
+    --latest) target="--latest" ;;
+    --dry-run) dry_run=true ;;
+    *) target="$arg" ;;
+  esac
+done
+
+if [ -z "$target" ]; then
+  echo "Usage: $0 <path-to-dump>|--latest [--dry-run]" >&2
+  exit 1
+fi
+
+if [ "$target" = "--latest" ]; then
+  if [ -z "${S3_BACKUP_BUCKET:-}" ]; then
+    echo "S3_BACKUP_BUCKET must be set to use --latest." >&2
+    exit 1
+  fi
+  echo "Fetching latest backup pointer from $S3_BACKUP_BUCKET"
+  aws s3 cp "$S3_BACKUP_BUCKET/latest.txt" "$backup_dir/latest.txt"
+  latest_name="$(cat "$backup_dir/latest.txt")"
+  dump_path="$backup_dir/$latest_name"
+  aws s3 cp "$S3_BACKUP_BUCKET/$latest_name" "$dump_path"
+  aws s3 cp "$S3_BACKUP_BUCKET/$latest_name.sha256" "$dump_path.sha256"
+else
+  dump_path="$target"
+fi
+
+if [ ! -f "$dump_path" ]; then
+  echo "Backup file not found: $dump_path" >&2
+  exit 1
+fi
+
+if [ -f "$dump_path.sha256" ]; then
+  echo "Verifying checksum..."
+  sha256sum -c "$dump_path.sha256"
+else
+  echo "Warning: no checksum file found for $dump_path, skipping verification." >&2
+fi
+
+if [ "$dry_run" = true ]; then
+  echo "Dry run: backup downloaded and verified at $dump_path, not restored."
+  exit 0
+fi
+
+echo "Restoring $dump_path into target database..."
+pg_restore --clean --if-exists --no-owner --no-acl --dbname="$DATABASE_URL" "$dump_path"
+
+echo "Restore complete."

--- a/backend/scripts/verify-backup.sh
+++ b/backend/scripts/verify-backup.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Backup verification test: restores a backup into a disposable database
+# and runs sanity checks against it, then drops the scratch database.
+# This is what actually proves a backup is usable — a dump that "exists"
+# but can't be restored, or restores into an empty schema, is not a
+# working backup.
+#
+# Usage:
+#   ./scripts/verify-backup.sh <path-to-dump>
+#   ./scripts/verify-backup.sh --latest
+#
+# Env:
+#   DATABASE_URL   (required) admin connection string used as the template
+#                  for the scratch database (its own database is never
+#                  touched — a new sibling database is created/dropped)
+#   S3_BACKUP_BUCKET (required for --latest)
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+if [ -z "${DATABASE_URL:-}" ]; then
+  echo "DATABASE_URL must be set (used as the admin connection to create/drop the scratch database)." >&2
+  exit 1
+fi
+
+target="${1:-}"
+if [ -z "$target" ]; then
+  echo "Usage: $0 <path-to-dump>|--latest" >&2
+  exit 1
+fi
+
+scratch_db="arenax_backup_verify_$(date -u +%Y%m%d%H%M%S)"
+
+# Derive an admin URL (connects to the `postgres` maintenance database)
+# and a scratch-db URL from DATABASE_URL, e.g.
+# postgres://user:pass@host:5432/arenax -> .../postgres and .../<scratch>
+base_url="${DATABASE_URL%/*}"
+admin_url="$base_url/postgres"
+scratch_url="$base_url/$scratch_db"
+
+cleanup() {
+  echo "Dropping scratch database $scratch_db"
+  psql "$admin_url" -v ON_ERROR_STOP=1 -c "DROP DATABASE IF EXISTS \"$scratch_db\";" >/dev/null
+}
+trap cleanup EXIT
+
+echo "Creating scratch database $scratch_db"
+psql "$admin_url" -v ON_ERROR_STOP=1 -c "CREATE DATABASE \"$scratch_db\";"
+
+echo "Restoring backup into $scratch_db..."
+DATABASE_URL="$scratch_url" ./scripts/restore-database.sh "$target"
+
+echo "Running verification checks against $scratch_db..."
+
+table_count="$(psql "$scratch_url" -t -A -c "SELECT count(*) FROM information_schema.tables WHERE table_schema = 'public';")"
+echo "  public tables: $table_count"
+if [ "$table_count" -lt 1 ]; then
+  echo "FAIL: restored database has no tables in the public schema." >&2
+  exit 1
+fi
+
+if psql "$scratch_url" -t -A -c "SELECT to_regclass('public._sqlx_migrations');" | grep -q '_sqlx_migrations'; then
+  applied_migrations="$(psql "$scratch_url" -t -A -c "SELECT count(*) FROM _sqlx_migrations WHERE success = true;")"
+  echo "  applied migrations: $applied_migrations"
+  if [ "$applied_migrations" -lt 1 ]; then
+    echo "FAIL: _sqlx_migrations table exists but no migration recorded as applied." >&2
+    exit 1
+  fi
+else
+  echo "WARN: _sqlx_migrations table not found — skipping migration-count check." >&2
+fi
+
+echo "PASS: backup $target restores cleanly and contains expected schema state."

--- a/backend/scripts/wal-archive-push.sh
+++ b/backend/scripts/wal-archive-push.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Postgres `archive_command` — ships each completed WAL segment to S3 so
+# point-in-time recovery can replay WAL past the last full backup instead
+# of only being able to restore to a backup's own timestamp.
+#
+# postgresql.conf:
+#   archive_mode = on
+#   archive_command = '/path/to/wal-archive-push.sh %p %f'
+#
+# Env:
+#   S3_BACKUP_BUCKET (required) e.g. s3://arenax-db-backups/backend
+set -euo pipefail
+
+wal_path="$1"   # %p — full path to the WAL file to archive
+wal_file="$2"   # %f — the WAL file's name
+
+if [ -z "${S3_BACKUP_BUCKET:-}" ]; then
+  echo "S3_BACKUP_BUCKET must be set." >&2
+  exit 1
+fi
+
+aws s3 cp "$wal_path" "$S3_BACKUP_BUCKET/wal/$wal_file" --only-show-errors

--- a/backend/scripts/wal-archive-restore.sh
+++ b/backend/scripts/wal-archive-restore.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Postgres `restore_command` for point-in-time recovery — fetches an
+# archived WAL segment from S3 so a recovering standby/replica can replay
+# it. Paired with wal-archive-push.sh (the archive_command) and a
+# recovery_target_time set in postgresql.conf / recovery signal file.
+#
+# postgresql.conf (on the recovery target host, after restoring the base
+# backup produced by backup-database.sh / pg_basebackup):
+#   restore_command = '/path/to/wal-archive-restore.sh %f %p'
+#   recovery_target_time = '2026-08-26 12:00:00+00'
+#
+# Env:
+#   S3_BACKUP_BUCKET (required) e.g. s3://arenax-db-backups/backend
+set -euo pipefail
+
+wal_file="$1"   # %f — the WAL file name Postgres wants
+dest_path="$2"  # %p — where Postgres wants it written
+
+if [ -z "${S3_BACKUP_BUCKET:-}" ]; then
+  echo "S3_BACKUP_BUCKET must be set." >&2
+  exit 1
+fi
+
+aws s3 cp "$S3_BACKUP_BUCKET/wal/$wal_file" "$dest_path" --only-show-errors


### PR DESCRIPTION
## Summary

Adds automated, verified daily backups for the backend's PostgreSQL database plus a documented recovery path, closing the gap where backups only existed as a manual `pg_dump` script with no automation, no S3 durability, and no way to prove a backup actually restores.

- **Daily backups to S3** — `backup-database.sh` now checksums each dump and uploads it (plus a `latest.txt` pointer) to `S3_BACKUP_BUCKET`, pruning local copies past `BACKUP_RETENTION_DAYS`. `.github/workflows/db-backup.yml` runs it daily at 03:00 UTC (also `workflow_dispatch`-able).
- **Point-in-time recovery** — `wal-archive-push.sh` / `wal-archive-restore.sh` are ready to wire up as Postgres `archive_command` / `restore_command` so WAL can be replayed to an arbitrary point past the last full backup.
- **Backup verification tests** — new `verify-backup.sh` restores a backup into a disposable scratch database (created/dropped via the admin connection, never touching the real database) and checks table count + applied-migrations count. The daily workflow runs this immediately after every backup, so a broken backup is caught the same day, not during an incident.
- **RTO/RPO targets defined** and **recovery procedures documented** in new `backend/scripts/BACKUP_RECOVERY.md`.
- `restore-database.sh` restores a local dump or `--latest` from S3, with checksum verification and a `--dry-run` mode.

## Secrets this workflow expects (not created here)

`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, `PROD_DATABASE_URL`, `DB_BACKUP_S3_BUCKET`, `DB_BACKUP_VERIFY_DATABASE_URL` — repo/org secrets to be provisioned by whoever owns the AWS account and production database.

## Test plan

- [ ] Provision the secrets above and confirm the scheduled workflow runs a backup + verification successfully
- [ ] Manually run `restore-database.sh --latest` against a scratch environment and confirm the app boots against the restored data
- [ ] Exercise the PITR procedure in `BACKUP_RECOVERY.md` end to end against a disposable Postgres instance

Closes #971