### PR TITLE
feat(#890): Chat moderation UI for admins

### DIFF
--- a/frontend/src/__tests__/chat-moderation.test.tsx
+++ b/frontend/src/__tests__/chat-moderation.test.tsx
@@ -1,0 +1,256 @@
+/**
+ * Tests for the admin chat-moderation UI on <ChatInterface /> (issue #890).
+ *
+ * Acceptance criteria covered:
+ *  - flag / report a message
+ *  - mute a user for 1 / 24 / 72 hours
+ *  - ban a user
+ *  - view a user's message history
+ *  - undo any action within the (configurable) 5-minute window
+ *  - report available to everyone, mute/ban/history gated behind `isAdmin`
+ *  - fully backwards-compatible when no `moderation` config is supplied
+ */
+import React from "react";
+import { render, screen, fireEvent, act, within } from "@testing-library/react";
+import {
+  ChatInterface,
+  MUTE_DURATIONS,
+  type ChatModerationConfig,
+} from "@/components/social/ChatInterface";
+
+// The chat renders against a looser runtime shape than the exported types, so
+// fixtures are built as plain objects and passed through `as any`.
+const currentUser = {
+  id: "me",
+  username: "Me",
+  elo: 1200,
+  status: "online",
+} as any;
+
+// A party conversation keeps the header on the icon path (no next/image).
+const conversation = {
+  id: "c1",
+  type: "party",
+  participants: [
+    { id: "u1", username: "Griefer", status: "online" },
+    { id: "me", username: "Me", status: "online" },
+  ],
+} as any;
+
+let msgSeq = 0;
+function makeMessage(overrides: Record<string, unknown> = {}) {
+  msgSeq += 1;
+  return {
+    id: `m${msgSeq}`,
+    senderId: "u1",
+    senderName: "Griefer",
+    content: "you all suck",
+    timestamp: "2026-08-25T10:00:00.000Z",
+    status: "read",
+    ...overrides,
+  } as any;
+}
+
+function setup(
+  moderation?: ChatModerationConfig,
+  messages: any[] = [makeMessage()]
+) {
+  const props = {
+    conversations: [conversation],
+    activeConversation: conversation,
+    messages,
+    isTyping: false,
+    currentUser,
+    onSelectConversation: jest.fn(),
+    onSendMessage: jest.fn(),
+    moderation,
+  };
+  const utils = render(<ChatInterface {...(props as any)} />);
+  return { ...utils, props };
+}
+
+function openMenu(index = 0) {
+  const triggers = screen.getAllByLabelText(/^Moderate message from/);
+  fireEvent.click(triggers[index]);
+  return screen.getByRole("menu", { name: /Moderation actions for/ });
+}
+
+beforeEach(() => {
+  msgSeq = 0;
+  // jsdom has no layout engine; the chat auto-scrolls on mount.
+  Element.prototype.scrollIntoView = jest.fn();
+});
+
+describe("ChatInterface moderation (#890)", () => {
+  it("renders no moderation affordances without a moderation config", () => {
+    setup(undefined);
+    expect(
+      screen.queryByLabelText(/^Moderate message from/)
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not show the trigger on the admin's own messages", () => {
+    setup(
+      { isAdmin: true },
+      [makeMessage({ senderId: "me", senderName: "Me", content: "gg" })]
+    );
+    expect(
+      screen.queryByLabelText(/^Moderate message from/)
+    ).not.toBeInTheDocument();
+  });
+
+  it("reports a message and surfaces an undoable toast", () => {
+    const onReportMessage = jest.fn();
+    const onUndoReport = jest.fn();
+    setup({ isAdmin: true, onReportMessage, onUndoReport });
+
+    openMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Report message" }));
+
+    expect(onReportMessage).toHaveBeenCalledWith("m1", {
+      senderId: "u1",
+      content: "you all suck",
+    });
+
+    const toast = screen.getByRole("status");
+    expect(toast).toHaveTextContent("Message reported");
+
+    fireEvent.click(within(toast).getByRole("button", { name: "Undo" }));
+    expect(onUndoReport).toHaveBeenCalledWith("m1");
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+
+  it("offers all three mute presets and mutes for the chosen duration", () => {
+    const onMuteUser = jest.fn();
+    setup({ isAdmin: true, onMuteUser });
+
+    openMenu();
+    // 1 / 24 / 72 hours all present.
+    MUTE_DURATIONS.forEach((h) => {
+      const label = h === 1 ? "Mute for 1 hour" : `Mute for ${h} hours`;
+      expect(screen.getByRole("menuitem", { name: label })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("menuitem", { name: "Mute for 24 hours" }));
+    expect(onMuteUser).toHaveBeenCalledWith("u1", 24);
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Muted Griefer for 24 hours"
+    );
+  });
+
+  it("bans a user and can undo the ban within the window", () => {
+    const onBanUser = jest.fn();
+    const onUnbanUser = jest.fn();
+    setup({ isAdmin: true, onBanUser, onUnbanUser });
+
+    openMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Ban user" }));
+    expect(onBanUser).toHaveBeenCalledWith("u1");
+
+    const toast = screen.getByRole("status");
+    expect(toast).toHaveTextContent("Banned Griefer");
+    fireEvent.click(within(toast).getByRole("button", { name: "Undo" }));
+    expect(onUnbanUser).toHaveBeenCalledWith("u1");
+  });
+
+  it("lets non-admins report but hides mute / ban / history", () => {
+    setup({ isAdmin: false });
+
+    openMenu();
+    expect(
+      screen.getByRole("menuitem", { name: "Report message" })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("menuitem", { name: "Ban user" })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("menuitem", { name: "Mute for 1 hour" })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("menuitem", { name: "View message history" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides the trigger entirely when reporting is disabled for a non-admin", () => {
+    setup({ isAdmin: false, canReport: false });
+    expect(
+      screen.queryByLabelText(/^Moderate message from/)
+    ).not.toBeInTheDocument();
+  });
+
+  it("opens message history and lists only that user's messages", () => {
+    const onViewUserHistory = jest.fn();
+    setup(
+      { isAdmin: true, onViewUserHistory },
+      [
+        makeMessage({ content: "hello there" }),
+        makeMessage({ senderId: "me", senderName: "Me", content: "be nice" }),
+        makeMessage({ content: "spam spam spam" }),
+      ]
+    );
+
+    openMenu(0); // first Griefer message
+    fireEvent.click(
+      screen.getByRole("menuitem", { name: "View message history" })
+    );
+    expect(onViewUserHistory).toHaveBeenCalledWith("u1");
+
+    const dialog = screen.getByRole("dialog", {
+      name: "Message history for Griefer",
+    });
+    const entries = within(dialog).getAllByTestId("history-message");
+    expect(entries).toHaveLength(2);
+    expect(dialog).toHaveTextContent("hello there");
+    expect(dialog).toHaveTextContent("spam spam spam");
+    expect(dialog).not.toHaveTextContent("be nice");
+
+    fireEvent.click(
+      within(dialog).getByRole("button", { name: "Close message history" })
+    );
+    expect(
+      screen.queryByRole("dialog", { name: "Message history for Griefer" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("reflects banned / muted status on the offending user's messages", () => {
+    const { rerender } = setup({ isAdmin: true, bannedUserIds: ["u1"] });
+    expect(screen.getByTestId("moderation-status")).toHaveTextContent("Banned");
+
+    rerender(
+      <ChatInterface
+        {...({
+          conversations: [conversation],
+          activeConversation: conversation,
+          messages: [makeMessage({ id: "m1" })],
+          isTyping: false,
+          currentUser,
+          onSelectConversation: jest.fn(),
+          onSendMessage: jest.fn(),
+          moderation: { isAdmin: true, mutedUserIds: ["u1"] },
+        } as any)}
+      />
+    );
+    expect(screen.getByTestId("moderation-status")).toHaveTextContent("Muted");
+  });
+
+  it("auto-dismisses the undo toast after the undo window elapses", () => {
+    jest.useFakeTimers();
+    try {
+      const onMuteUser = jest.fn();
+      setup({ isAdmin: true, undoWindowMs: 1000, onMuteUser });
+
+      openMenu();
+      fireEvent.click(
+        screen.getByRole("menuitem", { name: "Mute for 1 hour" })
+      );
+      expect(screen.getByRole("status")).toBeInTheDocument();
+
+      act(() => {
+        jest.advanceTimersByTime(1000);
+      });
+      expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});

--- a/frontend/src/components/social/ChatInterface.tsx
+++ b/frontend/src/components/social/ChatInterface.tsx
@@ -14,11 +14,72 @@ import {
   Clock,
   ArrowLeft,
   Users,
+  Flag,
+  MicOff,
+  Ban,
+  History,
+  Undo2,
+  MoreHorizontal,
+  X,
 } from "lucide-react";
 import { Card } from "@/components/ui/Card";
 import { Button } from "@/components/ui/Button";
 import { AvatarWithStatus } from "./OnlineStatus";
 import type { Conversation, Message, SocialUser } from "@/types/social";
+
+/** Mute presets (hours) required by the acceptance criteria. */
+export const MUTE_DURATIONS = [1, 24, 72] as const;
+export type MuteDuration = (typeof MUTE_DURATIONS)[number];
+
+/**
+ * Optional admin moderation surface for the chat (issue #890). When omitted the
+ * chat renders exactly as before, so existing (non-admin) call sites are
+ * unaffected. Reporting is available to everyone unless `canReport` is false;
+ * mute/ban/history are gated behind `isAdmin`.
+ */
+export interface ChatModerationConfig {
+  /** Unlocks mute / ban / message-history actions. */
+  isAdmin?: boolean;
+  /** Allow reporting messages. Defaults to true. */
+  canReport?: boolean;
+  /** How long a moderation action can be undone. Defaults to 5 minutes. */
+  undoWindowMs?: number;
+  /** Users currently muted / banned — used to reflect state in the menu. */
+  mutedUserIds?: string[];
+  bannedUserIds?: string[];
+  onReportMessage?: (
+    messageId: string,
+    meta: { senderId: string; content: string }
+  ) => void;
+  onMuteUser?: (userId: string, durationHours: MuteDuration) => void;
+  onBanUser?: (userId: string) => void;
+  /** Inverse operations, invoked when an action is undone within the window. */
+  onUnmuteUser?: (userId: string) => void;
+  onUnbanUser?: (userId: string) => void;
+  onUndoReport?: (messageId: string) => void;
+  /** Optional server-side history fetch; falls back to the loaded messages. */
+  onViewUserHistory?: (userId: string) => void;
+}
+
+// The chat's runtime message/conversation shape is looser than the exported
+// type (it carries senderId/senderName/timestamp); read those fields defensively
+// so moderation works regardless of which shape a caller passes.
+const getSenderId = (m: Message): string =>
+  (m as any).senderId ?? (m as any).fromUserId ?? "";
+const getSenderName = (m: Message): string =>
+  (m as any).senderName ??
+  (m as any).fromUsername ??
+  "User";
+const getTimestamp = (m: Message): string =>
+  (m as any).timestamp ?? (m as any).createdAt ?? "";
+
+interface UndoEntry {
+  id: string;
+  kind: "report" | "mute" | "ban";
+  label: string;
+  userId?: string;
+  messageId?: string;
+}
 
 interface ChatInterfaceProps {
   conversations: Conversation[];
@@ -29,6 +90,8 @@ interface ChatInterfaceProps {
   onSelectConversation: (conversation: Conversation) => void;
   onSendMessage: (content: string) => void;
   onSearchConversations?: (query: string) => void;
+  /** Admin moderation configuration (issue #890). Omit for a normal chat. */
+  moderation?: ChatModerationConfig;
 }
 
 export function ChatInterface({
@@ -40,10 +103,113 @@ export function ChatInterface({
   onSelectConversation,
   onSendMessage,
   onSearchConversations,
+  moderation,
 }: ChatInterfaceProps) {
   const [messageInput, setMessageInput] = useState("");
   const [showEmojiPicker, setShowEmojiPicker] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  // ── Moderation state (issue #890) ──
+  const moderationEnabled = !!moderation;
+  const isAdmin = !!moderation?.isAdmin;
+  const canReport = moderation?.canReport !== false;
+  const undoWindowMs = moderation?.undoWindowMs ?? 5 * 60 * 1000;
+  const mutedUserIds = moderation?.mutedUserIds ?? [];
+  const bannedUserIds = moderation?.bannedUserIds ?? [];
+  // Nothing to show if the viewer can neither report nor administrate.
+  const canModerate = canReport || isAdmin;
+
+  const [openMenuMessageId, setOpenMenuMessageId] = useState<string | null>(null);
+  const [historyUser, setHistoryUser] = useState<{ id: string; name: string } | null>(
+    null
+  );
+  const [undoStack, setUndoStack] = useState<UndoEntry[]>([]);
+  const undoTimers = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
+  const undoSeq = useRef(0);
+
+  // Clear any pending undo timers on unmount.
+  useEffect(() => {
+    const timers = undoTimers.current;
+    return () => {
+      Object.values(timers).forEach(clearTimeout);
+    };
+  }, []);
+
+  const registerUndo = (entry: Omit<UndoEntry, "id">) => {
+    const id = `undo-${(undoSeq.current += 1)}`;
+    setUndoStack((prev) => [...prev, { ...entry, id }]);
+    undoTimers.current[id] = setTimeout(() => {
+      setUndoStack((prev) => prev.filter((e) => e.id !== id));
+      delete undoTimers.current[id];
+    }, undoWindowMs);
+  };
+
+  const dismissUndo = (id: string) => {
+    if (undoTimers.current[id]) {
+      clearTimeout(undoTimers.current[id]);
+      delete undoTimers.current[id];
+    }
+    setUndoStack((prev) => prev.filter((e) => e.id !== id));
+  };
+
+  const handleUndo = (entry: UndoEntry) => {
+    switch (entry.kind) {
+      case "mute":
+        if (entry.userId) moderation?.onUnmuteUser?.(entry.userId);
+        break;
+      case "ban":
+        if (entry.userId) moderation?.onUnbanUser?.(entry.userId);
+        break;
+      case "report":
+        if (entry.messageId) moderation?.onUndoReport?.(entry.messageId);
+        break;
+    }
+    dismissUndo(entry.id);
+  };
+
+  const handleReport = (message: Message) => {
+    setOpenMenuMessageId(null);
+    moderation?.onReportMessage?.(message.id, {
+      senderId: getSenderId(message),
+      content: message.content,
+    });
+    registerUndo({
+      kind: "report",
+      messageId: message.id,
+      label: "Message reported",
+    });
+  };
+
+  const handleMute = (message: Message, hours: MuteDuration) => {
+    setOpenMenuMessageId(null);
+    const userId = getSenderId(message);
+    moderation?.onMuteUser?.(userId, hours);
+    registerUndo({
+      kind: "mute",
+      userId,
+      label: `Muted ${getSenderName(message)} for ${
+        hours === 1 ? "1 hour" : `${hours} hours`
+      }`,
+    });
+  };
+
+  const handleBan = (message: Message) => {
+    setOpenMenuMessageId(null);
+    const userId = getSenderId(message);
+    moderation?.onBanUser?.(userId);
+    registerUndo({
+      kind: "ban",
+      userId,
+      label: `Banned ${getSenderName(message)}`,
+    });
+  };
+
+  const handleViewHistory = (message: Message) => {
+    setOpenMenuMessageId(null);
+    const userId = getSenderId(message);
+    moderation?.onViewUserHistory?.(userId);
+    setHistoryUser({ id: userId, name: getSenderName(message) });
+  };
 
   const scrollToBottom = () => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
@@ -52,6 +218,19 @@ export function ChatInterface({
   useEffect(() => {
     scrollToBottom();
   }, [messages]);
+
+  // Escape closes the moderation menu / history dialog (issue #890).
+  useEffect(() => {
+    if (!openMenuMessageId && !historyUser) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setOpenMenuMessageId(null);
+        setHistoryUser(null);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [openMenuMessageId, historyUser]);
 
   const handleSendMessage = (e: React.FormEvent) => {
     e.preventDefault();
@@ -266,7 +445,9 @@ export function ChatInterface({
                       </div>
                     )}
                     <div
-                      className={`flex ${isOwn ? "justify-end" : "justify-start"}`}
+                      className={`group flex items-start gap-1 ${
+                        isOwn ? "justify-end" : "justify-start"
+                      }`}
                     >
                       <div
                         className={`max-w-[70%] min-w-0 ${
@@ -283,6 +464,19 @@ export function ChatInterface({
                             {(message as any).senderName || (message as any).fromUsername || (activeConversation.type === "party" ? "Party Member" : getConversationName(activeConversation))}
                           </span>
                         )}
+                        {!isOwn &&
+                          moderationEnabled &&
+                          (bannedUserIds.includes(getSenderId(message)) ||
+                            mutedUserIds.includes(getSenderId(message))) && (
+                            <span
+                              className="mb-1 inline-flex items-center gap-1 rounded-full bg-destructive/10 px-2 py-0.5 text-[10px] font-medium text-destructive"
+                              data-testid="moderation-status"
+                            >
+                              {bannedUserIds.includes(getSenderId(message))
+                                ? "Banned"
+                                : "Muted"}
+                            </span>
+                          )}
                         <p className="text-sm break-words [overflow-wrap:anywhere] whitespace-pre-wrap">{message.content}</p>
                         <div
                           className={`flex items-center justify-end gap-1 mt-1 ${
@@ -295,6 +489,98 @@ export function ChatInterface({
                           {isOwn && getMessageStatus(message)}
                         </div>
                       </div>
+
+                      {/* Admin moderation menu (issue #890) */}
+                      {moderationEnabled && !isOwn && canModerate && (
+                        <div className="relative shrink-0 self-center">
+                          <button
+                            type="button"
+                            onClick={() =>
+                              setOpenMenuMessageId((cur) =>
+                                cur === message.id ? null : message.id
+                              )
+                            }
+                            className="rounded-md p-1 text-muted-foreground opacity-0 transition-opacity hover:bg-muted focus:opacity-100 focus:outline-none focus:ring-2 focus:ring-primary group-hover:opacity-100"
+                            aria-label={`Moderate message from ${getSenderName(message)}`}
+                            aria-haspopup="menu"
+                            aria-expanded={openMenuMessageId === message.id}
+                          >
+                            <MoreHorizontal className="h-4 w-4" aria-hidden="true" />
+                          </button>
+
+                          {openMenuMessageId === message.id && (
+                            <>
+                              <div
+                                className="fixed inset-0 z-20"
+                                aria-hidden="true"
+                                onClick={() => setOpenMenuMessageId(null)}
+                              />
+                              <ul
+                                role="menu"
+                                aria-label={`Moderation actions for ${getSenderName(message)}`}
+                                className="absolute right-0 z-30 mt-1 w-52 overflow-hidden rounded-md border bg-popover p-1 shadow-lg"
+                              >
+                                {canReport && (
+                                  <li role="none">
+                                    <button
+                                      role="menuitem"
+                                      type="button"
+                                      onClick={() => handleReport(message)}
+                                      className="flex w-full items-center gap-2 rounded-sm px-3 py-2 text-left text-sm text-foreground hover:bg-muted"
+                                    >
+                                      <Flag className="h-4 w-4" aria-hidden="true" />
+                                      Report message
+                                    </button>
+                                  </li>
+                                )}
+                                {isAdmin && (
+                                  <>
+                                    <li role="none">
+                                      <button
+                                        role="menuitem"
+                                        type="button"
+                                        onClick={() => handleViewHistory(message)}
+                                        className="flex w-full items-center gap-2 rounded-sm px-3 py-2 text-left text-sm text-foreground hover:bg-muted"
+                                      >
+                                        <History className="h-4 w-4" aria-hidden="true" />
+                                        View message history
+                                      </button>
+                                    </li>
+                                    <li
+                                      role="separator"
+                                      className="my-1 border-t"
+                                    />
+                                    {MUTE_DURATIONS.map((h) => (
+                                      <li role="none" key={h}>
+                                        <button
+                                          role="menuitem"
+                                          type="button"
+                                          onClick={() => handleMute(message, h)}
+                                          className="flex w-full items-center gap-2 rounded-sm px-3 py-2 text-left text-sm text-foreground hover:bg-muted"
+                                        >
+                                          <MicOff className="h-4 w-4" aria-hidden="true" />
+                                          Mute for {h === 1 ? "1 hour" : `${h} hours`}
+                                        </button>
+                                      </li>
+                                    ))}
+                                    <li role="none">
+                                      <button
+                                        role="menuitem"
+                                        type="button"
+                                        onClick={() => handleBan(message)}
+                                        className="flex w-full items-center gap-2 rounded-sm px-3 py-2 text-left text-sm text-destructive hover:bg-destructive/10"
+                                      >
+                                        <Ban className="h-4 w-4" aria-hidden="true" />
+                                        Ban user
+                                      </button>
+                                    </li>
+                                  </>
+                                )}
+                              </ul>
+                            </>
+                          )}
+                        </div>
+                      )}
                     </div>
                   </div>
                 );
@@ -369,6 +655,94 @@ export function ChatInterface({
           </div>
         )}
       </div>
+
+      {/* Message history dialog (issue #890) */}
+      {historyUser && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-label={`Message history for ${historyUser.name}`}
+        >
+          <div
+            className="absolute inset-0 bg-black/50"
+            aria-hidden="true"
+            onClick={() => setHistoryUser(null)}
+          />
+          <div className="relative z-10 flex max-h-[80vh] w-full max-w-md flex-col overflow-hidden rounded-lg border bg-background shadow-xl">
+            <div className="flex items-center justify-between border-b p-4">
+              <h3 className="font-semibold">
+                Message history · {historyUser.name}
+              </h3>
+              <button
+                type="button"
+                onClick={() => setHistoryUser(null)}
+                className="text-muted-foreground hover:text-foreground"
+                aria-label="Close message history"
+              >
+                <X className="h-4 w-4" aria-hidden="true" />
+              </button>
+            </div>
+            <div className="flex-1 space-y-2 overflow-auto p-4">
+              {(() => {
+                const history = messages.filter(
+                  (m) => getSenderId(m) === historyUser.id
+                );
+                if (history.length === 0) {
+                  return (
+                    <p className="py-6 text-center text-sm text-muted-foreground">
+                      No messages from this user in the current conversation.
+                    </p>
+                  );
+                }
+                return history.map((m) => (
+                  <div
+                    key={m.id}
+                    className="rounded-md border bg-muted/30 p-2"
+                    data-testid="history-message"
+                  >
+                    <p className="text-sm [overflow-wrap:anywhere]">{m.content}</p>
+                    <span className="text-[10px] text-muted-foreground">
+                      {getTimestamp(m) ? formatTime(getTimestamp(m)) : ""}
+                    </span>
+                  </div>
+                ));
+              })()}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Undo toasts — moderation actions are reversible within the window */}
+      {undoStack.length > 0 && (
+        <div className="fixed bottom-4 left-1/2 z-50 flex -translate-x-1/2 flex-col gap-2">
+          {undoStack.map((entry) => (
+            <div
+              key={entry.id}
+              role="status"
+              className="flex items-center gap-3 rounded-lg border bg-background px-4 py-2 shadow-lg"
+            >
+              <span className="text-sm">{entry.label}</span>
+              <button
+                type="button"
+                onClick={() => handleUndo(entry)}
+                className="inline-flex items-center gap-1 text-sm font-medium text-primary hover:underline"
+              >
+                <Undo2 className="h-3.5 w-3.5" aria-hidden="true" />
+                Undo
+              </button>
+              <button
+                type="button"
+                onClick={() => dismissUndo(entry.id)}
+                className="text-muted-foreground hover:text-foreground"
+                aria-label="Dismiss"
+              >
+                <X className="h-3.5 w-3.5" aria-hidden="true" />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
     </Card>
   );
 }


### PR DESCRIPTION
Closes #890.

Adds an optional **admin moderation surface** to `ChatInterface`. When a `moderation` config is passed, each incoming message gets a per-message actions menu; when it is omitted the chat renders exactly as before, so all existing (non-admin) call sites are unaffected.

## Acceptance criteria
- [x] **Flag / report a message** — available to everyone unless `canReport: false`
- [x] **Mute a user for 1 / 24 / 72 hours** — the three required presets
- [x] **Ban a user**
- [x] **View a user's message history** — dialog listing only that user's messages
- [x] **Undo actions within 5 minutes** — every mute/ban/report raises an undo toast that auto-expires after a configurable `undoWindowMs` (default 5 min) and calls the matching inverse callback

## Notes
- Mute / ban / history are gated behind `isAdmin`; reporting is open to all users. When a viewer can neither report nor administrate, no trigger is rendered.
- Muted / banned users are badged inline on their messages.
- Fully keyboard-accessible: real `<button>`/`role="menu"`/`role="dialog"` semantics, `Escape` closes the menu and dialog, backdrop dismiss is a separate `aria-hidden` element. Passes `jsx-a11y` lint.
- The runtime message shape is read defensively (`senderId`/`senderName`/`timestamp`), so this works regardless of which message shape a caller passes.

## Backwards compatibility
The `moderation` prop is optional and additive. No existing prop or behavior changed.

## Testing
- New suite `src/__tests__/chat-moderation.test.tsx` — **10 tests, all passing** (report + undo, all three mute presets, ban + undo, admin gating, non-admin reporting, history dialog filtering, muted/banned badges, undo auto-expiry, no-config backwards-compat).
- `tsc --noEmit`: no new errors in touched files.
- `eslint`: clean.
- Verified against a clean baseline that the full test suite's pre-existing failures are unchanged (no regressions introduced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)